### PR TITLE
Feature/exhaustive switch

### DIFF
--- a/apps/progdiag/get_expr_color.hpp
+++ b/apps/progdiag/get_expr_color.hpp
@@ -40,6 +40,8 @@ public:
     m_fg = rang::fg::green;
   }
 
+  auto visit(const prog::expr::FailNode & /*unused*/) -> void override { m_fg = rang::fg::red; }
+
   auto visit(const prog::expr::LitBoolNode & /*unused*/) -> void override { m_fg = rang::fg::cyan; }
 
   auto visit(const prog::expr::LitFloatNode & /*unused*/) -> void override {

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -121,4 +121,6 @@ auto errMismatchedBranchTypes(
     const std::string& newTypeName,
     input::Span span) -> Diag;
 
+auto nonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag;
+
 } // namespace frontend

--- a/include/parse/node_expr_switch.hpp
+++ b/include/parse/node_expr_switch.hpp
@@ -18,6 +18,8 @@ public:
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
+  [[nodiscard]] auto hasElse() const -> bool;
+
   auto accept(NodeVisitor* visitor) const -> void override;
 
 private:

--- a/include/prog/expr/node_fail.hpp
+++ b/include/prog/expr/node_fail.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include "prog/expr/node.hpp"
+#include "prog/program.hpp"
+
+namespace prog::expr {
+
+class FailNode final : public Node {
+  friend auto failNode(sym::TypeId type) -> NodePtr;
+
+public:
+  FailNode() = delete;
+
+  auto operator==(const Node& rhs) const noexcept -> bool override;
+  auto operator!=(const Node& rhs) const noexcept -> bool override;
+
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
+  [[nodiscard]] auto getChildCount() const -> unsigned int override;
+  [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
+  [[nodiscard]] auto toString() const -> std::string override;
+
+  auto accept(NodeVisitor* visitor) const -> void override;
+
+private:
+  sym::TypeId m_type;
+
+  explicit FailNode(sym::TypeId type);
+};
+
+// Factories.
+auto failNode(sym::TypeId type) -> NodePtr;
+
+} // namespace prog::expr

--- a/include/prog/expr/node_visitor.hpp
+++ b/include/prog/expr/node_visitor.hpp
@@ -10,6 +10,7 @@ class FieldExprNode;
 class GroupExprNode;
 class UnionCheckExprNode;
 class UnionGetExprNode;
+class FailNode;
 class LitBoolNode;
 class LitFloatNode;
 class LitIntNode;
@@ -25,6 +26,7 @@ public:
   virtual auto visit(const GroupExprNode& n) -> void      = 0;
   virtual auto visit(const UnionCheckExprNode& n) -> void = 0;
   virtual auto visit(const UnionGetExprNode& n) -> void   = 0;
+  virtual auto visit(const FailNode& n) -> void           = 0;
   virtual auto visit(const LitBoolNode& n) -> void        = 0;
   virtual auto visit(const LitFloatNode& n) -> void       = 0;
   virtual auto visit(const LitIntNode& n) -> void         = 0;

--- a/include/prog/expr/nodes.hpp
+++ b/include/prog/expr/nodes.hpp
@@ -1,6 +1,7 @@
 #include "prog/expr/node_assign.hpp"
 #include "prog/expr/node_call.hpp"
 #include "prog/expr/node_const.hpp"
+#include "prog/expr/node_fail.hpp"
 #include "prog/expr/node_field.hpp"
 #include "prog/expr/node_group.hpp"
 #include "prog/expr/node_lit_bool.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ target_include_directories(prog PRIVATE prog)
 
 # Frontend.
 add_library(frontend STATIC
+  frontend/internal/check_union_exhaustiveness.cpp
   frontend/internal/declare_user_funcs.cpp
   frontend/internal/declare_user_types.cpp
   frontend/internal/define_exec_stmts.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(prog STATIC
   prog/expr/node_assign.cpp
   prog/expr/node_call.cpp
   prog/expr/node_const.cpp
+  prog/expr/node_fail.cpp
   prog/expr/node_field.cpp
   prog/expr/node_group.cpp
   prog/expr/node_lit_bool.cpp

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -279,6 +279,8 @@ auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
   m_builder->label(endLabel);
 }
 
+auto GenExpr::visit(const prog::expr::FailNode & /*unused*/) -> void { m_builder->addFail(); }
+
 auto GenExpr::visit(const prog::expr::LitBoolNode& n) -> void {
   m_builder->addLoadLitInt(n.getVal() ? 1U : 0U);
 }

--- a/src/backend/internal/gen_expr.hpp
+++ b/src/backend/internal/gen_expr.hpp
@@ -17,6 +17,7 @@ public:
   auto visit(const prog::expr::GroupExprNode& n) -> void override;
   auto visit(const prog::expr::UnionCheckExprNode& n) -> void override;
   auto visit(const prog::expr::UnionGetExprNode& n) -> void override;
+  auto visit(const prog::expr::FailNode& n) -> void override;
   auto visit(const prog::expr::LitBoolNode& n) -> void override;
   auto visit(const prog::expr::LitFloatNode& n) -> void override;
   auto visit(const prog::expr::LitIntNode& n) -> void override;

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -293,4 +293,10 @@ auto errMismatchedBranchTypes(
   return error(src, oss.str(), span);
 }
 
+auto nonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Switch expression is missing an 'else' branch and cannot be guaranteed to be exhaustive";
+  return error(src, oss.str(), span);
+}
+
 } // namespace frontend

--- a/src/frontend/internal/check_union_exhaustiveness.cpp
+++ b/src/frontend/internal/check_union_exhaustiveness.cpp
@@ -1,0 +1,64 @@
+#include "internal/check_union_exhaustiveness.hpp"
+#include "prog/expr/nodes.hpp"
+
+namespace frontend::internal {
+
+CheckUnionExhaustiveness::CheckUnionExhaustiveness(const prog::Program& program) :
+    m_program{program} {}
+
+auto CheckUnionExhaustiveness::isExhaustive() const -> bool {
+  if (!m_unionType) {
+    return false;
+  }
+  const auto& unionDef = std::get<prog::sym::UnionDef>(m_program.getTypeDef(*m_unionType));
+
+  // Validate that all union-types have been checked.
+  for (const auto& type : unionDef.getTypes()) {
+    if (std::find(m_checkedTypes.begin(), m_checkedTypes.end(), type) == m_checkedTypes.end()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::AssignExprNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::SwitchExprNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::CallExprNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::ConstExprNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::FieldExprNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::GroupExprNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::UnionCheckExprNode& n) -> void {
+  const auto unionType = n[0].getType();
+  if (m_unionType && m_unionType != unionType) {
+    return;
+  }
+  m_unionType = unionType;
+  m_checkedTypes.push_back(n.getTargetType());
+}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::UnionGetExprNode& n) -> void {
+  const auto unionType = n[0].getType();
+  if (m_unionType && m_unionType != unionType) {
+    return;
+  }
+  m_unionType = unionType;
+  m_checkedTypes.push_back(n.getTargetType());
+}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::FailNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::LitBoolNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::LitFloatNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::LitIntNode & /*unused*/) -> void {}
+
+auto CheckUnionExhaustiveness::visit(const prog::expr::LitStringNode & /*unused*/) -> void {}
+
+} // namespace frontend::internal

--- a/src/frontend/internal/check_union_exhaustiveness.hpp
+++ b/src/frontend/internal/check_union_exhaustiveness.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include "prog/expr/node_visitor.hpp"
+#include "prog/program.hpp"
+#include <optional>
+
+namespace frontend::internal {
+
+class CheckUnionExhaustiveness final : public prog::expr::NodeVisitor {
+public:
+  explicit CheckUnionExhaustiveness(const prog::Program& program);
+
+  [[nodiscard]] auto isExhaustive() const -> bool;
+
+  auto visit(const prog::expr::AssignExprNode& n) -> void override;
+  auto visit(const prog::expr::SwitchExprNode& n) -> void override;
+  auto visit(const prog::expr::CallExprNode& n) -> void override;
+  auto visit(const prog::expr::ConstExprNode& n) -> void override;
+  auto visit(const prog::expr::FieldExprNode& n) -> void override;
+  auto visit(const prog::expr::GroupExprNode& n) -> void override;
+  auto visit(const prog::expr::UnionCheckExprNode& n) -> void override;
+  auto visit(const prog::expr::UnionGetExprNode& n) -> void override;
+  auto visit(const prog::expr::FailNode& n) -> void override;
+  auto visit(const prog::expr::LitBoolNode& n) -> void override;
+  auto visit(const prog::expr::LitFloatNode& n) -> void override;
+  auto visit(const prog::expr::LitIntNode& n) -> void override;
+  auto visit(const prog::expr::LitStringNode& n) -> void override;
+
+private:
+  const prog::Program& m_program;
+  std::optional<prog::sym::TypeId> m_unionType;
+  std::vector<prog::sym::TypeId> m_checkedTypes;
+};
+
+} // namespace frontend::internal

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -50,17 +50,20 @@ private:
   std::vector<Diag> m_diags;
   prog::expr::NodePtr m_expr;
 
-  auto getSubExpr(
+  [[nodiscard]] auto getSubExpr(
       const parse::Node& n,
       std::vector<prog::sym::ConstId>* visibleConsts,
       bool checkedConstsAccess = false) -> prog::expr::NodePtr;
 
-  auto getBinLogicOpExpr(const parse::BinaryExprNode& n, BinLogicOp op) -> prog::expr::NodePtr;
+  [[nodiscard]] auto getBinLogicOpExpr(const parse::BinaryExprNode& n, BinLogicOp op)
+      -> prog::expr::NodePtr;
 
-  auto declareConst(const lex::Token& nameToken, prog::sym::TypeId type)
+  [[nodiscard]] auto declareConst(const lex::Token& nameToken, prog::sym::TypeId type)
       -> std::optional<prog::sym::ConstId>;
 
-  auto isBoolType(prog::sym::TypeId type) -> bool;
+  [[nodiscard]] auto isExhaustive(const std::vector<prog::expr::NodePtr>& conditions) const -> bool;
+
+  [[nodiscard]] auto isBoolType(prog::sym::TypeId type) -> bool;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -168,8 +168,15 @@ auto TypeInferExpr::visit(const parse::SwitchExprIfNode & /*unused*/) -> void {
 
 auto TypeInferExpr::visit(const parse::SwitchExprNode& n) -> void {
   for (auto i = 0U; i < n.getChildCount(); ++i) {
-    const auto isElseClause = i == n.getChildCount() - 1;
-    auto branchType         = inferSubExpr(n[i][isElseClause ? 0 : 1]);
+    const auto isElseClause = n.hasElse() && i == n.getChildCount() - 1;
+
+    // Also run type-inference on the conditions as they might declare consts.
+    if (!isElseClause) {
+      inferSubExpr(n[i][0]);
+    }
+
+    // Get type of the branch.
+    auto branchType = inferSubExpr(n[i][isElseClause ? 0 : 1]);
 
     // Because all branches have the same type we can stop when we successfully inferred one.
     if (branchType.isConcrete()) {

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -365,7 +365,8 @@ auto ParserImpl::nextExprSwitch() -> NodePtr {
   do {
     ifClauses.push_back(nextExprSwitchIf());
   } while (getKw(peekToken(0)) == lex::Keyword::If);
-  return switchExprNode(std::move(ifClauses), nextExprSwitchElse());
+  auto elseClause = getKw(peekToken(0)) == lex::Keyword::Else ? nextExprSwitchElse() : nullptr;
+  return switchExprNode(std::move(ifClauses), std::move(elseClause));
 }
 
 auto ParserImpl::nextExprSwitchIf() -> NodePtr {

--- a/src/prog/expr/node_fail.cpp
+++ b/src/prog/expr/node_fail.cpp
@@ -1,0 +1,31 @@
+#include "prog/expr/node_fail.hpp"
+#include <sstream>
+
+namespace prog::expr {
+
+FailNode::FailNode(sym::TypeId type) : m_type{type} {}
+
+auto FailNode::operator==(const Node& rhs) const noexcept -> bool {
+  return dynamic_cast<const FailNode*>(&rhs) != nullptr;
+}
+
+auto FailNode::operator!=(const Node& rhs) const noexcept -> bool {
+  return !FailNode::operator==(rhs);
+}
+
+auto FailNode::operator[](unsigned int /*unused*/) const -> const Node& {
+  throw std::out_of_range{"No child at given index"};
+}
+
+auto FailNode::getChildCount() const -> unsigned int { return 0; }
+
+auto FailNode::getType() const noexcept -> sym::TypeId { return m_type; }
+
+auto FailNode::toString() const -> std::string { return "fail"; }
+
+auto FailNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
+
+// Factories.
+auto failNode(sym::TypeId type) -> NodePtr { return std::unique_ptr<FailNode>{new FailNode{type}}; }
+
+} // namespace prog::expr

--- a/tests/frontend/get_switch_expr_test.cpp
+++ b/tests/frontend/get_switch_expr_test.cpp
@@ -3,10 +3,13 @@
 #include "helpers.hpp"
 #include "prog/expr/node_assign.hpp"
 #include "prog/expr/node_const.hpp"
+#include "prog/expr/node_fail.hpp"
 #include "prog/expr/node_group.hpp"
 #include "prog/expr/node_lit_bool.hpp"
 #include "prog/expr/node_lit_int.hpp"
 #include "prog/expr/node_switch.hpp"
+#include "prog/expr/node_union_check.hpp"
+#include "prog/expr/node_union_get.hpp"
 
 namespace frontend {
 
@@ -14,9 +17,9 @@ TEST_CASE("Analyzing switch expressions", "[frontend]") {
 
   SECTION("Get basic switch expression") {
     const auto& output = ANALYZE("fun f() -> int "
-                                 "if true   -> 1 "
-                                 "if false  -> 2 "
-                                 "else      -> 3");
+                                 "  if true   -> 1 "
+                                 "  if false  -> 2 "
+                                 "  else      -> 3");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 
@@ -36,8 +39,8 @@ TEST_CASE("Analyzing switch expressions", "[frontend]") {
 
   SECTION("Declare consts in switch expression conditions") {
     const auto& output = ANALYZE("fun f() -> int "
-                                 "if x = 1; true  -> x "
-                                 "else            -> 2");
+                                 "  if x = 1; true  -> x "
+                                 "  else            -> 2");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
     const auto& consts  = funcDef.getConsts();
@@ -59,23 +62,62 @@ TEST_CASE("Analyzing switch expressions", "[frontend]") {
         *prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches)));
   }
 
+  SECTION("Exhaustive union check switch expression") {
+    const auto& output = ANALYZE("union U = int, float "
+                                 "fun f(U u) -> int "
+                                 "  if u is int i   -> i "
+                                 "  if u is float _ -> 0");
+    REQUIRE(output.isSuccess());
+    const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "U"));
+    const auto& consts  = funcDef.getConsts();
+
+    auto conditions = std::vector<prog::expr::NodePtr>{};
+    conditions.push_back(prog::expr::unionGetExprNode(
+        output.getProg(),
+        prog::expr::constExprNode(consts, *consts.lookup("u")),
+        consts,
+        *consts.lookup("i")));
+    conditions.push_back(prog::expr::unionCheckExprNode(
+        output.getProg(),
+        prog::expr::constExprNode(consts, *consts.lookup("u")),
+        GET_TYPE_ID(output, "float")));
+
+    auto branches = std::vector<prog::expr::NodePtr>{};
+    branches.push_back(prog::expr::constExprNode(consts, *consts.lookup("i")));
+    branches.push_back(prog::expr::litIntNode(output.getProg(), 0));
+    branches.push_back(prog::expr::failNode(GET_TYPE_ID(output, "int")));
+
+    CHECK(
+        funcDef.getExpr() ==
+        *prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches)));
+  }
+
   SECTION("Diagnostics") {
     CHECK_DIAG(
         "fun f(int a) -> int "
-        "if a   -> 1 "
-        "else   -> 2",
-        errNonBoolConditionExpression(src, "int", input::Span{23, 23}));
+        "  if a   -> 1 "
+        "  else   -> 2",
+        errNonBoolConditionExpression(src, "int", input::Span{25, 25}));
     CHECK_DIAG(
         "fun f() -> int "
-        "if true   -> 1 "
-        "else      -> true",
-        errMismatchedBranchTypes(src, "int", "bool", input::Span{43, 46}));
+        "  if true   -> 1 "
+        "  else      -> true",
+        errMismatchedBranchTypes(src, "int", "bool", input::Span{47, 50}));
     CHECK_DIAG(
         "fun f() -> int "
-        "if true   -> 1 "
-        "if false  -> false "
-        "else      -> 2",
-        errMismatchedBranchTypes(src, "int", "bool", input::Span{43, 47}));
+        "  if true   -> 1 "
+        "  if false  -> false "
+        "  else      -> 2",
+        errMismatchedBranchTypes(src, "int", "bool", input::Span{47, 51}));
+    CHECK_DIAG(
+        "fun f() -> int "
+        "  if false  -> 2 ",
+        nonExhaustiveSwitchWithoutElse(src, input::Span{17, 30}));
+    CHECK_DIAG(
+        "union U = int, float "
+        "fun f(U u) -> int "
+        "  if u is float _ -> 1 ",
+        nonExhaustiveSwitchWithoutElse(src, input::Span{41, 60}));
   }
 }
 

--- a/tests/parse/expr_switch_test.cpp
+++ b/tests/parse/expr_switch_test.cpp
@@ -12,12 +12,24 @@ namespace parse {
 TEST_CASE("Parsing switch expressions", "[parse]") {
 
   CHECK_EXPR(
-      "if x -> 1 else -> 2",
+      "if x -> 1 "
+      "else -> 2",
       switchExprNode(
           NODES(switchExprIfNode(IF, CONST("x"), ARROW, INT(1))),
           switchExprElseNode(ELSE, ARROW, INT(2))));
   CHECK_EXPR(
-      "if y > 5 -> x + 1 else -> x * 2",
+      "if x -> 1", switchExprNode(NODES(switchExprIfNode(IF, CONST("x"), ARROW, INT(1))), nullptr));
+  CHECK_EXPR(
+      "if x -> 1 "
+      "if y -> 2",
+      switchExprNode(
+          NODES(
+              switchExprIfNode(IF, CONST("x"), ARROW, INT(1)),
+              switchExprIfNode(IF, CONST("y"), ARROW, INT(2))),
+          nullptr));
+  CHECK_EXPR(
+      "if y > 5 -> x + 1 "
+      "else -> x * 2",
       switchExprNode(
           NODES(switchExprIfNode(
               IF,
@@ -26,7 +38,10 @@ TEST_CASE("Parsing switch expressions", "[parse]") {
               binaryExprNode(CONST("x"), PLUS, INT(1)))),
           switchExprElseNode(ELSE, ARROW, binaryExprNode(CONST("x"), STAR, INT(2)))));
   CHECK_EXPR(
-      "if x -> 1 if y -> 2 if z -> 3 else -> 4",
+      "if x -> 1 "
+      "if y -> 2 "
+      "if z -> 3 "
+      "else -> 4",
       switchExprNode(
           NODES(
               switchExprIfNode(IF, CONST("x"), ARROW, INT(1)),
@@ -52,17 +67,25 @@ TEST_CASE("Parsing switch expressions", "[parse]") {
         switchExprNode(
             NODES(errInvalidSwitchIf(
                 IF, errInvalidPrimaryExpr(END), END, errInvalidPrimaryExpr(END))),
-            errInvalidSwitchElse(END, END, errInvalidPrimaryExpr(END))));
+            nullptr));
     CHECK_EXPR(
-        "if x -> 1",
+        "if x -> 1 else",
         switchExprNode(
             NODES(switchExprIfNode(IF, CONST("x"), ARROW, INT(1))),
-            errInvalidSwitchElse(END, END, errInvalidPrimaryExpr(END))));
+            errInvalidSwitchElse(ELSE, END, errInvalidPrimaryExpr(END))));
   }
 
   SECTION("Spans") {
-    CHECK_EXPR_SPAN("if x -> 1 else -> 2", input::Span(0, 18));
-    CHECK_EXPR_SPAN("if x -> 1 if 1 + 2 == y -> 2 else -> 3", input::Span(0, 37));
+    CHECK_EXPR_SPAN("if x -> 1", input::Span(0, 8));
+    CHECK_EXPR_SPAN(
+        "if x -> 1 "
+        "else -> 2",
+        input::Span(0, 18));
+    CHECK_EXPR_SPAN(
+        "if x -> 1 "
+        "if 1 + 2 == y -> 2 "
+        "else -> 3",
+        input::Span(0, 37));
   }
 }
 


### PR DESCRIPTION
Allow omitting the `else` branch of a switch expression when the compiler can determine that the `if` checks are exhaustive. At the moment the only implemented exhaustiveness check is for `union` types.
<img width="826" alt="Screenshot 2019-12-07 at 16 37 56" src="https://user-images.githubusercontent.com/14230060/70376582-e3318300-1912-11ea-81fd-e0b790572c7d.png">
