### PR TITLE
Function return type inference

### DIFF
--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -18,6 +18,9 @@ auto errFuncNameConflictsWithAction(const Source& src, const std::string& name, 
 auto errDuplicateFuncDeclaration(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
+auto errUnableToInferFuncReturnType(const Source& src, const std::string& name, input::Span span)
+    -> Diag;
+
 auto errNonMatchingFuncReturnType(
     const Source& src,
     const std::string& name,

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -11,11 +11,10 @@ auto errInvalidStmtFuncDecl(
     lex::Token kw,
     lex::Token id,
     lex::Token open,
-    const std::vector<FuncDeclStmtNode::arg>& args,
+    const std::vector<FuncDeclStmtNode::ArgSpec>& args,
     std::vector<lex::Token> commas,
     lex::Token close,
-    lex::Token arrow,
-    lex::Token retType,
+    std::optional<FuncDeclStmtNode::RetTypeSpec> retType,
     NodePtr body) -> NodePtr;
 
 auto errInvalidStmtExec(

--- a/include/parse/node_stmt_func_decl.hpp
+++ b/include/parse/node_stmt_func_decl.hpp
@@ -1,24 +1,50 @@
 #pragma once
 #include "lex/token.hpp"
 #include "parse/node.hpp"
+#include <utility>
 #include <vector>
 
 namespace parse {
 
 class FuncDeclStmtNode final : public Node {
+public:
+  class ArgSpec final {
+  public:
+    ArgSpec(lex::Token type, lex::Token identifier);
+
+    auto operator==(const ArgSpec& rhs) const noexcept -> bool;
+
+    [[nodiscard]] auto getType() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto getIdentifier() const noexcept -> const lex::Token&;
+
+  private:
+    lex::Token m_type;
+    lex::Token m_identifier;
+  };
+
+  class RetTypeSpec final {
+  public:
+    RetTypeSpec(lex::Token arrow, lex::Token type);
+
+    auto operator==(const RetTypeSpec& rhs) const noexcept -> bool;
+
+    [[nodiscard]] auto getArrow() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto getType() const noexcept -> const lex::Token&;
+
+  private:
+    lex::Token m_arrow;
+    lex::Token m_type;
+  };
+
   friend auto funcDeclStmtNode(
       lex::Token kw,
       lex::Token id,
       lex::Token open,
-      std::vector<std::pair<lex::Token, lex::Token>> args,
+      std::vector<ArgSpec> args,
       std::vector<lex::Token> commas,
       lex::Token close,
-      lex::Token arrow,
-      lex::Token retType,
+      std::optional<RetTypeSpec> retType,
       NodePtr body) -> NodePtr;
-
-public:
-  using arg = typename std::pair<lex::Token, lex::Token>;
 
   FuncDeclStmtNode() = delete;
 
@@ -30,8 +56,8 @@ public:
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
   [[nodiscard]] auto getId() const -> const lex::Token&;
-  [[nodiscard]] auto getArgs() const -> const std::vector<arg>&;
-  [[nodiscard]] auto getRetType() const -> const lex::Token&;
+  [[nodiscard]] auto getArgs() const -> const std::vector<ArgSpec>&;
+  [[nodiscard]] auto getRetType() const -> const std::optional<RetTypeSpec>&;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 
@@ -39,22 +65,20 @@ private:
   const lex::Token m_kw;
   const lex::Token m_id;
   const lex::Token m_open;
-  const std::vector<arg> m_args;
+  const std::vector<ArgSpec> m_args;
   const std::vector<lex::Token> m_commas;
   const lex::Token m_close;
-  const lex::Token m_arrow;
-  const lex::Token m_retType;
+  const std::optional<RetTypeSpec> m_retType;
   const NodePtr m_body;
 
   FuncDeclStmtNode(
       lex::Token kw,
       lex::Token id,
       lex::Token open,
-      std::vector<arg> args,
+      std::vector<ArgSpec> args,
       std::vector<lex::Token> commas,
       lex::Token close,
-      lex::Token arrow,
-      lex::Token retType,
+      std::optional<RetTypeSpec> retType,
       NodePtr body);
 
   auto print(std::ostream& out) const -> std::ostream& override;
@@ -65,11 +89,10 @@ auto funcDeclStmtNode(
     lex::Token kw,
     lex::Token id,
     lex::Token open,
-    std::vector<FuncDeclStmtNode::arg> args,
+    std::vector<FuncDeclStmtNode::ArgSpec> args,
     std::vector<lex::Token> commas,
     lex::Token close,
-    lex::Token arrow,
-    lex::Token retType,
+    std::optional<FuncDeclStmtNode::RetTypeSpec> retTypeSpec,
     NodePtr body) -> NodePtr;
 
 } // namespace parse

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -69,7 +69,7 @@ private:
 
   auto getFromInput() -> lex::Token override {
     if (m_input == m_inputEnd) {
-      return lex::endToken();
+      return *m_input;
     }
     auto val = *m_input;
     ++m_input;

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -58,6 +58,8 @@ public:
   addExecStmt(sym::ActionId action, sym::ConstDeclTable consts, std::vector<expr::NodePtr> args)
       -> void;
 
+  auto updateFuncRetType(sym::FuncId funcId, sym::TypeId newRetType) -> void;
+
 private:
   sym::TypeDeclTable m_typeDecls;
   sym::FuncDeclTable m_funcDecls;

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -52,7 +52,7 @@ public:
   [[nodiscard]] auto getActionDecl(sym::ActionId id) const -> const sym::ActionDecl&;
   [[nodiscard]] auto getFuncDef(sym::FuncId id) const -> const sym::FuncDef&;
 
-  auto declareUserFunc(std::string name, sym::FuncSig sig) -> void;
+  auto declareUserFunc(std::string name, sym::FuncSig sig) -> sym::FuncId;
   auto defineUserFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
   auto
   addExecStmt(sym::ActionId action, sym::ConstDeclTable consts, std::vector<expr::NodePtr> args)

--- a/include/prog/sym/func_decl.hpp
+++ b/include/prog/sym/func_decl.hpp
@@ -22,6 +22,8 @@ public:
   [[nodiscard]] auto getName() const -> const std::string&;
   [[nodiscard]] auto getSig() const -> const FuncSig&;
 
+  auto updateSig(FuncSig newSig) -> void;
+
 private:
   FuncId m_id;
   FuncKind m_kind;

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -32,6 +32,8 @@ public:
 
   auto registerFunc(FuncKind kind, std::string name, FuncSig sig) -> FuncId;
 
+  auto updateFuncRetType(FuncId id, TypeId newRetType) -> void;
+
 private:
   std::vector<FuncDecl> m_funcs;
   std::unordered_map<std::string, std::vector<FuncId>> m_lookup;

--- a/include/prog/sym/type_id.hpp
+++ b/include/prog/sym/type_id.hpp
@@ -8,8 +8,12 @@ class TypeId final {
   friend auto operator<<(std::ostream& out, const TypeId& rhs) -> std::ostream&;
 
 public:
+  [[nodiscard]] static auto inferredType() -> TypeId;
+
   auto operator==(const TypeId& rhs) const noexcept -> bool;
   auto operator!=(const TypeId& rhs) const noexcept -> bool;
+
+  [[nodiscard]] auto isInferred() const noexcept -> bool;
 
 private:
   unsigned int m_id;

--- a/include/prog/sym/type_id.hpp
+++ b/include/prog/sym/type_id.hpp
@@ -8,12 +8,13 @@ class TypeId final {
   friend auto operator<<(std::ostream& out, const TypeId& rhs) -> std::ostream&;
 
 public:
-  [[nodiscard]] static auto inferredType() -> TypeId;
+  [[nodiscard]] static auto inferType() -> TypeId;
 
   auto operator==(const TypeId& rhs) const noexcept -> bool;
   auto operator!=(const TypeId& rhs) const noexcept -> bool;
 
-  [[nodiscard]] auto isInferred() const noexcept -> bool;
+  [[nodiscard]] auto isInfer() const noexcept -> bool;
+  [[nodiscard]] auto isConcrete() const noexcept -> bool;
 
 private:
   unsigned int m_id;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(frontend STATIC
   frontend/internal/define_user_funcs.cpp
   frontend/internal/get_expr.cpp
   frontend/internal/get_parse_diags.cpp
+  frontend/internal/typeinfer_user_funcs.cpp
 
   frontend/analysis.cpp
   frontend/diag_defs.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(frontend STATIC
   frontend/internal/define_user_funcs.cpp
   frontend/internal/get_expr.cpp
   frontend/internal/get_parse_diags.cpp
+  frontend/internal/typeinfer_expr.cpp
   frontend/internal/typeinfer_user_funcs.cpp
 
   frontend/analysis.cpp

--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -28,7 +28,9 @@ auto analyze(const Source& src) -> Output {
 
   // Define user functions.
   auto defineUserFuncs = internal::DefineUserFuncs{src, prog.get()};
-  src.accept(&defineUserFuncs);
+  for (const auto& funcDecl : declareUserFuncs.getFuncs()) {
+    defineUserFuncs.define(funcDecl.first, funcDecl.second);
+  }
   if (defineUserFuncs.hasErrors()) {
     return buildOutput(nullptr, defineUserFuncs.getDiags());
   }

--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -3,6 +3,7 @@
 #include "internal/define_exec_stmts.hpp"
 #include "internal/define_user_funcs.hpp"
 #include "internal/get_parse_diags.hpp"
+#include "internal/typeinfer_user_funcs.hpp"
 #include "prog/program.hpp"
 #include <memory>
 #include <vector>
@@ -24,6 +25,15 @@ auto analyze(const Source& src) -> Output {
   src.accept(&declareUserFuncs);
   if (declareUserFuncs.hasErrors()) {
     return buildOutput(nullptr, declareUserFuncs.getDiags());
+  }
+
+  // Infer types for user fuctions.
+  auto typeInferUserFuncs = internal::TypeInferUserFuncs{src, prog.get()};
+  for (const auto& funcDecl : declareUserFuncs.getFuncs()) {
+    typeInferUserFuncs.inferTypes(funcDecl.first, funcDecl.second);
+  }
+  if (typeInferUserFuncs.hasErrors()) {
+    return buildOutput(nullptr, typeInferUserFuncs.getDiags());
   }
 
   // Define user functions.

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -37,6 +37,14 @@ auto errDuplicateFuncDeclaration(const Source& src, const std::string& name, inp
   return error(src, oss.str(), span);
 }
 
+auto errUnableToInferFuncReturnType(const Source& src, const std::string& name, input::Span span)
+    -> Diag {
+  std::ostringstream oss;
+  oss << "Unable to infer return-type of function '" << name
+      << "', please specify return-type using the '-> [TYPE]' syntax";
+  return error(src, oss.str(), span);
+}
+
 auto errNonMatchingFuncReturnType(
     const Source& src,
     const std::string& name,

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -16,7 +16,7 @@ auto DeclareUserFuncs::hasErrors() const noexcept -> bool { return !m_diags.empt
 
 auto DeclareUserFuncs::getDiags() const noexcept -> const std::vector<Diag>& { return m_diags; }
 
-auto DeclareUserFuncs::getFuncs() const noexcept -> const std::vector<Declaration>& {
+auto DeclareUserFuncs::getFuncs() const noexcept -> const std::vector<DeclarationInfo>& {
   return m_funcs;
 }
 
@@ -54,7 +54,7 @@ auto DeclareUserFuncs::getRetType(const parse::FuncDeclStmtNode& n)
     -> std::optional<prog::sym::TypeId> {
   const auto& retTypeSpec = n.getRetType();
   if (!retTypeSpec) {
-    return prog::sym::TypeId::inferredType();
+    return prog::sym::TypeId::inferType();
   }
   const auto retTypeName = getName(retTypeSpec->getType());
   auto retType           = m_prog->lookupType(retTypeName);

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -16,6 +16,10 @@ auto DeclareUserFuncs::hasErrors() const noexcept -> bool { return !m_diags.empt
 
 auto DeclareUserFuncs::getDiags() const noexcept -> const std::vector<Diag>& { return m_diags; }
 
+auto DeclareUserFuncs::getFuncs() const noexcept -> const std::vector<Declaration>& {
+  return m_funcs;
+}
+
 auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   // Get func name.
   const auto name = getName(n.getId());
@@ -49,7 +53,8 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   }
 
   // Declare the function in the program.
-  m_prog->declareUserFunc(name, prog::sym::FuncSig{input.value(), retType.value()});
+  auto funcId = m_prog->declareUserFunc(name, prog::sym::FuncSig{input.value(), retType.value()});
+  m_funcs.emplace_back(funcId, n);
 }
 
 auto DeclareUserFuncs::validateFuncName(const lex::Token& nameToken) -> bool {

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -36,10 +36,15 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   }
 
   // Get return type.
-  const auto retTypeName = getName(n.getRetType());
+  const auto& retTypeSpec = n.getRetType();
+  if (!retTypeSpec) {
+    m_diags.push_back(errUnableToInferFuncReturnType(m_src, name, n.getSpan()));
+    return;
+  }
+  const auto retTypeName = getName(retTypeSpec->getType());
   const auto retType     = m_prog->lookupType(retTypeName);
   if (!retType) {
-    m_diags.push_back(errUndeclaredType(m_src, retTypeName, n.getRetType().getSpan()));
+    m_diags.push_back(errUndeclaredType(m_src, retTypeName, retTypeSpec->getType().getSpan()));
     return;
   }
 
@@ -65,12 +70,12 @@ auto DeclareUserFuncs::getFuncInput(const parse::FuncDeclStmtNode& n)
   auto isValid  = true;
   auto argTypes = std::vector<prog::sym::TypeId>{};
   for (const auto& arg : n.getArgs()) {
-    const auto argTypeName = getName(arg.first);
+    const auto argTypeName = getName(arg.getType());
     const auto argType     = m_prog->lookupType(argTypeName);
     if (argType) {
       argTypes.push_back(argType.value());
     } else {
-      m_diags.push_back(errUndeclaredType(m_src, argTypeName, arg.first.getSpan()));
+      m_diags.push_back(errUndeclaredType(m_src, argTypeName, arg.getType().getSpan()));
       isValid = false;
     }
   }

--- a/src/frontend/internal/declare_user_funcs.hpp
+++ b/src/frontend/internal/declare_user_funcs.hpp
@@ -26,8 +26,8 @@ private:
   std::vector<Declaration> m_funcs;
   std::vector<Diag> m_diags;
 
+  auto getRetType(const parse::FuncDeclStmtNode& n) -> std::optional<prog::sym::TypeId>;
   auto validateFuncName(const lex::Token& nameToken) -> bool;
-
   auto getFuncInput(const parse::FuncDeclStmtNode& n) -> std::optional<prog::sym::Input>;
 };
 

--- a/src/frontend/internal/declare_user_funcs.hpp
+++ b/src/frontend/internal/declare_user_funcs.hpp
@@ -3,15 +3,19 @@
 #include "frontend/source.hpp"
 #include "parse/node_visitor_optional.hpp"
 #include "prog/program.hpp"
+#include <utility>
 
 namespace frontend::internal {
 
 class DeclareUserFuncs final : public parse::OptionalNodeVisitor {
 public:
+  using Declaration = typename std::pair<prog::sym::FuncId, const parse::FuncDeclStmtNode&>;
+
   DeclareUserFuncs() = delete;
   DeclareUserFuncs(const Source& src, prog::Program* prog);
 
   [[nodiscard]] auto hasErrors() const noexcept -> bool;
+  [[nodiscard]] auto getFuncs() const noexcept -> const std::vector<Declaration>&;
   [[nodiscard]] auto getDiags() const noexcept -> const std::vector<Diag>&;
 
   auto visit(const parse::FuncDeclStmtNode& n) -> void override;
@@ -19,6 +23,7 @@ public:
 private:
   const Source& m_src;
   prog::Program* m_prog;
+  std::vector<Declaration> m_funcs;
   std::vector<Diag> m_diags;
 
   auto validateFuncName(const lex::Token& nameToken) -> bool;

--- a/src/frontend/internal/declare_user_funcs.hpp
+++ b/src/frontend/internal/declare_user_funcs.hpp
@@ -9,13 +9,13 @@ namespace frontend::internal {
 
 class DeclareUserFuncs final : public parse::OptionalNodeVisitor {
 public:
-  using Declaration = typename std::pair<prog::sym::FuncId, const parse::FuncDeclStmtNode&>;
+  using DeclarationInfo = typename std::pair<prog::sym::FuncId, const parse::FuncDeclStmtNode&>;
 
   DeclareUserFuncs() = delete;
   DeclareUserFuncs(const Source& src, prog::Program* prog);
 
   [[nodiscard]] auto hasErrors() const noexcept -> bool;
-  [[nodiscard]] auto getFuncs() const noexcept -> const std::vector<Declaration>&;
+  [[nodiscard]] auto getFuncs() const noexcept -> const std::vector<DeclarationInfo>&;
   [[nodiscard]] auto getDiags() const noexcept -> const std::vector<Diag>&;
 
   auto visit(const parse::FuncDeclStmtNode& n) -> void override;
@@ -23,7 +23,7 @@ public:
 private:
   const Source& m_src;
   prog::Program* m_prog;
-  std::vector<Declaration> m_funcs;
+  std::vector<DeclarationInfo> m_funcs;
   std::vector<Diag> m_diags;
 
   auto getRetType(const parse::FuncDeclStmtNode& n) -> std::optional<prog::sym::TypeId>;

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -13,9 +13,8 @@ auto DefineUserFuncs::hasErrors() const noexcept -> bool { return !m_diags.empty
 
 auto DefineUserFuncs::getDiags() const noexcept -> const std::vector<Diag>& { return m_diags; }
 
-auto DefineUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
-  const auto id = getFuncId(n);
-  auto consts   = prog::sym::ConstDeclTable{};
+auto DefineUserFuncs::define(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n) -> void {
+  auto consts = prog::sym::ConstDeclTable{};
   if (!declareInputs(n, &consts)) {
     return;
   }
@@ -36,21 +35,6 @@ auto DefineUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   }
 
   m_prog->defineUserFunc(id, std::move(consts), std::move(expr));
-}
-
-auto DefineUserFuncs::getFuncId(const parse::FuncDeclStmtNode& n) -> prog::sym::FuncId {
-  auto argTypes = std::vector<prog::sym::TypeId>{};
-  for (const auto& arg : n.getArgs()) {
-    const auto argType = m_prog->lookupType(getName(arg.getType()));
-    if (argType) {
-      argTypes.push_back(argType.value());
-    }
-  }
-  const auto result = m_prog->lookupFunc(getName(n.getId()), prog::sym::Input{std::move(argTypes)});
-  if (!result) {
-    throw std::logic_error("Attempted to define function which was not declared yet");
-  }
-  return result.value();
 }
 
 auto DefineUserFuncs::declareInputs(

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -14,11 +14,12 @@ auto DefineUserFuncs::hasErrors() const noexcept -> bool { return !m_diags.empty
 auto DefineUserFuncs::getDiags() const noexcept -> const std::vector<Diag>& { return m_diags; }
 
 auto DefineUserFuncs::define(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n) -> void {
+  const auto& funcDecl = m_prog->getFuncDecl(id);
+
   auto consts = prog::sym::ConstDeclTable{};
   if (!declareInputs(n, &consts)) {
     return;
   }
-  const auto& funcDecl = m_prog->getFuncDecl(id);
 
   auto visibleConsts = consts.getAll();
   auto expr          = getExpr(n[0], &consts, &visibleConsts);

--- a/src/frontend/internal/define_user_funcs.hpp
+++ b/src/frontend/internal/define_user_funcs.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "frontend/diag.hpp"
 #include "frontend/source.hpp"
-#include "parse/node_visitor_optional.hpp"
 #include "prog/program.hpp"
 
 namespace frontend::internal {

--- a/src/frontend/internal/define_user_funcs.hpp
+++ b/src/frontend/internal/define_user_funcs.hpp
@@ -6,7 +6,7 @@
 
 namespace frontend::internal {
 
-class DefineUserFuncs final : public parse::OptionalNodeVisitor {
+class DefineUserFuncs final {
 public:
   DefineUserFuncs() = delete;
   DefineUserFuncs(const Source& src, prog::Program* prog);
@@ -14,14 +14,13 @@ public:
   [[nodiscard]] auto hasErrors() const noexcept -> bool;
   [[nodiscard]] auto getDiags() const noexcept -> const std::vector<Diag>&;
 
-  auto visit(const parse::FuncDeclStmtNode& n) -> void override;
+  auto define(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n) -> void;
 
 private:
   const Source& m_src;
   prog::Program* m_prog;
   std::vector<Diag> m_diags;
 
-  auto getFuncId(const parse::FuncDeclStmtNode& n) -> prog::sym::FuncId;
   auto declareInputs(const parse::FuncDeclStmtNode& n, prog::sym::ConstDeclTable* consts) -> bool;
   auto getExpr(
       const parse::Node& n,

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -1,0 +1,183 @@
+#include "internal/typeinfer_expr.hpp"
+#include "internal/utilities.hpp"
+#include "lex/token_payload_lit_bool.hpp"
+#include "lex/token_payload_lit_int.hpp"
+#include "parse/nodes.hpp"
+
+namespace frontend::internal {
+
+TypeInferExpr::TypeInferExpr(
+    prog::Program* prog, std::unordered_map<std::string, prog::sym::TypeId>* constTypes) :
+    m_prog{prog}, m_constTypes{constTypes}, m_type{prog::sym::TypeId::inferredType()} {
+  if (m_prog == nullptr) {
+    throw std::invalid_argument{"Program cannot be null"};
+  }
+  if (m_constTypes == nullptr) {
+    throw std::invalid_argument{"ConstTypes cannot be null"};
+  }
+}
+
+auto TypeInferExpr::getType() const noexcept -> prog::sym::TypeId { return m_type; }
+
+auto TypeInferExpr::visit(const parse::ErrorNode & /*unused*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
+auto TypeInferExpr::visit(const parse::BinaryExprNode& n) -> void {
+  const auto& opToken = n.getOperator();
+  switch (opToken.getKind()) {
+  case lex::TokenKind::OpAmpAmp:
+  case lex::TokenKind::OpPipePipe: {
+    auto boolType = m_prog->lookupType("bool");
+    if (!boolType) {
+      throw std::logic_error{"No 'bool' type present in type-table"};
+    }
+    m_type = *boolType;
+    break;
+  }
+  default:
+    break;
+  }
+  const auto op = getOperator(opToken);
+  if (!op) {
+    return;
+  }
+  auto argTypes = std::vector<prog::sym::TypeId>{};
+  argTypes.reserve(n.getChildCount());
+  for (auto i = 0U; i < n.getChildCount(); ++i) {
+    argTypes.push_back(inferSubExpr(n[i]));
+  }
+  m_type = inferFuncCall(prog::getFuncName(*op), std::move(argTypes));
+}
+
+auto TypeInferExpr::visit(const parse::CallExprNode& n) -> void {
+  auto argTypes = std::vector<prog::sym::TypeId>{};
+  argTypes.reserve(n.getChildCount());
+  for (auto i = 0U; i < n.getChildCount(); ++i) {
+    argTypes.push_back(inferSubExpr(n[i]));
+  }
+  m_type = inferFuncCall(getName(n.getFunc()), std::move(argTypes));
+}
+
+auto TypeInferExpr::visit(const parse::ConditionalExprNode& n) -> void {
+  const auto ifBranchType = inferSubExpr(n[1]);
+  if (!ifBranchType.isInferred()) {
+    m_type = ifBranchType;
+    return;
+  }
+  m_type = inferSubExpr(n[2]);
+}
+
+auto TypeInferExpr::visit(const parse::ConstDeclExprNode& n) -> void {
+  auto assignmentType = inferSubExpr(n[0]);
+  setConstType(n.getId(), assignmentType);
+}
+
+auto TypeInferExpr::visit(const parse::ConstExprNode& n) -> void {
+  m_type = inferConstType(n.getId());
+}
+
+auto TypeInferExpr::visit(const parse::GroupExprNode& n) -> void {
+  for (auto i = 0U; i < n.getChildCount(); ++i) {
+    m_type = inferSubExpr(n[i]);
+  }
+}
+
+auto TypeInferExpr::visit(const parse::LitExprNode& n) -> void {
+  switch (n.getVal().getKind()) {
+  case lex::TokenKind::LitInt: {
+    auto intType = m_prog->lookupType("int");
+    if (!intType) {
+      throw std::logic_error{"No 'int' type present in type-table"};
+    }
+    m_type = *intType;
+    break;
+  }
+  case lex::TokenKind::LitBool: {
+    auto boolType = m_prog->lookupType("bool");
+    if (!boolType) {
+      throw std::logic_error{"No 'bool' type present in type-table"};
+    }
+    m_type = *boolType;
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+auto TypeInferExpr::visit(const parse::ParenExprNode& n) -> void { m_type = inferSubExpr(n[0]); }
+
+auto TypeInferExpr::visit(const parse::SwitchExprElseNode & /*unused*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
+auto TypeInferExpr::visit(const parse::SwitchExprIfNode & /*unused*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
+auto TypeInferExpr::visit(const parse::SwitchExprNode& n) -> void {
+  for (auto i = 0U; i < n.getChildCount(); ++i) {
+    const auto isElseClause = i == n.getChildCount() - 1;
+    auto branchType         = inferSubExpr(n[i][isElseClause ? 0 : 1]);
+
+    // Because all branches have the same type we can stop when we successfully inferred one.
+    if (!branchType.isInferred()) {
+      m_type = branchType;
+      return;
+    }
+  }
+}
+
+auto TypeInferExpr::visit(const parse::UnaryExprNode& n) -> void {
+  const auto& opToken = n.getOperator();
+  const auto op       = getOperator(opToken);
+  if (!op) {
+    return;
+  }
+  auto argType = inferSubExpr(n[0]);
+  m_type       = inferFuncCall(prog::getFuncName(*op), {argType});
+}
+
+auto TypeInferExpr::visit(const parse::ExecStmtNode & /*unused*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
+auto TypeInferExpr::visit(const parse::FuncDeclStmtNode & /*unused*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
+auto TypeInferExpr::inferSubExpr(const parse::Node& n) -> prog::sym::TypeId {
+  auto visitor = TypeInferExpr{m_prog, m_constTypes};
+  n.accept(&visitor);
+  return visitor.getType();
+}
+
+auto TypeInferExpr::inferFuncCall(
+    const std::string& funcName, std::vector<prog::sym::TypeId> argTypes) -> prog::sym::TypeId {
+  for (const auto& argType : argTypes) {
+    if (argType.isInferred()) {
+      return prog::sym::TypeId::inferredType();
+    }
+  }
+  auto func = m_prog->lookupFunc(funcName, prog::sym::Input{std::move(argTypes)});
+  if (func) {
+    return m_prog->getFuncDecl(*func).getSig().getOutput();
+  }
+  return prog::sym::TypeId::inferredType();
+}
+
+auto TypeInferExpr::setConstType(const lex::Token& constId, prog::sym::TypeId type) -> void {
+  auto name = getName(constId);
+  m_constTypes->insert({name, type});
+}
+
+auto TypeInferExpr::inferConstType(const lex::Token& constId) -> prog::sym::TypeId {
+  const auto itr = m_constTypes->find(getName(constId));
+  if (itr == m_constTypes->end()) {
+    return prog::sym::TypeId::inferredType();
+  }
+  return itr->second;
+}
+
+} // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "frontend/diag.hpp"
+#include "prog/program.hpp"
+#include <unordered_map>
+
+namespace frontend::internal {
+
+class TypeInferExpr final : public parse::NodeVisitor {
+public:
+  TypeInferExpr() = delete;
+  TypeInferExpr(
+      prog::Program* prog, std::unordered_map<std::string, prog::sym::TypeId>* constTypes);
+
+  [[nodiscard]] auto getType() const noexcept -> prog::sym::TypeId;
+
+  auto visit(const parse::ErrorNode& n) -> void override;
+  auto visit(const parse::BinaryExprNode& n) -> void override;
+  auto visit(const parse::CallExprNode& n) -> void override;
+  auto visit(const parse::ConditionalExprNode& n) -> void override;
+  auto visit(const parse::ConstDeclExprNode& n) -> void override;
+  auto visit(const parse::ConstExprNode& n) -> void override;
+  auto visit(const parse::GroupExprNode& n) -> void override;
+  auto visit(const parse::LitExprNode& n) -> void override;
+  auto visit(const parse::ParenExprNode& n) -> void override;
+  auto visit(const parse::SwitchExprElseNode& n) -> void override;
+  auto visit(const parse::SwitchExprIfNode& n) -> void override;
+  auto visit(const parse::SwitchExprNode& n) -> void override;
+  auto visit(const parse::UnaryExprNode& n) -> void override;
+  auto visit(const parse::ExecStmtNode& n) -> void override;
+  auto visit(const parse::FuncDeclStmtNode& n) -> void override;
+
+private:
+  prog::Program* m_prog;
+  std::unordered_map<std::string, prog::sym::TypeId>* m_constTypes;
+  prog::sym::TypeId m_type;
+
+  auto inferSubExpr(const parse::Node& n) -> prog::sym::TypeId;
+  auto inferFuncCall(const std::string& funcName, std::vector<prog::sym::TypeId> argTypes)
+      -> prog::sym::TypeId;
+
+  auto setConstType(const lex::Token& constId, prog::sym::TypeId type) -> void;
+  auto inferConstType(const lex::Token& constId) -> prog::sym::TypeId;
+};
+
+} // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_user_funcs.cpp
+++ b/src/frontend/internal/typeinfer_user_funcs.cpp
@@ -1,0 +1,25 @@
+#include "internal/typeinfer_user_funcs.hpp"
+#include "frontend/diag_defs.hpp"
+#include "internal/utilities.hpp"
+#include "parse/nodes.hpp"
+
+namespace frontend::internal {
+
+TypeInferUserFuncs::TypeInferUserFuncs(const Source& src, prog::Program* prog) :
+    m_src{src}, m_prog{prog} {}
+
+auto TypeInferUserFuncs::hasErrors() const noexcept -> bool { return !m_diags.empty(); }
+
+auto TypeInferUserFuncs::getDiags() const noexcept -> const std::vector<Diag>& { return m_diags; }
+
+auto TypeInferUserFuncs::inferTypes(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n)
+    -> void {
+  const auto& funcDecl = m_prog->getFuncDecl(id);
+  if (!funcDecl.getSig().getOutput().isInferred()) {
+    return;
+  }
+
+  m_diags.push_back(errUnableToInferFuncReturnType(m_src, funcDecl.getName(), n.getSpan()));
+}
+
+} // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_user_funcs.cpp
+++ b/src/frontend/internal/typeinfer_user_funcs.cpp
@@ -1,5 +1,6 @@
 #include "internal/typeinfer_user_funcs.hpp"
 #include "frontend/diag_defs.hpp"
+#include "internal/typeinfer_expr.hpp"
 #include "internal/utilities.hpp"
 #include "parse/nodes.hpp"
 
@@ -14,12 +15,31 @@ auto TypeInferUserFuncs::getDiags() const noexcept -> const std::vector<Diag>& {
 
 auto TypeInferUserFuncs::inferTypes(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n)
     -> void {
-  const auto& funcDecl = m_prog->getFuncDecl(id);
+  auto& funcDecl = m_prog->getFuncDecl(id);
   if (!funcDecl.getSig().getOutput().isInferred()) {
     return;
   }
 
-  m_diags.push_back(errUnableToInferFuncReturnType(m_src, funcDecl.getName(), n.getSpan()));
+  auto constTypes = std::unordered_map<std::string, prog::sym::TypeId>{};
+  for (const auto& arg : n.getArgs()) {
+    const auto argType = m_prog->lookupType(getName(arg.getType()));
+    if (argType) {
+      constTypes.insert({getName(arg.getIdentifier()), *argType});
+    }
+  }
+
+  auto inferBodyType = TypeInferExpr{m_prog, &constTypes};
+  n[0].accept(&inferBodyType);
+  const auto type = inferBodyType.getType();
+
+  // If type is still not a concrete type then we fail.
+  if (type.isInferred()) {
+    m_diags.push_back(errUnableToInferFuncReturnType(m_src, funcDecl.getName(), n.getSpan()));
+    return;
+  }
+
+  // Update signature with inferred type.
+  m_prog->updateFuncRetType(id, type);
 }
 
 } // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_user_funcs.hpp
+++ b/src/frontend/internal/typeinfer_user_funcs.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "frontend/diag.hpp"
+#include "frontend/source.hpp"
+#include "prog/program.hpp"
+
+namespace frontend::internal {
+
+class TypeInferUserFuncs final {
+public:
+  TypeInferUserFuncs() = delete;
+  TypeInferUserFuncs(const Source& src, prog::Program* prog);
+
+  [[nodiscard]] auto hasErrors() const noexcept -> bool;
+  [[nodiscard]] auto getDiags() const noexcept -> const std::vector<Diag>&;
+
+  auto inferTypes(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n) -> void;
+
+private:
+  const Source& m_src;
+  prog::Program* m_prog;
+  std::vector<Diag> m_diags;
+};
+
+} // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_user_funcs.hpp
+++ b/src/frontend/internal/typeinfer_user_funcs.hpp
@@ -8,17 +8,12 @@ namespace frontend::internal {
 class TypeInferUserFuncs final {
 public:
   TypeInferUserFuncs() = delete;
-  TypeInferUserFuncs(const Source& src, prog::Program* prog);
+  explicit TypeInferUserFuncs(prog::Program* prog);
 
-  [[nodiscard]] auto hasErrors() const noexcept -> bool;
-  [[nodiscard]] auto getDiags() const noexcept -> const std::vector<Diag>&;
-
-  auto inferTypes(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n) -> void;
+  auto inferRetType(prog::sym::FuncId id, const parse::FuncDeclStmtNode& n) -> bool;
 
 private:
-  const Source& m_src;
   prog::Program* m_prog;
-  std::vector<Diag> m_diags;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -74,7 +74,7 @@ inline auto getText(const prog::Operator& op) -> std::string {
   case prog::Operator::GtEq:
     return ">=";
   }
-  return "__unkown";
+  return "__unknown";
 }
 
 } // namespace frontend::internal

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -141,4 +141,8 @@ auto Program::addExecStmt(
       sym::execStmt(m_actionDecls, action, std::move(consts), std::move(args)));
 }
 
+auto Program::updateFuncRetType(sym::FuncId funcId, sym::TypeId newRetType) -> void {
+  m_funcDecls.updateFuncRetType(funcId, newRetType);
+}
+
 } // namespace prog

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -126,8 +126,8 @@ auto Program::getActionDecl(sym::ActionId id) const -> const sym::ActionDecl& {
 
 auto Program::getFuncDef(sym::FuncId id) const -> const sym::FuncDef& { return m_funcDefs[id]; }
 
-auto Program::declareUserFunc(std::string name, sym::FuncSig sig) -> void {
-  m_funcDecls.registerFunc(sym::FuncKind::User, std::move(name), std::move(sig));
+auto Program::declareUserFunc(std::string name, sym::FuncSig sig) -> sym::FuncId {
+  return m_funcDecls.registerFunc(sym::FuncKind::User, std::move(name), std::move(sig));
 }
 
 auto Program::defineUserFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr)

--- a/src/prog/sym/func_decl.cpp
+++ b/src/prog/sym/func_decl.cpp
@@ -19,6 +19,8 @@ auto FuncDecl::getName() const -> const std::string& { return m_name; }
 
 auto FuncDecl::getSig() const -> const FuncSig& { return m_sig; }
 
+auto FuncDecl::updateSig(FuncSig sig) -> void { m_sig = std::move(sig); }
+
 auto operator<<(std::ostream& out, const FuncDecl& rhs) -> std::ostream& {
   return out << '[' << rhs.m_id << "]-'" << rhs.m_name << "'-" << rhs.m_sig;
 }

--- a/src/prog/sym/func_decl_table.cpp
+++ b/src/prog/sym/func_decl_table.cpp
@@ -48,6 +48,12 @@ auto FuncDeclTable::registerFunc(FuncKind kind, std::string name, FuncSig sig) -
   return id;
 }
 
+auto FuncDeclTable::updateFuncRetType(FuncId id, TypeId newRetType) -> void {
+  const auto index = id.m_id;
+  assert(index < this->m_funcs.size());
+  m_funcs[index].updateSig(FuncSig{m_funcs[index].getSig().getInput(), newRetType});
+}
+
 auto FuncDeclTable::findOverload(const std::vector<FuncId>& overloads, const Input& input) const
     -> std::optional<FuncId> {
   for (const auto& funcId : overloads) {

--- a/src/prog/sym/type_decl_table.cpp
+++ b/src/prog/sym/type_decl_table.cpp
@@ -3,8 +3,13 @@
 
 namespace prog::sym {
 
+const unsigned int reservedTypesCount = 1;
+
 auto TypeDeclTable::operator[](TypeId id) const -> const TypeDecl& {
-  const auto index = id.m_id;
+  if (id.m_id < reservedTypesCount) {
+    throw std::invalid_argument{"Given type-id is a reserved type that has no declaration"};
+  }
+  const auto index = id.m_id - reservedTypesCount;
   assert(index < this->m_types.size());
   return m_types[index];
 }
@@ -26,7 +31,7 @@ auto TypeDeclTable::registerType(TypeKind kind, std::string name) -> TypeId {
     throw std::invalid_argument{"Name has to contain aleast 1 char"};
   }
 
-  auto id = TypeId{static_cast<unsigned int>(m_types.size())};
+  auto id = TypeId{static_cast<unsigned int>(m_types.size() + reservedTypesCount)};
   if (m_lookup.insert({name, id}).second) {
     m_types.push_back(TypeDecl{id, kind, std::move(name)});
     return id;

--- a/src/prog/sym/type_id.cpp
+++ b/src/prog/sym/type_id.cpp
@@ -4,7 +4,7 @@ namespace prog::sym {
 
 TypeId::TypeId(unsigned int id) : m_id{id} {}
 
-auto TypeId::inferredType() -> TypeId { return TypeId{0}; };
+auto TypeId::inferType() -> TypeId { return TypeId{0}; };
 
 auto TypeId::operator==(const TypeId& rhs) const noexcept -> bool { return m_id == rhs.m_id; }
 
@@ -12,7 +12,9 @@ auto TypeId::operator!=(const TypeId& rhs) const noexcept -> bool {
   return !TypeId::operator==(rhs);
 }
 
-auto TypeId::isInferred() const noexcept -> bool { return m_id == 0; };
+auto TypeId::isInfer() const noexcept -> bool { return m_id == 0; };
+
+auto TypeId::isConcrete() const noexcept -> bool { return m_id != 0; };
 
 auto operator<<(std::ostream& out, const TypeId& rhs) -> std::ostream& {
   return out << "t-" << rhs.m_id;

--- a/src/prog/sym/type_id.cpp
+++ b/src/prog/sym/type_id.cpp
@@ -4,11 +4,15 @@ namespace prog::sym {
 
 TypeId::TypeId(unsigned int id) : m_id{id} {}
 
+auto TypeId::inferredType() -> TypeId { return TypeId{0}; };
+
 auto TypeId::operator==(const TypeId& rhs) const noexcept -> bool { return m_id == rhs.m_id; }
 
 auto TypeId::operator!=(const TypeId& rhs) const noexcept -> bool {
   return !TypeId::operator==(rhs);
 }
+
+auto TypeId::isInferred() const noexcept -> bool { return m_id == 0; };
 
 auto operator<<(std::ostream& out, const TypeId& rhs) -> std::ostream& {
   return out << "t-" << rhs.m_id;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(tests
   frontend/get_unary_expr_test.cpp
   frontend/parse_diags_test.cpp
   frontend/source_test.cpp
+  frontend/typeinfer_user_funcs_test.cpp
 
   input/info_test.cpp
   input/span_test.cpp

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -84,12 +84,19 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
     CHECK(GET_FUNC_DECL(output, "f2").getSig().getOutput() == GET_TYPE_ID(output, "bool"));
   }
 
+  SECTION("Call function that is declared later") {
+    const auto& output = ANALYZE("fun f1() f2() "
+                                 "fun f2() false");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f1").getSig().getOutput() == GET_TYPE_ID(output, "bool"));
+  }
+
   SECTION("Diagnostics") {
     CHECK_DIAG(
         "fun f1() f2() "
         "fun f2() f1()",
-        errUnableToInferFuncReturnType(src, "f1", input::Span{0, 12}),
-        errUnableToInferFuncReturnType(src, "f2", input::Span{14, 26}));
+        errUnableToInferFuncReturnType(src, "f1", input::Span{9, 12}),
+        errUnableToInferFuncReturnType(src, "f2", input::Span{23, 26}));
   }
 }
 

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -1,0 +1,96 @@
+#include "catch2/catch.hpp"
+#include "frontend/diag_defs.hpp"
+#include "helpers.hpp"
+#include "prog/sym/input.hpp"
+
+namespace frontend {
+
+TEST_CASE("Infer return type of user functions", "[frontend]") {
+
+  SECTION("Int literal") {
+    const auto& output = ANALYZE("fun f() 1");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Bool literal") {
+    const auto& output = ANALYZE("fun f() false");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "bool"));
+  }
+
+  SECTION("Function argument") {
+    const auto& output = ANALYZE("fun f(int arg) arg");
+    REQUIRE(output.isSuccess());
+    CHECK(
+        GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "int")).getSig().getOutput() ==
+        GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Parenthesized") {
+    const auto& output = ANALYZE("fun f() (1)");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Constant") {
+    const auto& output = ANALYZE("fun f() x = 45; x");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Logic and operator") {
+    const auto& output = ANALYZE("fun f() true && false");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "bool"));
+  }
+
+  SECTION("Logic or operator") {
+    const auto& output = ANALYZE("fun f() true || false");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "bool"));
+  }
+
+  SECTION("Binary operator") {
+    const auto& output = ANALYZE("fun f() 42 + 1337");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Unary operator") {
+    const auto& output = ANALYZE("fun f() -42");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Conditional operator") {
+    const auto& output = ANALYZE("fun f() 1 > 2 ? 42 : 1337");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Switch") {
+    const auto& output = ANALYZE("fun f() "
+                                 "if 1 > 2  -> 1 "
+                                 "else      -> 2");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getSig().getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Call") {
+    const auto& output = ANALYZE("fun f1() false "
+                                 "fun f2() f1()");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f2").getSig().getOutput() == GET_TYPE_ID(output, "bool"));
+  }
+
+  SECTION("Diagnostics") {
+    CHECK_DIAG(
+        "fun f1() f2() "
+        "fun f2() f1()",
+        errUnableToInferFuncReturnType(src, "f1", input::Span{0, 12}),
+        errUnableToInferFuncReturnType(src, "f2", input::Span{14, 26}));
+  }
+}
+
+} // namespace frontend


### PR DESCRIPTION
Return type specification `-> [TYPE]` is now optional and if its not provided the frontend will infer the type from the body of the function.

```
fun min(int x, int y)
  x < y ? x : y

fun min(int x, int y, int z)
  min(min(x, y), z)

print(min(34, -12, -23 * 3 / 2))
```