### PR TITLE
Feature/union check only

### DIFF
--- a/apps/progdiag/get_expr_color.hpp
+++ b/apps/progdiag/get_expr_color.hpp
@@ -32,6 +32,10 @@ public:
     m_fg = rang::fg::yellow;
   }
 
+  auto visit(const prog::expr::UnionCheckExprNode & /*unused*/) -> void override {
+    m_fg = rang::fg::green;
+  }
+
   auto visit(const prog::expr::UnionGetExprNode & /*unused*/) -> void override {
     m_fg = rang::fg::green;
   }

--- a/include/lex/token_kind.hpp
+++ b/include/lex/token_kind.hpp
@@ -36,6 +36,7 @@ enum class TokenKind {
   LitString,
   Keyword,
   Identifier,
+  Discard,
   Error
 };
 

--- a/include/parse/node_expr_is.hpp
+++ b/include/parse/node_expr_is.hpp
@@ -18,6 +18,7 @@ public:
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
   [[nodiscard]] auto getType() const -> const lex::Token&;
+  [[nodiscard]] auto hasId() const -> bool;
   [[nodiscard]] auto getId() const -> const lex::Token&;
 
   auto accept(NodeVisitor* visitor) const -> void override;

--- a/include/prog/expr/node_union_check.hpp
+++ b/include/prog/expr/node_union_check.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include "prog/expr/node.hpp"
+#include "prog/program.hpp"
+
+namespace prog::expr {
+
+class UnionCheckExprNode final : public Node {
+  friend auto unionCheckExprNode(const Program& prog, NodePtr lhs, sym::TypeId targetType)
+      -> NodePtr;
+
+public:
+  UnionCheckExprNode() = delete;
+
+  auto operator==(const Node& rhs) const noexcept -> bool override;
+  auto operator!=(const Node& rhs) const noexcept -> bool override;
+
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
+  [[nodiscard]] auto getChildCount() const -> unsigned int override;
+  [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
+  [[nodiscard]] auto toString() const -> std::string override;
+
+  [[nodiscard]] auto getTargetType() const noexcept -> sym::TypeId;
+
+  auto accept(NodeVisitor* visitor) const -> void override;
+
+private:
+  sym::TypeId m_boolType;
+  NodePtr m_lhs;
+  sym::TypeId m_targetType;
+
+  UnionCheckExprNode(sym::TypeId boolType, NodePtr lhs, sym::TypeId targetType);
+};
+
+// Factories.
+auto unionCheckExprNode(const Program& prog, NodePtr lhs, sym::TypeId targetType) -> NodePtr;
+
+} // namespace prog::expr

--- a/include/prog/expr/node_visitor.hpp
+++ b/include/prog/expr/node_visitor.hpp
@@ -8,6 +8,7 @@ class CallExprNode;
 class ConstExprNode;
 class FieldExprNode;
 class GroupExprNode;
+class UnionCheckExprNode;
 class UnionGetExprNode;
 class LitBoolNode;
 class LitFloatNode;
@@ -16,17 +17,18 @@ class LitStringNode;
 
 class NodeVisitor {
 public:
-  virtual auto visit(const AssignExprNode& n) -> void   = 0;
-  virtual auto visit(const SwitchExprNode& n) -> void   = 0;
-  virtual auto visit(const CallExprNode& n) -> void     = 0;
-  virtual auto visit(const ConstExprNode& n) -> void    = 0;
-  virtual auto visit(const FieldExprNode& n) -> void    = 0;
-  virtual auto visit(const GroupExprNode& n) -> void    = 0;
-  virtual auto visit(const UnionGetExprNode& n) -> void = 0;
-  virtual auto visit(const LitBoolNode& n) -> void      = 0;
-  virtual auto visit(const LitFloatNode& n) -> void     = 0;
-  virtual auto visit(const LitIntNode& n) -> void       = 0;
-  virtual auto visit(const LitStringNode& n) -> void    = 0;
+  virtual auto visit(const AssignExprNode& n) -> void     = 0;
+  virtual auto visit(const SwitchExprNode& n) -> void     = 0;
+  virtual auto visit(const CallExprNode& n) -> void       = 0;
+  virtual auto visit(const ConstExprNode& n) -> void      = 0;
+  virtual auto visit(const FieldExprNode& n) -> void      = 0;
+  virtual auto visit(const GroupExprNode& n) -> void      = 0;
+  virtual auto visit(const UnionCheckExprNode& n) -> void = 0;
+  virtual auto visit(const UnionGetExprNode& n) -> void   = 0;
+  virtual auto visit(const LitBoolNode& n) -> void        = 0;
+  virtual auto visit(const LitFloatNode& n) -> void       = 0;
+  virtual auto visit(const LitIntNode& n) -> void         = 0;
+  virtual auto visit(const LitStringNode& n) -> void      = 0;
 };
 
 } // namespace prog::expr

--- a/include/prog/expr/nodes.hpp
+++ b/include/prog/expr/nodes.hpp
@@ -8,4 +8,5 @@
 #include "prog/expr/node_lit_int.hpp"
 #include "prog/expr/node_lit_string.hpp"
 #include "prog/expr/node_switch.hpp"
+#include "prog/expr/node_union_check.hpp"
 #include "prog/expr/node_union_get.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(prog STATIC
   prog/expr/node_lit_int.cpp
   prog/expr/node_lit_string.cpp
   prog/expr/node_switch.cpp
+  prog/expr/node_union_check.cpp
   prog/expr/node_union_get.cpp
   prog/expr/node.cpp
   prog/expr/utilities.cpp

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -237,6 +237,16 @@ auto GenExpr::visit(const prog::expr::GroupExprNode& n) -> void {
   }
 }
 
+auto GenExpr::visit(const prog::expr::UnionCheckExprNode& n) -> void {
+  // Load the union.
+  genSubExpr(n[0]);
+
+  // Test if the union is the correct type.
+  m_builder->addLoadStructField(0);
+  m_builder->addLoadLitInt(static_cast<int32_t>(n.getTargetType().getNum()));
+  m_builder->addCheckEqInt();
+}
+
 auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
   // Load the union.
   genSubExpr(n[0]);

--- a/src/backend/internal/gen_expr.hpp
+++ b/src/backend/internal/gen_expr.hpp
@@ -15,6 +15,7 @@ public:
   auto visit(const prog::expr::ConstExprNode& n) -> void override;
   auto visit(const prog::expr::FieldExprNode& n) -> void override;
   auto visit(const prog::expr::GroupExprNode& n) -> void override;
+  auto visit(const prog::expr::UnionCheckExprNode& n) -> void override;
   auto visit(const prog::expr::UnionGetExprNode& n) -> void override;
   auto visit(const prog::expr::LitBoolNode& n) -> void override;
   auto visit(const prog::expr::LitFloatNode& n) -> void override;

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -251,6 +251,11 @@ auto GetExpr::visit(const parse::IsExprNode& n) -> void {
     return;
   }
 
+  if (!n.hasId()) {
+    m_expr = prog::expr::unionCheckExprNode(*m_prog, std::move(lhsExpr), *type);
+    return;
+  }
+
   // Validate that this expression is part of a checked context, meaning the const is only accessed
   // when the expression evaluates to 'true'.
   if (!m_checkedConstsAccess) {

--- a/src/lex/lexer.cpp
+++ b/src/lex/lexer.cpp
@@ -163,8 +163,7 @@ auto LexerImpl::next() -> Token {
       if (isWordStart(nextChar) || isDigit(nextChar) || nextChar == '_') {
         return nextWordToken(c);
       }
-      // Current '_' is not used as a valid token own.
-      return errInvalidChar(c, input::Span(m_inputPos, m_inputPos));
+      return basicToken(TokenKind::Discard, input::Span{m_inputPos});
     }
     default:
       if (isWordStart(c)) {

--- a/src/lex/token_cat.cpp
+++ b/src/lex/token_cat.cpp
@@ -66,6 +66,7 @@ auto lookupCat(const TokenKind kind) -> TokenCat {
   case TokenKind::Keyword:
     return TokenCat::Keyword;
   case TokenKind::Identifier:
+  case TokenKind::Discard:
     return TokenCat::Identifier;
   case TokenKind::Error:
     return TokenCat::Error;

--- a/src/lex/token_kind.cpp
+++ b/src/lex/token_kind.cpp
@@ -94,6 +94,9 @@ auto operator<<(std::ostream& out, const TokenKind& rhs) -> std::ostream& {
   case TokenKind::Keyword:
     out << "keyword";
     break;
+  case TokenKind::Discard:
+    out << "discard";
+    break;
   case TokenKind::Identifier:
     out << "identifier";
     break;

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -227,8 +227,9 @@ auto errInvalidIsExpr(NodePtr lhs, lex::Token kw, lex::Token type, lex::Token id
     oss << "Expected keyword 'is' but got: " << kw;
   } else if (type.getKind() != lex::TokenKind::Identifier) {
     oss << "Expected type identifier but got: " << type;
-  } else if (id.getKind() != lex::TokenKind::Identifier) {
-    oss << "Expected identifier but got: " << id;
+  } else if (
+      id.getKind() != lex::TokenKind::Identifier && id.getKind() != lex::TokenKind::Discard) {
+    oss << "Expected identifier or discard '_' but got: " << id;
   } else {
     oss << "Invalid 'is' expression";
   }

--- a/src/parse/node_expr_is.cpp
+++ b/src/parse/node_expr_is.cpp
@@ -30,13 +30,18 @@ auto IsExprNode::getSpan() const -> input::Span {
 
 auto IsExprNode::getType() const -> const lex::Token& { return m_type; }
 
+auto IsExprNode::hasId() const -> bool { return m_id.getKind() == lex::TokenKind::Identifier; }
+
 auto IsExprNode::getId() const -> const lex::Token& { return m_id; }
 
 auto IsExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
 auto IsExprNode::print(std::ostream& out) const -> std::ostream& {
-  return out << "is-" << parse::getId(m_type).value_or("error") << '-'
-             << parse::getId(m_id).value_or("error");
+  out << "is-" << parse::getId(m_type).value_or("error");
+  if (m_id.getKind() == lex::TokenKind::Identifier) {
+    out << '-' << parse::getId(m_id).value_or("error");
+  }
+  return out;
 }
 
 // Factories.

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -298,7 +298,7 @@ auto ParserImpl::nextExprIs(NodePtr lhs) -> NodePtr {
   auto id   = consumeToken();
 
   if (getKw(kw) == lex::Keyword::Is && type.getKind() == lex::TokenKind::Identifier &&
-      id.getKind() == lex::TokenKind::Identifier) {
+      (id.getKind() == lex::TokenKind::Identifier || id.getKind() == lex::TokenKind::Discard)) {
     return isExprNode(std::move(lhs), std::move(kw), std::move(type), std::move(id));
   }
   return errInvalidIsExpr(std::move(lhs), std::move(kw), std::move(type), std::move(id));

--- a/src/prog/expr/node_union_check.cpp
+++ b/src/prog/expr/node_union_check.cpp
@@ -1,0 +1,67 @@
+#include "prog/expr/node_union_check.hpp"
+#include "utilities.hpp"
+#include <sstream>
+#include <stdexcept>
+
+namespace prog::expr {
+
+UnionCheckExprNode::UnionCheckExprNode(sym::TypeId boolType, NodePtr lhs, sym::TypeId targetType) :
+    m_boolType{boolType}, m_lhs{std::move(lhs)}, m_targetType{targetType} {}
+
+auto UnionCheckExprNode::operator==(const Node& rhs) const noexcept -> bool {
+  const auto r = dynamic_cast<const UnionCheckExprNode*>(&rhs);
+  return r != nullptr && *m_lhs == *r->m_lhs && m_targetType == r->m_targetType;
+}
+
+auto UnionCheckExprNode::operator!=(const Node& rhs) const noexcept -> bool {
+  return !UnionCheckExprNode::operator==(rhs);
+}
+
+auto UnionCheckExprNode::operator[](unsigned int i) const -> const Node& {
+  if (i == 0) {
+    return *m_lhs;
+  }
+  throw std::out_of_range{"No child at given index"};
+}
+
+auto UnionCheckExprNode::getChildCount() const -> unsigned int { return 1; }
+
+auto UnionCheckExprNode::getType() const noexcept -> sym::TypeId { return m_boolType; }
+
+auto UnionCheckExprNode::toString() const -> std::string {
+  auto oss = std::ostringstream{};
+  oss << "union-check-" << m_targetType;
+  return oss.str();
+}
+
+auto UnionCheckExprNode::getTargetType() const noexcept -> sym::TypeId { return m_targetType; }
+
+auto UnionCheckExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
+
+// Factories.
+auto unionCheckExprNode(const Program& prog, NodePtr lhs, sym::TypeId targetType) -> NodePtr {
+  if (!lhs) {
+    throw std::invalid_argument{"Left-hand-side expression in union-check cannot be null"};
+  }
+  const auto boolType = prog.lookupType("bool");
+  if (!boolType) {
+    throw std::logic_error{"No 'bool' type found in program"};
+  }
+
+  const auto& exprTypeDecl = prog.getTypeDecl(lhs->getType());
+  if (exprTypeDecl.getKind() != sym::TypeKind::UserUnion) {
+    throw std::invalid_argument{"Type of the left-hand-side expression needs to be a union type"};
+  }
+  const auto& exprTypeDef = prog.getTypeDef(lhs->getType());
+  const auto& unionDef    = std::get<prog::sym::UnionDef>(exprTypeDef);
+
+  if (!unionDef.hasType(targetType)) {
+    throw std::invalid_argument{
+        "Type of the constant needs to be a type in the left-hand-side union"};
+  }
+
+  return std::unique_ptr<UnionCheckExprNode>{
+      new UnionCheckExprNode{*boolType, std::move(lhs), targetType}};
+}
+
+} // namespace prog::expr

--- a/tests/lex/identifier_test.cpp
+++ b/tests/lex/identifier_test.cpp
@@ -17,6 +17,7 @@ TEST_CASE("Lexing identifiers", "[lex]") {
     CHECK_TOKENS("你好世界", identiferToken("你好世界"));
     CHECK_TOKENS("_你好世界", identiferToken("_你好世界"));
     CHECK_TOKENS("_你1好2世3界", identiferToken("_你1好2世3界"));
+    CHECK_TOKENS("_", basicToken(TokenKind::Discard));
   }
 
   SECTION("Sequences") {
@@ -41,7 +42,6 @@ TEST_CASE("Lexing identifiers", "[lex]") {
     CHECK_TOKENS("1hello", errLitNumberInvalidChar());
     CHECK_TOKENS("h\a_hello", errIdentifierIllegalCharacter());
     CHECK_TOKENS("@", errInvalidChar('@'));
-    CHECK_TOKENS("_", errInvalidChar('_'));
 
     // Ids containing '__' are reserved for internal use.
     CHECK_TOKENS("__", errIdentifierIllegalSequence());

--- a/tests/parse/expr_is_test.cpp
+++ b/tests/parse/expr_is_test.cpp
@@ -11,6 +11,7 @@ namespace parse {
 TEST_CASE("Parsing is expressions", "[parse]") {
 
   CHECK_EXPR("x is int i", isExprNode(CONST("x"), IS, ID("int"), ID("i")));
+  CHECK_EXPR("x is int _", isExprNode(CONST("x"), IS, ID("int"), DISCARD));
   CHECK_EXPR("-x is int i", isExprNode(unaryExprNode(MINUS, CONST("x")), IS, ID("int"), ID("i")));
   CHECK_EXPR(
       "(x + y) is int i",

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -36,6 +36,7 @@ namespace parse {
 #define COLON lex::basicToken(lex::TokenKind::SepColon)
 #define COMMAS(COUNT) std::vector<lex::Token>(COUNT, lex::basicToken(lex::TokenKind::SepComma))
 #define ARROW lex::basicToken(lex::TokenKind::SepArrow)
+#define DISCARD lex::basicToken(lex::TokenKind::Discard)
 #define FUN lex::keywordToken(lex::Keyword::Fun)
 #define STRUCT lex::keywordToken(lex::Keyword::Struct)
 #define UNION lex::keywordToken(lex::Keyword::Union)


### PR DESCRIPTION
Add syntax for checking a union type without getting the value. Syntax is `[UNION] is [TYPE] _`, so it is the same as union access except you use a `_` instead of a const identifier.

Reason is that its cheaper when you only want to check the type and its valid in more places as the frontend doesn't need to validate that you access the value in a safe way.

<img width="567" alt="Screenshot 2019-12-07 at 15 04 34" src="https://user-images.githubusercontent.com/14230060/70375170-8084bb00-1903-11ea-9eaa-af3945a4481c.png">

<img width="571" alt="Screenshot 2019-12-07 at 15 05 40" src="https://user-images.githubusercontent.com/14230060/70375168-7b277080-1903-11ea-9816-abbbb5c3fdc0.png">