### PR TITLE
Generate struct equality functions

### DIFF
--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -30,6 +30,9 @@ enum class FuncKind {
   ConvBoolString,
 
   MakeStruct,
+
+  CheckEqUserType,
+  CheckNEqUserType,
 };
 
 } // namespace prog::sym

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,7 @@ add_library(backend STATIC
   backend/dasm/disassembler.cpp
   backend/dasm/instruction.cpp
   backend/internal/gen_expr.cpp
+  backend/internal/gen_type_eq.cpp
   backend/internal/utilities.cpp
   backend/builder.cpp
   backend/generator.cpp)

--- a/src/backend/internal/gen_type_eq.cpp
+++ b/src/backend/internal/gen_type_eq.cpp
@@ -1,0 +1,56 @@
+#include "gen_type_eq.hpp"
+#include "utilities.hpp"
+
+namespace backend::internal {
+
+auto generateStructEquality(
+    Builder* builder, const prog::Program& program, const prog::sym::StructDef& structDef) -> void {
+  builder->label(getUserTypeEqLabel(structDef.getId()));
+
+  // Store the 2 struct's as consts.
+  builder->addReserveConsts(2);
+  builder->addStoreConst(0);
+  builder->addStoreConst(1);
+
+  const auto& fields = structDef.getFields();
+  for (const auto& field : fields) {
+    const auto fieldId        = getFieldId(field.getId());
+    const auto& fieldTypeDecl = program.getTypeDecl(field.getType());
+
+    // Load the field for both structs on the stack.
+    builder->addLoadConst(0);
+    builder->addLoadStructField(fieldId);
+    builder->addLoadConst(1);
+    builder->addLoadStructField(fieldId);
+
+    // Check if the field is equal.
+    switch (fieldTypeDecl.getKind()) {
+    case prog::sym::TypeKind::Bool:
+    case prog::sym::TypeKind::Int:
+      builder->addCheckEqInt();
+      break;
+    case prog::sym::TypeKind::String:
+      builder->addCheckEqString();
+      break;
+    case prog::sym::TypeKind::UserStruct:
+      builder->addCall(getUserTypeEqLabel(field.getType()));
+      break;
+    }
+
+    // If equal jump to the next field.
+    const auto eqLabel = builder->generateLabel();
+    builder->addJumpIf(eqLabel);
+
+    // If not equal return false.
+    builder->addLoadLitInt(0);
+    builder->addRet();
+
+    builder->label(eqLabel);
+  }
+
+  builder->addLoadLitInt(1);
+  builder->addRet();
+  builder->addFail(); // Add a fail between sections to aid in detecting invalid programs.
+}
+
+} // namespace backend::internal

--- a/src/backend/internal/gen_type_eq.hpp
+++ b/src/backend/internal/gen_type_eq.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "backend/builder.hpp"
+#include "prog/program.hpp"
+
+namespace backend::internal {
+
+auto generateStructEquality(
+    Builder* builder, const prog::Program& program, const prog::sym::StructDef& structDef) -> void;
+
+} // namespace backend::internal

--- a/src/backend/internal/utilities.cpp
+++ b/src/backend/internal/utilities.cpp
@@ -10,6 +10,12 @@ auto getLabel(prog::sym::FuncId funcId) -> std::string {
   return oss.str();
 }
 
+auto getUserTypeEqLabel(prog::sym::TypeId typeId) -> std::string {
+  std::ostringstream oss;
+  oss << "eq" << typeId;
+  return oss.str();
+}
+
 auto getConstId(prog::sym::ConstId constId) -> uint8_t {
   auto constNum = constId.getNum();
   if (constNum > std::numeric_limits<uint8_t>::max()) {

--- a/src/backend/internal/utilities.hpp
+++ b/src/backend/internal/utilities.hpp
@@ -2,11 +2,14 @@
 #include "prog/sym/const_id.hpp"
 #include "prog/sym/field_id.hpp"
 #include "prog/sym/func_id.hpp"
+#include "prog/sym/type_id.hpp"
 #include <string>
 
 namespace backend::internal {
 
 auto getLabel(prog::sym::FuncId funcId) -> std::string;
+
+auto getUserTypeEqLabel(prog::sym::TypeId typeId) -> std::string;
 
 auto getConstId(prog::sym::ConstId constId) -> uint8_t;
 

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -198,6 +198,20 @@ auto Program::defineUserStruct(sym::TypeId id, sym::FieldDeclTable fields) -> vo
   // Register constructor function.
   const auto& name = m_typeDecls[id].getName();
   m_funcDecls.registerFunc(*this, sym::FuncKind::MakeStruct, name, sym::Input{fieldTypes}, id);
+
+  // Register (in)equality function.
+  m_funcDecls.registerFunc(
+      *this,
+      sym::FuncKind::CheckEqUserType,
+      getFuncName(Operator::EqEq),
+      sym::Input{id, id},
+      *m_typeDecls.lookup("bool"));
+  m_funcDecls.registerFunc(
+      *this,
+      sym::FuncKind::CheckNEqUserType,
+      getFuncName(Operator::BangEq),
+      sym::Input{id, id},
+      *m_typeDecls.lookup("bool"));
 }
 
 auto Program::defineUserFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr)

--- a/src/prog/sym/func_id.cpp
+++ b/src/prog/sym/func_id.cpp
@@ -11,7 +11,7 @@ auto FuncId::operator!=(const FuncId& rhs) const noexcept -> bool {
 }
 
 auto operator<<(std::ostream& out, const FuncId& rhs) -> std::ostream& {
-  return out << "func-" << rhs.m_id;
+  return out << "f-" << rhs.m_id;
 }
 
 } // namespace prog::sym

--- a/src/prog/sym/type_id.cpp
+++ b/src/prog/sym/type_id.cpp
@@ -17,7 +17,7 @@ auto TypeId::isInfer() const noexcept -> bool { return m_id == 0; };
 auto TypeId::isConcrete() const noexcept -> bool { return m_id != 0; };
 
 auto operator<<(std::ostream& out, const TypeId& rhs) -> std::ostream& {
-  return out << "type-" << rhs.m_id;
+  return out << "t-" << rhs.m_id;
 }
 
 } // namespace prog::sym

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(tests
   backend/constants_test.cpp
   backend/literals_test.cpp
   backend/switch_expr_test.cpp
+  backend/user_struct_test.cpp
 
   frontend/declare_user_funcs_test.cpp
   frontend/declare_user_types_test.cpp

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -159,30 +159,6 @@ TEST_CASE("Generate assembly for call expressions", "[backend]") {
     });
   }
 
-  SECTION("User struct") {
-    CHECK_PROG(
-        "struct User = string name, int age "
-        "print(u = User(\"hello\", 27); u.age)",
-        [](backend::Builder* builder) -> void {
-          builder->label("print");
-          builder->addReserveConsts(1);
-
-          builder->addLoadLitString("hello");
-          builder->addLoadLitInt(27);
-          builder->addMakeStruct(2);
-          builder->addStoreConst(0);
-
-          builder->addLoadConst(0);
-          builder->addLoadStructField(1);
-          builder->addConvIntString();
-          builder->addPrintString();
-          builder->addRet();
-          builder->addFail();
-
-          builder->addEntryPoint("print");
-        });
-  }
-
   SECTION("User functions") {
     CHECK_PROG(
         "fun test(int a, int b) -> int a + b "

--- a/tests/backend/user_struct_test.cpp
+++ b/tests/backend/user_struct_test.cpp
@@ -1,0 +1,66 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+
+namespace backend {
+
+TEST_CASE("Generating assembly for user-structs", "[backend]") {
+
+  SECTION("Create user struct and check for equality") {
+    CHECK_PROG(
+        "struct User = string name, int age "
+        "print(User(\"hello\", 42) == User(\"world\", 1337))",
+        [](backend::Builder* builder) -> void {
+          // Struct equality function.
+          builder->label("UserEq");
+          builder->addReserveConsts(2);
+          builder->addStoreConst(0);
+          builder->addStoreConst(1);
+
+          builder->addLoadConst(0);
+          builder->addLoadStructField(0);
+          builder->addLoadConst(1);
+          builder->addLoadStructField(0);
+          builder->addCheckEqString();
+
+          builder->addJumpIf("field1 equal");
+          builder->addLoadLitInt(0);
+          builder->addRet();
+
+          builder->label("field1 equal");
+          builder->addLoadConst(0);
+          builder->addLoadStructField(1);
+          builder->addLoadConst(1);
+          builder->addLoadStructField(1);
+          builder->addCheckEqInt();
+
+          builder->addJumpIf("field2 equal");
+          builder->addLoadLitInt(0);
+          builder->addRet();
+
+          builder->label("field2 equal");
+          builder->addLoadLitInt(1);
+          builder->addRet();
+          builder->addFail();
+
+          // Print statement.
+          builder->label("print");
+          builder->addLoadLitString("hello");
+          builder->addLoadLitInt(42);
+          builder->addMakeStruct(2);
+
+          builder->addLoadLitString("world");
+          builder->addLoadLitInt(1337);
+          builder->addMakeStruct(2);
+
+          builder->addCall("UserEq");
+          builder->addConvBoolString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+
+          builder->addEntryPoint("print");
+        });
+  }
+}
+
+} // namespace backend


### PR DESCRIPTION
<img width="1161" alt="Screenshot 2019-12-01 at 21 30 29" src="https://user-images.githubusercontent.com/14230060/69919115-41c5af80-1482-11ea-8fa8-a7614260f777.png">

Equality functions for user defined structs are generated on the backend. Reason for generating them on the backend is that at runtime the type information is not available and on the frontend level its hard to generate efficient functions.