### PR TITLE
Apply conversions on conditional branches

### DIFF
--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -5,122 +5,131 @@
 
 namespace frontend {
 
-auto errParseError(const Source& src, const parse::ErrorNode& n) -> Diag;
+[[nodiscard]] auto errParseError(const Source& src, const parse::ErrorNode& n) -> Diag;
 
-auto errUnsupportedLiteral(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto
+errUnsupportedLiteral(const Source& src, const std::string& name, input::Span span) -> Diag;
 
-auto errTypeAlreadyDeclared(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto
+errTypeAlreadyDeclared(const Source& src, const std::string& name, input::Span span) -> Diag;
 
-auto errTypeNameConflictsWithFunc(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errTypeNameConflictsWithFunc(const Source& src, const std::string& name, input::Span span) -> Diag;
+
+[[nodiscard]] auto
+errTypeNameConflictsWithAction(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errTypeNameConflictsWithAction(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errDuplicateFieldNameInStruct(const Source& src, const std::string& fieldName, input::Span span)
     -> Diag;
 
-auto errDuplicateFieldNameInStruct(
-    const Source& src, const std::string& fieldName, input::Span span) -> Diag;
-
-auto errCyclicStruct(
+[[nodiscard]] auto errCyclicStruct(
     const Source& src,
     const std::string& fieldName,
     const std::string& structName,
     input::Span span) -> Diag;
 
-auto errFieldNameConflictsWithType(const Source& src, const std::string& name, input::Span span)
-    -> Diag;
+[[nodiscard]] auto
+errFieldNameConflictsWithType(const Source& src, const std::string& name, input::Span span) -> Diag;
 
-auto errFieldNotFoundOnType(
+[[nodiscard]] auto errFieldNotFoundOnType(
     const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
     -> Diag;
 
-auto errDuplicateTypeInUnion(const Source& src, const std::string& typeName, input::Span span)
-    -> Diag;
+[[nodiscard]] auto
+errDuplicateTypeInUnion(const Source& src, const std::string& typeName, input::Span span) -> Diag;
 
-auto errNonUnionIsExpression(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errNonUnionIsExpression(const Source& src, input::Span span) -> Diag;
 
-auto errTypeNotPartOfUnion(
+[[nodiscard]] auto errTypeNotPartOfUnion(
     const Source& src, const std::string& typeName, const std::string& unionName, input::Span span)
     -> Diag;
 
-auto errUncheckedIsExpressionWithConst(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errUncheckedIsExpressionWithConst(const Source& src, input::Span span) -> Diag;
 
-auto errConvFuncCannotSpecifyReturnType(
-    const Source& src, const std::string& name, input::Span span) -> Diag;
-
-auto errFuncNameConflictsWithAction(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errConvFuncCannotSpecifyReturnType(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errDuplicateFuncDeclaration(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errFuncNameConflictsWithAction(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errUnableToInferFuncReturnType(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errDuplicateFuncDeclaration(const Source& src, const std::string& name, input::Span span) -> Diag;
+
+[[nodiscard]] auto
+errUnableToInferFuncReturnType(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errNonMatchingFuncReturnType(
+[[nodiscard]] auto errNonMatchingFuncReturnType(
     const Source& src,
     const std::string& name,
     const std::string& declaredType,
     const std::string& returnedType,
     input::Span span) -> Diag;
 
-auto errConstNameConflictsWithType(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errConstNameConflictsWithType(const Source& src, const std::string& name, input::Span span) -> Diag;
+
+[[nodiscard]] auto
+errConstNameConflictsWithFunction(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errConstNameConflictsWithFunction(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errConstNameConflictsWithAction(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errConstNameConflictsWithAction(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto
+errConstNameConflictsWithConst(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errConstNameConflictsWithConst(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto errUndeclaredType(const Source& src, const std::string& name, input::Span span)
     -> Diag;
 
-auto errUndeclaredType(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto errUndeclaredConst(const Source& src, const std::string& name, input::Span span)
+    -> Diag;
 
-auto errUndeclaredConst(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto
+errUninitializedConst(const Source& src, const std::string& name, input::Span span) -> Diag;
 
-auto errUninitializedConst(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto errUndeclaredFunc(const Source& src, const std::string& name, input::Span span)
+    -> Diag;
 
-auto errUndeclaredFunc(const Source& src, const std::string& name, input::Span span) -> Diag;
-
-auto errUndeclaredFuncOverload(
+[[nodiscard]] auto errUndeclaredFuncOverload(
     const Source& src,
     const std::string& name,
     const std::vector<std::string>& argTypes,
     input::Span span) -> Diag;
 
-auto errUndeclaredAction(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto errUndeclaredAction(const Source& src, const std::string& name, input::Span span)
+    -> Diag;
 
-auto errUndeclaredActionOverload(
+[[nodiscard]] auto errUndeclaredActionOverload(
     const Source& src,
     const std::string& name,
     const std::vector<std::string>& argTypes,
     input::Span span) -> Diag;
 
-auto errUnsupportedOperator(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto
+errUnsupportedOperator(const Source& src, const std::string& name, input::Span span) -> Diag;
 
-auto errUndeclaredUnaryOperator(
+[[nodiscard]] auto errUndeclaredUnaryOperator(
     const Source& src, const std::string& name, const std::string& type, input::Span span) -> Diag;
 
-auto errUndeclaredBinOperator(
+[[nodiscard]] auto errUndeclaredBinOperator(
     const Source& src,
     const std::string& name,
     const std::string& lhsType,
     const std::string& rhsType,
     input::Span span) -> Diag;
 
-auto errNonBoolExpressionInLogicOp(const Source& src, const std::string& typeName, input::Span span)
-    -> Diag;
+[[nodiscard]] auto errBranchesHaveNoCommonType(const Source& src, input::Span span) -> Diag;
 
-auto errNonBoolConditionExpression(const Source& src, const std::string& typeName, input::Span span)
-    -> Diag;
+[[nodiscard]] auto errNoConversionFound(
+    const Source& src, const std::string& from, const std::string& to, input::Span span) -> Diag;
 
-auto errMismatchedBranchTypes(
-    const Source& src,
-    const std::string& prevTypeName,
-    const std::string& newTypeName,
-    input::Span span) -> Diag;
-
-auto nonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errNonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag;
 
 } // namespace frontend

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -57,6 +57,11 @@ public:
   [[nodiscard]] auto beginExecStmts() const -> execStmtIterator;
   [[nodiscard]] auto endExecStmts() const -> execStmtIterator;
 
+  [[nodiscard]] auto getInt() const noexcept -> sym::TypeId;
+  [[nodiscard]] auto getFloat() const noexcept -> sym::TypeId;
+  [[nodiscard]] auto getBool() const noexcept -> sym::TypeId;
+  [[nodiscard]] auto getString() const noexcept -> sym::TypeId;
+
   [[nodiscard]] auto lookupType(const std::string& name) const -> std::optional<sym::TypeId>;
   [[nodiscard]] auto
   lookupFunc(const std::string& name, const sym::Input& input, int maxConversions) const
@@ -70,6 +75,9 @@ public:
 
   [[nodiscard]] auto lookupConversion(sym::TypeId from, sym::TypeId to) const
       -> std::optional<sym::FuncId>;
+
+  [[nodiscard]] auto findCommonType(const std::vector<sym::TypeId>& types)
+      -> std::optional<sym::TypeId>;
 
   [[nodiscard]] auto getTypeDecl(sym::TypeId id) const -> const sym::TypeDecl&;
   [[nodiscard]] auto getFuncDecl(sym::FuncId id) const -> const sym::FuncDecl&;
@@ -98,6 +106,11 @@ private:
   sym::TypeDefTable m_typeDefs;
   sym::FuncDefTable m_funcDefs;
   std::vector<sym::ExecStmt> m_execStmts;
+
+  sym::TypeId m_int;
+  sym::TypeId m_float;
+  sym::TypeId m_bool;
+  sym::TypeId m_string;
 };
 
 } // namespace prog

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -268,32 +268,20 @@ auto errUndeclaredBinOperator(
   return error(src, oss.str(), span);
 }
 
-auto errNonBoolExpressionInLogicOp(const Source& src, const std::string& typeName, input::Span span)
-    -> Diag {
+auto errBranchesHaveNoCommonType(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Type in logical operation has to be 'bool' but was: '" << typeName << '\'';
+  oss << "Branches have no common type they are convertable to";
   return error(src, oss.str(), span);
 }
 
-auto errNonBoolConditionExpression(const Source& src, const std::string& typeName, input::Span span)
-    -> Diag {
+auto errNoConversionFound(
+    const Source& src, const std::string& from, const std::string& to, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Type of conditional expression has to be 'bool' but was: '" << typeName << '\'';
+  oss << "No conversion found from '" << from << "' to '" << to << '\'';
   return error(src, oss.str(), span);
 }
 
-auto errMismatchedBranchTypes(
-    const Source& src,
-    const std::string& prevTypeName,
-    const std::string& newTypeName,
-    input::Span span) -> Diag {
-  std::ostringstream oss;
-  oss << "Branch has type '" << newTypeName << "' but type of previous branch is '" << prevTypeName
-      << '\'';
-  return error(src, oss.str(), span);
-}
-
-auto nonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag {
+auto errNonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
   oss << "Switch expression is missing an 'else' branch and cannot be guaranteed to be exhaustive";
   return error(src, oss.str(), span);

--- a/src/frontend/internal/define_exec_stmts.cpp
+++ b/src/frontend/internal/define_exec_stmts.cpp
@@ -21,7 +21,7 @@ auto DefineExecStmts::visit(const parse::ExecStmtNode& n) -> void {
   auto args          = std::vector<prog::expr::NodePtr>{};
 
   for (auto i = 0U; i < n.getChildCount(); ++i) {
-    auto arg = getExpr(n[i], &consts, &visibleConsts);
+    auto arg = getExpr(n[i], &consts, &visibleConsts, prog::sym::TypeId::inferType());
     if (arg) {
       argTypes.push_back(arg->getType());
       args.push_back(std::move(arg));
@@ -54,9 +54,10 @@ auto DefineExecStmts::visit(const parse::ExecStmtNode& n) -> void {
 auto DefineExecStmts::getExpr(
     const parse::Node& n,
     prog::sym::ConstDeclTable* consts,
-    std::vector<prog::sym::ConstId>* visibleConsts) -> prog::expr::NodePtr {
+    std::vector<prog::sym::ConstId>* visibleConsts,
+    prog::sym::TypeId typeHint) -> prog::expr::NodePtr {
 
-  auto getExpr = GetExpr{m_src, m_prog, consts, visibleConsts};
+  auto getExpr = GetExpr{m_src, m_prog, consts, visibleConsts, typeHint};
   n.accept(&getExpr);
   m_diags.insert(m_diags.end(), getExpr.getDiags().begin(), getExpr.getDiags().end());
   return std::move(getExpr.getValue());

--- a/src/frontend/internal/define_exec_stmts.hpp
+++ b/src/frontend/internal/define_exec_stmts.hpp
@@ -24,7 +24,8 @@ private:
   [[nodiscard]] auto getExpr(
       const parse::Node& n,
       prog::sym::ConstDeclTable* consts,
-      std::vector<prog::sym::ConstId>* visibleConsts) -> prog::expr::NodePtr;
+      std::vector<prog::sym::ConstId>* visibleConsts,
+      prog::sym::TypeId typeHint) -> prog::expr::NodePtr;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -24,7 +24,7 @@ auto DefineUserFuncs::define(prog::sym::FuncId id, const parse::FuncDeclStmtNode
   }
 
   auto visibleConsts = consts.getAll();
-  auto expr          = getExpr(n[0], &consts, &visibleConsts);
+  auto expr          = getExpr(n[0], &consts, &visibleConsts, funcRetType);
   if (!expr) {
     return;
   }
@@ -94,9 +94,10 @@ auto DefineUserFuncs::declareInputs(
 auto DefineUserFuncs::getExpr(
     const parse::Node& n,
     prog::sym::ConstDeclTable* consts,
-    std::vector<prog::sym::ConstId>* visibleConsts) -> prog::expr::NodePtr {
+    std::vector<prog::sym::ConstId>* visibleConsts,
+    prog::sym::TypeId typeHint) -> prog::expr::NodePtr {
 
-  auto getExpr = GetExpr{m_src, m_prog, consts, visibleConsts};
+  auto getExpr = GetExpr{m_src, m_prog, consts, visibleConsts, typeHint};
   n.accept(&getExpr);
   m_diags.insert(m_diags.end(), getExpr.getDiags().begin(), getExpr.getDiags().end());
   return std::move(getExpr.getValue());

--- a/src/frontend/internal/define_user_funcs.hpp
+++ b/src/frontend/internal/define_user_funcs.hpp
@@ -24,7 +24,8 @@ private:
   auto getExpr(
       const parse::Node& n,
       prog::sym::ConstDeclTable* consts,
-      std::vector<prog::sym::ConstId>* visibleConsts) -> prog::expr::NodePtr;
+      std::vector<prog::sym::ConstId>* visibleConsts,
+      prog::sym::TypeId typeHint) -> prog::expr::NodePtr;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -18,11 +18,13 @@ GetExpr::GetExpr(
     prog::Program* prog,
     prog::sym::ConstDeclTable* consts,
     std::vector<prog::sym::ConstId>* visibleConsts,
+    prog::sym::TypeId typeHint,
     bool checkedConstsAccess) :
     m_src{src},
     m_prog{prog},
     m_consts{consts},
     m_visibleConsts{visibleConsts},
+    m_typeHint{typeHint},
     m_checkedConstsAccess{checkedConstsAccess} {
 
   if (m_prog == nullptr) {
@@ -65,8 +67,8 @@ auto GetExpr::visit(const parse::BinaryExprNode& n) -> void {
   }
 
   auto args = std::vector<prog::expr::NodePtr>{};
-  args.push_back(getSubExpr(n[0], m_visibleConsts));
-  args.push_back(getSubExpr(n[1], m_visibleConsts));
+  args.push_back(getSubExpr(n[0], m_visibleConsts, prog::sym::TypeId::inferType()));
+  args.push_back(getSubExpr(n[1], m_visibleConsts, prog::sym::TypeId::inferType()));
   if (!args[0] || !args[1] || !args[0]->getType().isConcrete() ||
       !args[1]->getType().isConcrete()) {
     return;
@@ -91,7 +93,7 @@ auto GetExpr::visit(const parse::CallExprNode& n) -> void {
   auto argTypes = std::vector<prog::sym::TypeId>{};
   auto args     = std::vector<prog::expr::NodePtr>{};
   for (auto i = 0U; i < n.getChildCount(); ++i) {
-    auto arg = getSubExpr(n[i], m_visibleConsts);
+    auto arg = getSubExpr(n[i], m_visibleConsts, prog::sym::TypeId::inferType());
     if (arg) {
       const auto argType = arg->getType();
       if (argType.isConcrete()) {
@@ -124,41 +126,52 @@ auto GetExpr::visit(const parse::CallExprNode& n) -> void {
 }
 
 auto GetExpr::visit(const parse::ConditionalExprNode& n) -> void {
-  auto conditions = std::vector<prog::expr::NodePtr>();
-  auto branches   = std::vector<prog::expr::NodePtr>();
-  conditions.push_back(getSubExpr(n[0], m_visibleConsts, true));
+  auto conditions = std::vector<prog::expr::NodePtr>{};
+  auto branches   = std::vector<prog::expr::NodePtr>{};
+  conditions.push_back(getSubExpr(n[0], m_visibleConsts, m_prog->getBool(), true));
   if (!conditions[0]) {
     return;
   }
-  if (!isBoolType(conditions[0]->getType())) {
-    const auto& typeName = m_prog->getTypeDecl(conditions[0]->getType()).getName();
-    m_diags.push_back(errNonBoolConditionExpression(m_src, typeName, n[0].getSpan()));
+  if (!applyConversion(&conditions[0], m_prog->getBool(), n[0].getSpan())) {
     return;
   }
 
   // Make a copy of the visible constants, constants should not be visible outside.
   auto ifBranchConsts = *m_visibleConsts;
-  branches.push_back(getSubExpr(n[1], &ifBranchConsts));
+  branches.push_back(getSubExpr(n[1], &ifBranchConsts, m_typeHint));
 
   // Make a copy of the visible constants, constants should not be visible outside.
   auto elseBranchConsts = *m_visibleConsts;
-  branches.push_back(getSubExpr(n[2], &elseBranchConsts));
+  branches.push_back(getSubExpr(n[2], &elseBranchConsts, m_typeHint));
 
   if (!branches[0] || !branches[1]) {
     return;
   }
-  if (branches[0]->getType() != branches[1]->getType()) {
-    const auto& typeName       = m_prog->getTypeDecl(branches[0]->getType()).getName();
-    const auto& branchTypeName = m_prog->getTypeDecl(branches[1]->getType()).getName();
-    m_diags.push_back(errMismatchedBranchTypes(m_src, typeName, branchTypeName, n[2].getSpan()));
-    return;
+
+  // If no preference is given over the desired output type then check what type the branches
+  // have in common.
+  if (m_typeHint.isInfer()) {
+    const auto branchTypes = std::vector{branches[0]->getType(), branches[1]->getType()};
+    auto commonType        = m_prog->findCommonType(branchTypes);
+    if (!commonType) {
+      m_diags.push_back(errBranchesHaveNoCommonType(m_src, n.getSpan()));
+      return;
+    }
+    m_typeHint = *commonType;
+  }
+
+  // Add a conversion for all branches that require one.
+  for (auto i = 0U; i != branches.size(); ++i) {
+    if (!applyConversion(&branches[i], m_typeHint, n[i].getSpan())) {
+      return;
+    }
   }
 
   m_expr = prog::expr::switchExprNode(*m_prog, std::move(conditions), std::move(branches));
 }
 
 auto GetExpr::visit(const parse::ConstDeclExprNode& n) -> void {
-  auto assignExpr = getSubExpr(n[0], m_visibleConsts);
+  auto assignExpr = getSubExpr(n[0], m_visibleConsts, prog::sym::TypeId::inferType());
   if (assignExpr == nullptr) {
     return;
   }
@@ -187,7 +200,7 @@ auto GetExpr::visit(const parse::ConstExprNode& n) -> void {
 
 auto GetExpr::visit(const parse::FieldExprNode& n) -> void {
   const auto& fieldName = getName(n.getId());
-  auto lhsExpr          = getSubExpr(n[0], m_visibleConsts);
+  auto lhsExpr          = getSubExpr(n[0], m_visibleConsts, prog::sym::TypeId::inferType());
   if (lhsExpr == nullptr) {
     return;
   }
@@ -212,7 +225,11 @@ auto GetExpr::visit(const parse::GroupExprNode& n) -> void {
   auto subExprs = std::vector<prog::expr::NodePtr>();
   for (auto i = 0U; i < n.getChildCount(); ++i) {
     auto last    = i == n.getChildCount() - 1;
-    auto subExpr = getSubExpr(n[i], m_visibleConsts, m_checkedConstsAccess && last);
+    auto subExpr = getSubExpr(
+        n[i],
+        m_visibleConsts,
+        last ? m_typeHint : prog::sym::TypeId::inferType(),
+        m_checkedConstsAccess && last);
     if (subExpr) {
       subExprs.push_back(std::move(subExpr));
     }
@@ -223,7 +240,7 @@ auto GetExpr::visit(const parse::GroupExprNode& n) -> void {
 }
 
 auto GetExpr::visit(const parse::IsExprNode& n) -> void {
-  auto lhsExpr = getSubExpr(n[0], m_visibleConsts);
+  auto lhsExpr = getSubExpr(n[0], m_visibleConsts, prog::sym::TypeId::inferType());
   if (lhsExpr == nullptr) {
     return;
   }
@@ -297,7 +314,7 @@ auto GetExpr::visit(const parse::LitExprNode& n) -> void {
 }
 
 auto GetExpr::visit(const parse::ParenExprNode& n) -> void {
-  m_expr = getSubExpr(n[0], m_visibleConsts, m_checkedConstsAccess);
+  m_expr = getSubExpr(n[0], m_visibleConsts, m_typeHint, m_checkedConstsAccess);
 }
 
 auto GetExpr::visit(const parse::SwitchExprElseNode & /*unused*/) -> void {
@@ -309,10 +326,10 @@ auto GetExpr::visit(const parse::SwitchExprIfNode & /*unused*/) -> void {
 }
 
 auto GetExpr::visit(const parse::SwitchExprNode& n) -> void {
-  auto isValid                          = true;
-  auto conditions                       = std::vector<prog::expr::NodePtr>();
-  auto branches                         = std::vector<prog::expr::NodePtr>();
-  std::optional<prog::sym::TypeId> type = std::nullopt;
+  auto isValid     = true;
+  auto conditions  = std::vector<prog::expr::NodePtr>();
+  auto branches    = std::vector<prog::expr::NodePtr>();
+  auto branchTypes = std::vector<prog::sym::TypeId>{};
 
   for (auto i = 0U; i < n.getChildCount(); ++i) {
     const auto isElseClause = n.hasElse() && i == n.getChildCount() - 1;
@@ -321,42 +338,47 @@ auto GetExpr::visit(const parse::SwitchExprNode& n) -> void {
     // be allowed to be accessed from another branch or after the switch.
     auto branchConsts = *m_visibleConsts;
     if (!isElseClause) {
-      auto condition = getSubExpr(n[i][0], &branchConsts, true);
+      auto condition = getSubExpr(n[i][0], &branchConsts, m_prog->getBool(), true);
       if (!condition) {
         isValid = false;
         continue;
       }
-      if (!isBoolType(condition->getType())) {
-        const auto& typeName = m_prog->getTypeDecl(condition->getType()).getName();
-        m_diags.push_back(errNonBoolConditionExpression(m_src, typeName, n[i][0].getSpan()));
+      if (applyConversion(&condition, m_prog->getBool(), n[i][0].getSpan())) {
+        conditions.push_back(std::move(condition));
+      } else {
         isValid = false;
-        continue;
       }
-      conditions.push_back(std::move(condition));
     }
 
-    auto branch = getSubExpr(n[i][isElseClause ? 0 : 1], &branchConsts);
+    auto branch = getSubExpr(n[i][isElseClause ? 0 : 1], &branchConsts, m_typeHint);
     if (!branch) {
       isValid = false;
       continue;
     }
-    if (!type) {
-      type = branch->getType();
-    } else if (branch->getType() != type) {
-      const auto& typeName       = m_prog->getTypeDecl(type.value()).getName();
-      const auto& branchTypeName = m_prog->getTypeDecl(branch->getType()).getName();
-      m_diags.push_back(errMismatchedBranchTypes(
-          m_src, typeName, branchTypeName, n[i][isElseClause ? 0 : 1].getSpan()));
-      isValid = false;
-      continue;
-    }
+    branchTypes.push_back(branch->getType());
     branches.push_back(std::move(branch));
+  }
+
+  // If no preference is given over the desired output type then check what type the branches
+  // have in common.
+  if (m_typeHint.isInfer()) {
+    auto commonType = m_prog->findCommonType(branchTypes);
+    if (!commonType) {
+      m_diags.push_back(errBranchesHaveNoCommonType(m_src, n.getSpan()));
+      return;
+    }
+    m_typeHint = *commonType;
+  }
+
+  // Add a conversion for all branches that require one.
+  for (auto i = 0U; i != branches.size(); ++i) {
+    isValid &= applyConversion(&branches[i], m_typeHint, n[i].getSpan());
   }
 
   if (isValid) {
     if (!n.hasElse()) {
       if (!isExhaustive(conditions)) {
-        m_diags.push_back(nonExhaustiveSwitchWithoutElse(m_src, n.getSpan()));
+        m_diags.push_back(errNonExhaustiveSwitchWithoutElse(m_src, n.getSpan()));
         return;
       }
       // When we know the switch is exhaustive then we insert a 'else' branch that is never taken.
@@ -375,7 +397,7 @@ auto GetExpr::visit(const parse::UnaryExprNode& n) -> void {
   }
 
   auto args = std::vector<prog::expr::NodePtr>{};
-  args.push_back(getSubExpr(n[0], m_visibleConsts));
+  args.push_back(getSubExpr(n[0], m_visibleConsts, prog::sym::TypeId::inferType()));
   if (!args[0] || !args[0]->getType().isConcrete()) {
     return;
   }
@@ -410,12 +432,35 @@ auto GetExpr::visit(const parse::UnionDeclStmtNode & /*unused*/) -> void {
 }
 
 auto GetExpr::getSubExpr(
-    const parse::Node& n, std::vector<prog::sym::ConstId>* visibleConsts, bool checkedConstsAccess)
-    -> prog::expr::NodePtr {
-  auto visitor = GetExpr{m_src, m_prog, m_consts, visibleConsts, checkedConstsAccess};
+    const parse::Node& n,
+    std::vector<prog::sym::ConstId>* visibleConsts,
+    prog::sym::TypeId typeHint,
+    bool checkedConstsAccess) -> prog::expr::NodePtr {
+  auto visitor = GetExpr{m_src, m_prog, m_consts, visibleConsts, typeHint, checkedConstsAccess};
   n.accept(&visitor);
   m_diags.insert(m_diags.end(), visitor.getDiags().begin(), visitor.getDiags().end());
   return std::move(visitor.getValue());
+}
+
+auto GetExpr::applyConversion(prog::expr::NodePtr* expr, prog::sym::TypeId toType, input::Span span)
+    -> bool {
+  const auto fromType = (*expr)->getType();
+  if (fromType == toType) {
+    return true;
+  }
+
+  const auto conv = m_prog->lookupConversion(fromType, toType);
+  if (!conv) {
+    const auto& fromName = m_prog->getTypeDecl(fromType).getName();
+    const auto& toName   = m_prog->getTypeDecl(toType).getName();
+    m_diags.push_back(errNoConversionFound(m_src, fromName, toName, span));
+    return false;
+  }
+
+  auto convArgs = std::vector<prog::expr::NodePtr>{};
+  convArgs.push_back(std::move(*expr));
+  *expr = prog::expr::callExprNode(*m_prog, *conv, std::move(convArgs));
+  return true;
 }
 
 auto GetExpr::getBinLogicOpExpr(const parse::BinaryExprNode& n, BinLogicOp op)
@@ -425,25 +470,17 @@ auto GetExpr::getBinLogicOpExpr(const parse::BinaryExprNode& n, BinLogicOp op)
   // 'And' has checked consts for the lhs, meaning the constants the lhs declares are only accessed
   // when the lhs expression evaluates to 'true'.
   auto checkedConsts = op == BinLogicOp::And;
-  auto lhs           = getSubExpr(n[0], m_visibleConsts, checkedConsts);
+  auto lhs           = getSubExpr(n[0], m_visibleConsts, m_prog->getBool(), checkedConsts);
 
   // Because the rhs might not get executed the constants it declares are not visible outside.
   auto rhsVisibleConsts = *m_visibleConsts;
-  auto rhs              = getSubExpr(n[1], &rhsVisibleConsts);
+  auto rhs              = getSubExpr(n[1], &rhsVisibleConsts, m_prog->getBool());
   if (!lhs || !rhs) {
     return nullptr;
   }
 
-  if (!isBoolType(lhs->getType())) {
-    const auto& typeName = m_prog->getTypeDecl(lhs->getType()).getName();
-    m_diags.push_back(errNonBoolExpressionInLogicOp(m_src, typeName, n[0].getSpan()));
-    isValid = false;
-  }
-  if (!isBoolType(rhs->getType())) {
-    const auto& typeName = m_prog->getTypeDecl(rhs->getType()).getName();
-    m_diags.push_back(errNonBoolExpressionInLogicOp(m_src, typeName, n[1].getSpan()));
-    isValid = false;
-  }
+  isValid &= applyConversion(&lhs, m_prog->getBool(), n[0].getSpan());
+  isValid &= applyConversion(&rhs, m_prog->getBool(), n[1].getSpan());
 
   if (isValid) {
     auto conditions = std::vector<prog::expr::NodePtr>{};
@@ -496,14 +533,6 @@ auto GetExpr::isExhaustive(const std::vector<prog::expr::NodePtr>& conditions) c
     cond->accept(&checkUnion);
   }
   return checkUnion.isExhaustive();
-}
-
-auto GetExpr::isBoolType(prog::sym::TypeId type) -> bool {
-  auto boolType = m_prog->lookupType("bool");
-  if (!boolType) {
-    throw std::logic_error{"No 'bool' type present in type-table"};
-  }
-  return type == boolType;
 }
 
 } // namespace frontend::internal

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -13,6 +13,7 @@ public:
       prog::Program* prog,
       prog::sym::ConstDeclTable* consts,
       std::vector<prog::sym::ConstId>* visibleConsts,
+      prog::sym::TypeId typeHint,
       bool checkedConstsAccess = false);
 
   [[nodiscard]] auto hasErrors() const noexcept -> bool;
@@ -46,14 +47,20 @@ private:
   prog::Program* m_prog;
   prog::sym::ConstDeclTable* m_consts;
   std::vector<prog::sym::ConstId>* m_visibleConsts;
+  prog::sym::TypeId m_typeHint;
   bool m_checkedConstsAccess;
-  std::vector<Diag> m_diags;
+
   prog::expr::NodePtr m_expr;
+  std::vector<Diag> m_diags;
 
   [[nodiscard]] auto getSubExpr(
       const parse::Node& n,
       std::vector<prog::sym::ConstId>* visibleConsts,
+      prog::sym::TypeId typeHint,
       bool checkedConstsAccess = false) -> prog::expr::NodePtr;
+
+  [[nodiscard]] auto
+  applyConversion(prog::expr::NodePtr* expr, prog::sym::TypeId toType, input::Span span) -> bool;
 
   [[nodiscard]] auto getBinLogicOpExpr(const parse::BinaryExprNode& n, BinLogicOp op)
       -> prog::expr::NodePtr;
@@ -62,8 +69,6 @@ private:
       -> std::optional<prog::sym::ConstId>;
 
   [[nodiscard]] auto isExhaustive(const std::vector<prog::expr::NodePtr>& conditions) const -> bool;
-
-  [[nodiscard]] auto isBoolType(prog::sym::TypeId type) -> bool;
 };
 
 } // namespace frontend::internal

--- a/src/prog/expr/node_lit_bool.cpp
+++ b/src/prog/expr/node_lit_bool.cpp
@@ -30,11 +30,7 @@ auto LitBoolNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*t
 
 // Factories.
 auto litBoolNode(const Program& program, bool val) -> NodePtr {
-  const auto type = program.lookupType("bool");
-  if (!type) {
-    throw std::invalid_argument{"No 'bool' type present in type-table"};
-  }
-  return std::unique_ptr<LitBoolNode>{new LitBoolNode{type.value(), val}};
+  return std::unique_ptr<LitBoolNode>{new LitBoolNode{program.getBool(), val}};
 }
 
 } // namespace prog::expr

--- a/src/prog/expr/node_lit_float.cpp
+++ b/src/prog/expr/node_lit_float.cpp
@@ -30,11 +30,7 @@ auto LitFloatNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*
 
 // Factories.
 auto litFloatNode(const Program& program, float val) -> NodePtr {
-  const auto type = program.lookupType("float");
-  if (!type) {
-    throw std::invalid_argument{"No 'float' type present in type-table"};
-  }
-  return std::unique_ptr<LitFloatNode>{new LitFloatNode{type.value(), val}};
+  return std::unique_ptr<LitFloatNode>{new LitFloatNode{program.getFloat(), val}};
 }
 
 } // namespace prog::expr

--- a/src/prog/expr/node_lit_int.cpp
+++ b/src/prog/expr/node_lit_int.cpp
@@ -30,11 +30,7 @@ auto LitIntNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*th
 
 // Factories.
 auto litIntNode(const Program& program, int32_t val) -> NodePtr {
-  const auto type = program.lookupType("int");
-  if (!type) {
-    throw std::invalid_argument{"No 'int' type present in type-table"};
-  }
-  return std::unique_ptr<LitIntNode>{new LitIntNode{type.value(), val}};
+  return std::unique_ptr<LitIntNode>{new LitIntNode{program.getInt(), val}};
 }
 
 } // namespace prog::expr

--- a/src/prog/expr/node_lit_string.cpp
+++ b/src/prog/expr/node_lit_string.cpp
@@ -36,11 +36,7 @@ auto LitStringNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(
 
 // Factories.
 auto litStringNode(const Program& program, std::string val) -> NodePtr {
-  const auto type = program.lookupType("string");
-  if (!type) {
-    throw std::invalid_argument{"No 'string' type present in type-table"};
-  }
-  return std::unique_ptr<LitStringNode>{new LitStringNode{type.value(), std::move(val)}};
+  return std::unique_ptr<LitStringNode>{new LitStringNode{program.getString(), std::move(val)}};
 }
 
 } // namespace prog::expr

--- a/src/prog/expr/node_switch.cpp
+++ b/src/prog/expr/node_switch.cpp
@@ -66,11 +66,7 @@ auto switchExprNode(
   if (anyNodeNull(branches)) {
     throw std::invalid_argument{"Switch node cannot contain a null branch"};
   }
-  const auto boolType = program.lookupType("bool");
-  if (!boolType) {
-    throw std::invalid_argument{"No 'bool' type present in type-table"};
-  }
-  if (getType(conditions) != boolType) {
+  if (getType(conditions) != program.getBool()) {
     throw std::invalid_argument{"All conditions need to be of type 'bool'"};
   }
   if (!getType(branches)) {

--- a/src/prog/expr/node_union_check.cpp
+++ b/src/prog/expr/node_union_check.cpp
@@ -43,10 +43,6 @@ auto unionCheckExprNode(const Program& prog, NodePtr lhs, sym::TypeId targetType
   if (!lhs) {
     throw std::invalid_argument{"Left-hand-side expression in union-check cannot be null"};
   }
-  const auto boolType = prog.lookupType("bool");
-  if (!boolType) {
-    throw std::logic_error{"No 'bool' type found in program"};
-  }
 
   const auto& exprTypeDecl = prog.getTypeDecl(lhs->getType());
   if (exprTypeDecl.getKind() != sym::TypeKind::UserUnion) {
@@ -61,7 +57,7 @@ auto unionCheckExprNode(const Program& prog, NodePtr lhs, sym::TypeId targetType
   }
 
   return std::unique_ptr<UnionCheckExprNode>{
-      new UnionCheckExprNode{*boolType, std::move(lhs), targetType}};
+      new UnionCheckExprNode{prog.getBool(), std::move(lhs), targetType}};
 }
 
 } // namespace prog::expr

--- a/src/prog/expr/node_union_get.cpp
+++ b/src/prog/expr/node_union_get.cpp
@@ -49,10 +49,6 @@ auto unionGetExprNode(
   if (!lhs) {
     throw std::invalid_argument{"Left-hand-side expression in union-get cannot be null"};
   }
-  const auto boolType = prog.lookupType("bool");
-  if (!boolType) {
-    throw std::logic_error{"No 'bool' type found in program"};
-  }
 
   const auto& exprTypeDecl = prog.getTypeDecl(lhs->getType());
   if (exprTypeDecl.getKind() != sym::TypeKind::UserUnion) {
@@ -68,7 +64,7 @@ auto unionGetExprNode(
   }
 
   return std::unique_ptr<UnionGetExprNode>{
-      new UnionGetExprNode{*boolType, std::move(lhs), targetType, constId}};
+      new UnionGetExprNode{prog.getBool(), std::move(lhs), targetType, constId}};
 }
 
 } // namespace prog::expr

--- a/src/prog/internal/conversion.hpp
+++ b/src/prog/internal/conversion.hpp
@@ -6,8 +6,15 @@ namespace prog::internal {
 [[nodiscard]] auto findConversion(const Program& prog, sym::TypeId from, sym::TypeId to)
     -> std::optional<sym::FuncId>;
 
+// Note: Can be expensive as it involves walking all function declarations.
+[[nodiscard]] auto findConvertibleTypes(const Program& prog, sym::TypeId from)
+    -> std::vector<sym::TypeId>;
+
 // Apply conversions to the args vector so it matches the given input set.
 auto applyConversions(
     const Program& prog, const sym::Input& input, std::vector<expr::NodePtr>* args) -> void;
+
+[[nodiscard]] auto findCommonType(const Program& prog, const std::vector<sym::TypeId>& types)
+    -> std::optional<sym::TypeId>;
 
 } // namespace prog::internal

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -17,104 +17,97 @@ auto getActionDeclTable(const Program& prog) -> const sym::ActionDeclTable& {
 
 } // namespace internal
 
-Program::Program() {
-  using tk = typename sym::TypeKind;
-  using fk = typename sym::FuncKind;
-  using ak = typename sym::ActionKind;
+Program::Program() :
+    m_int{m_typeDecls.registerType(sym::TypeKind::Int, "int")},
+    m_float{m_typeDecls.registerType(sym::TypeKind::Float, "float")},
+    m_bool{m_typeDecls.registerType(sym::TypeKind::Bool, "bool")},
+    m_string{m_typeDecls.registerType(sym::TypeKind::String, "string")} {
 
-  // Register build-in types.
-  const auto intT    = m_typeDecls.registerType(tk::Int, "int");
-  const auto floatT  = m_typeDecls.registerType(tk::Float, "float");
-  const auto boolT   = m_typeDecls.registerType(tk::Bool, "bool");
-  const auto stringT = m_typeDecls.registerType(tk::String, "string");
+  using fk = typename prog::sym::FuncKind;
+  using ak = typename prog::sym::ActionKind;
+  using op = typename prog::Operator;
 
   // Register build-in unary int operators.
-  m_funcDecls.registerFunc(
-      *this, fk::NegateInt, getFuncName(Operator::Minus), sym::Input{intT}, intT);
+  m_funcDecls.registerFunc(*this, fk::NegateInt, getFuncName(op::Minus), sym::Input{m_int}, m_int);
 
   // Register build-in binary int operators.
   m_funcDecls.registerFunc(
-      *this, fk::AddInt, getFuncName(Operator::Plus), sym::Input{intT, intT}, intT);
+      *this, fk::AddInt, getFuncName(op::Plus), sym::Input{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
-      *this, fk::SubInt, getFuncName(Operator::Minus), sym::Input{intT, intT}, intT);
+      *this, fk::SubInt, getFuncName(op::Minus), sym::Input{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
-      *this, fk::MulInt, getFuncName(Operator::Star), sym::Input{intT, intT}, intT);
+      *this, fk::MulInt, getFuncName(op::Star), sym::Input{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
-      *this, fk::DivInt, getFuncName(Operator::Slash), sym::Input{intT, intT}, intT);
+      *this, fk::DivInt, getFuncName(op::Slash), sym::Input{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
-      *this, fk::RemInt, getFuncName(Operator::Rem), sym::Input{intT, intT}, intT);
+      *this, fk::RemInt, getFuncName(op::Rem), sym::Input{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
-      *this, fk::CheckEqInt, getFuncName(Operator::EqEq), sym::Input{intT, intT}, boolT);
+      *this, fk::CheckEqInt, getFuncName(op::EqEq), sym::Input{m_int, m_int}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckNEqInt, getFuncName(Operator::BangEq), sym::Input{intT, intT}, boolT);
+      *this, fk::CheckNEqInt, getFuncName(op::BangEq), sym::Input{m_int, m_int}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckLeInt, getFuncName(Operator::Le), sym::Input{intT, intT}, boolT);
+      *this, fk::CheckLeInt, getFuncName(op::Le), sym::Input{m_int, m_int}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckLeEqInt, getFuncName(Operator::LeEq), sym::Input{intT, intT}, boolT);
+      *this, fk::CheckLeEqInt, getFuncName(op::LeEq), sym::Input{m_int, m_int}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckGtInt, getFuncName(Operator::Gt), sym::Input{intT, intT}, boolT);
+      *this, fk::CheckGtInt, getFuncName(op::Gt), sym::Input{m_int, m_int}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckGtEqInt, getFuncName(Operator::GtEq), sym::Input{intT, intT}, boolT);
+      *this, fk::CheckGtEqInt, getFuncName(op::GtEq), sym::Input{m_int, m_int}, m_bool);
 
   // Register build-in unary float operators.
   m_funcDecls.registerFunc(
-      *this, fk::NegateFloat, getFuncName(Operator::Minus), sym::Input{floatT}, floatT);
+      *this, fk::NegateFloat, getFuncName(op::Minus), sym::Input{m_float}, m_float);
 
   // Register build-in binary float operators.
   m_funcDecls.registerFunc(
-      *this, fk::AddFloat, getFuncName(Operator::Plus), sym::Input{floatT, floatT}, floatT);
+      *this, fk::AddFloat, getFuncName(op::Plus), sym::Input{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
-      *this, fk::SubFloat, getFuncName(Operator::Minus), sym::Input{floatT, floatT}, floatT);
+      *this, fk::SubFloat, getFuncName(op::Minus), sym::Input{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
-      *this, fk::MulFloat, getFuncName(Operator::Star), sym::Input{floatT, floatT}, floatT);
+      *this, fk::MulFloat, getFuncName(op::Star), sym::Input{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
-      *this, fk::DivFloat, getFuncName(Operator::Slash), sym::Input{floatT, floatT}, floatT);
+      *this, fk::DivFloat, getFuncName(op::Slash), sym::Input{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
-      *this, fk::CheckEqFloat, getFuncName(Operator::EqEq), sym::Input{floatT, floatT}, boolT);
+      *this, fk::CheckEqFloat, getFuncName(op::EqEq), sym::Input{m_float, m_float}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckNEqFloat, getFuncName(Operator::BangEq), sym::Input{floatT, floatT}, boolT);
+      *this, fk::CheckNEqFloat, getFuncName(op::BangEq), sym::Input{m_float, m_float}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckLeFloat, getFuncName(Operator::Le), sym::Input{floatT, floatT}, boolT);
+      *this, fk::CheckLeFloat, getFuncName(op::Le), sym::Input{m_float, m_float}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckLeEqFloat, getFuncName(Operator::LeEq), sym::Input{floatT, floatT}, boolT);
+      *this, fk::CheckLeEqFloat, getFuncName(op::LeEq), sym::Input{m_float, m_float}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckGtFloat, getFuncName(Operator::Gt), sym::Input{floatT, floatT}, boolT);
+      *this, fk::CheckGtFloat, getFuncName(op::Gt), sym::Input{m_float, m_float}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckGtEqFloat, getFuncName(Operator::GtEq), sym::Input{floatT, floatT}, boolT);
+      *this, fk::CheckGtEqFloat, getFuncName(op::GtEq), sym::Input{m_float, m_float}, m_bool);
 
   // Register build-in unary bool operators.
-  m_funcDecls.registerFunc(
-      *this, fk::InvBool, getFuncName(Operator::Bang), sym::Input{boolT}, boolT);
+  m_funcDecls.registerFunc(*this, fk::InvBool, getFuncName(op::Bang), sym::Input{m_bool}, m_bool);
 
   // Register build-in binary bool operators.
   m_funcDecls.registerFunc(
-      *this, fk::CheckEqBool, getFuncName(Operator::EqEq), sym::Input{boolT, boolT}, boolT);
+      *this, fk::CheckEqBool, getFuncName(op::EqEq), sym::Input{m_bool, m_bool}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckNEqBool, getFuncName(Operator::BangEq), sym::Input{boolT, boolT}, boolT);
+      *this, fk::CheckNEqBool, getFuncName(op::BangEq), sym::Input{m_bool, m_bool}, m_bool);
 
   // Register build-in binary string operators.
   m_funcDecls.registerFunc(
-      *this, fk::AddString, getFuncName(Operator::Plus), sym::Input{stringT, stringT}, stringT);
+      *this, fk::AddString, getFuncName(op::Plus), sym::Input{m_string, m_string}, m_string);
   m_funcDecls.registerFunc(
-      *this, fk::CheckEqString, getFuncName(Operator::EqEq), sym::Input{stringT, stringT}, boolT);
+      *this, fk::CheckEqString, getFuncName(op::EqEq), sym::Input{m_string, m_string}, m_bool);
   m_funcDecls.registerFunc(
-      *this,
-      fk::CheckNEqString,
-      getFuncName(Operator::BangEq),
-      sym::Input{stringT, stringT},
-      boolT);
+      *this, fk::CheckNEqString, getFuncName(op::BangEq), sym::Input{m_string, m_string}, m_bool);
 
   // Register build-in implicit conversions.
-  m_funcDecls.registerFunc(*this, fk::ConvIntFloat, "float", sym::Input{intT}, floatT);
-  m_funcDecls.registerFunc(*this, fk::ConvIntString, "string", sym::Input{intT}, stringT);
-  m_funcDecls.registerFunc(*this, fk::ConvFloatString, "string", sym::Input{floatT}, stringT);
-  m_funcDecls.registerFunc(*this, fk::ConvBoolString, "string", sym::Input{boolT}, stringT);
+  m_funcDecls.registerFunc(*this, fk::ConvIntFloat, "float", sym::Input{m_int}, m_float);
+  m_funcDecls.registerFunc(*this, fk::ConvIntString, "string", sym::Input{m_int}, m_string);
+  m_funcDecls.registerFunc(*this, fk::ConvFloatString, "string", sym::Input{m_float}, m_string);
+  m_funcDecls.registerFunc(*this, fk::ConvBoolString, "string", sym::Input{m_bool}, m_string);
 
   // Register build-in explicit conversions.
-  m_funcDecls.registerFunc(*this, fk::ConvFloatInt, "toInt", sym::Input{floatT}, intT);
+  m_funcDecls.registerFunc(*this, fk::ConvFloatInt, "toInt", sym::Input{m_float}, m_int);
 
   // Register build-in actions.
-  m_actionDecls.registerAction(*this, ak::PrintString, "print", sym::Input{stringT});
+  m_actionDecls.registerAction(*this, ak::PrintString, "print", sym::Input{m_string});
 }
 
 auto Program::beginTypeDecls() const -> typeDeclIterator { return m_typeDecls.begin(); }
@@ -141,6 +134,14 @@ auto Program::beginExecStmts() const -> execStmtIterator { return m_execStmts.be
 
 auto Program::endExecStmts() const -> execStmtIterator { return m_execStmts.end(); }
 
+auto Program::getInt() const noexcept -> sym::TypeId { return m_int; }
+
+auto Program::getFloat() const noexcept -> sym::TypeId { return m_float; }
+
+auto Program::getBool() const noexcept -> sym::TypeId { return m_bool; }
+
+auto Program::getString() const noexcept -> sym::TypeId { return m_string; }
+
 auto Program::lookupType(const std::string& name) const -> std::optional<sym::TypeId> {
   return m_typeDecls.lookup(name);
 }
@@ -166,6 +167,10 @@ auto Program::lookupActions(const std::string& name) const -> std::vector<sym::A
 auto Program::lookupConversion(sym::TypeId from, sym::TypeId to) const
     -> std::optional<sym::FuncId> {
   return internal::findConversion(*this, from, to);
+}
+
+auto Program::findCommonType(const std::vector<sym::TypeId>& types) -> std::optional<sym::TypeId> {
+  return internal::findCommonType(*this, types);
 }
 
 auto Program::getTypeDecl(sym::TypeId id) const -> const sym::TypeDecl& { return m_typeDecls[id]; }
@@ -212,13 +217,13 @@ auto Program::defineUserStruct(sym::TypeId id, sym::FieldDeclTable fields) -> vo
       sym::FuncKind::CheckEqUserType,
       getFuncName(Operator::EqEq),
       sym::Input{id, id},
-      *m_typeDecls.lookup("bool"));
+      m_bool);
   m_funcDecls.registerFunc(
       *this,
       sym::FuncKind::CheckNEqUserType,
       getFuncName(Operator::BangEq),
       sym::Input{id, id},
-      *m_typeDecls.lookup("bool"));
+      m_bool);
 
   // Register struct definition.
   m_typeDefs.registerStruct(m_typeDecls, id, std::move(fields));
@@ -237,13 +242,13 @@ auto Program::defineUserUnion(sym::TypeId id, std::vector<sym::TypeId> types) ->
       sym::FuncKind::CheckEqUserType,
       getFuncName(Operator::EqEq),
       sym::Input{id, id},
-      *m_typeDecls.lookup("bool"));
+      m_bool);
   m_funcDecls.registerFunc(
       *this,
       sym::FuncKind::CheckNEqUserType,
       getFuncName(Operator::BangEq),
       sym::Input{id, id},
-      *m_typeDecls.lookup("bool"));
+      m_bool);
 
   // Register union definition.
   m_typeDefs.registerUnion(m_typeDecls, id, std::move(types));

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -15,6 +15,14 @@ TEST_CASE("Analyzing user-function declarations", "[frontend]") {
             .getOutput() == GET_TYPE_ID(output, "bool"));
   }
 
+  SECTION("Declare type-inferred function") {
+    const auto& output = ANALYZE("fun f(int a, bool b) b");
+    REQUIRE(output.isSuccess());
+    CHECK(
+        GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "bool"))
+            .getOutput() == GET_TYPE_ID(output, "bool"));
+  }
+
   SECTION("Declare overloaded function") {
     const auto& output = ANALYZE("fun f(int a) -> bool false "
                                  "fun f(string a) -> string \"hello world\" "
@@ -30,7 +38,7 @@ TEST_CASE("Analyzing user-function declarations", "[frontend]") {
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "bool")).getOutput() ==
         GET_TYPE_ID(output, "bool"));
-    CHECK(GET_FUNC_DECL(output, "f").getOutput() == output.getProg().lookupType("int"));
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == output.getProg().getInt());
   }
 
   SECTION("Declare conversion function") {

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
 #include "frontend/diag_defs.hpp"
 #include "helpers.hpp"
-#include "prog/expr/node_call.hpp"
 #include "prog/expr/node_lit_int.hpp"
 #include "prog/expr/node_lit_string.hpp"
 #include "prog/sym/input.hpp"
@@ -26,17 +25,13 @@ TEST_CASE("Analyzing execute statements", "[frontend]") {
     const auto& output = ANALYZE("print(2)");
     REQUIRE(output.isSuccess());
 
-    const auto conversion = GET_CONV(output, "int", "string");
-    auto convArgs         = std::vector<prog::expr::NodePtr>{};
-    convArgs.push_back(prog::expr::litIntNode(output.getProg(), 2));
-
     auto execsBegin     = output.getProg().beginExecStmts();
     const auto execsEnd = output.getProg().endExecStmts();
     CHECK(
         execsBegin->getActionId() == GET_ACTION_ID(output, "print", GET_TYPE_ID(output, "string")));
     CHECK(
         *execsBegin->getArgs()[0] ==
-        *prog::expr::callExprNode(output.getProg(), *conversion, std::move(convArgs)));
+        *applyConv(output, "int", "string", prog::expr::litIntNode(output.getProg(), 2)));
     REQUIRE(++execsBegin == execsEnd);
   }
 

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
 #include "frontend/diag_defs.hpp"
 #include "helpers.hpp"
-#include "prog/expr/node_call.hpp"
 #include "prog/expr/node_lit_int.hpp"
 #include "prog/sym/input.hpp"
 
@@ -26,13 +25,9 @@ TEST_CASE("Analyzing user-function definitions", "[frontend]") {
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 
-    const auto conversion = GET_CONV(output, "int", "string");
-    auto convArgs         = std::vector<prog::expr::NodePtr>{};
-    convArgs.push_back(prog::expr::litIntNode(output.getProg(), 2));
-
     CHECK(
         funcDef.getExpr() ==
-        *prog::expr::callExprNode(output.getProg(), *conversion, std::move(convArgs)));
+        *applyConv(output, "int", "string", prog::expr::litIntNode(output.getProg(), 2)));
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_const_expr_test.cpp
+++ b/tests/frontend/get_const_expr_test.cpp
@@ -11,7 +11,7 @@ namespace frontend {
 TEST_CASE("Analyzing constant expressions", "[frontend]") {
 
   SECTION("Access function input") {
-    const auto& output = ANALYZE("fun f(int a) -> int a");
+    const auto& output = ANALYZE("fun f(int a) a");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"));
     const auto& consts  = funcDef.getConsts();
@@ -19,7 +19,7 @@ TEST_CASE("Analyzing constant expressions", "[frontend]") {
   }
 
   SECTION("Declare and access local const") {
-    const auto& output = ANALYZE("fun f() -> int a = 1; b = a; b");
+    const auto& output = ANALYZE("fun f() a = 1; b = a; b");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
     const auto& consts  = funcDef.getConsts();

--- a/tests/frontend/get_group_expr_test.cpp
+++ b/tests/frontend/get_group_expr_test.cpp
@@ -2,7 +2,6 @@
 #include "frontend/diag_defs.hpp"
 #include "helpers.hpp"
 #include "prog/expr/node_assign.hpp"
-#include "prog/expr/node_call.hpp"
 #include "prog/expr/node_const.hpp"
 #include "prog/expr/node_group.hpp"
 #include "prog/expr/node_lit_int.hpp"
@@ -13,7 +12,7 @@ namespace frontend {
 TEST_CASE("Analyzing group expressions", "[frontend]") {
 
   SECTION("Get basic group expression") {
-    const auto& output = ANALYZE("fun f() -> int b = 1; c = 2; b * c");
+    const auto& output = ANALYZE("fun f() b = 1; c = 2; b * c");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
     const auto& consts  = funcDef.getConsts();

--- a/tests/frontend/get_paren_expr_test.cpp
+++ b/tests/frontend/get_paren_expr_test.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
 #include "frontend/diag_defs.hpp"
 #include "helpers.hpp"
-#include "prog/expr/node_call.hpp"
 #include "prog/expr/node_const.hpp"
 #include "prog/operator.hpp"
 
@@ -10,7 +9,7 @@ namespace frontend {
 TEST_CASE("Analyzing parenthesized expressions", "[frontend]") {
 
   SECTION("Get basic paren expression") {
-    const auto& output = ANALYZE("fun f(int a, int b) -> int ((a) + (b))");
+    const auto& output = ANALYZE("fun f(int a, int b) ((a) + (b))");
     REQUIRE(output.isSuccess());
     const auto& funcDef =
         GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int"));

--- a/tests/frontend/get_switch_expr_test.cpp
+++ b/tests/frontend/get_switch_expr_test.cpp
@@ -6,6 +6,7 @@
 #include "prog/expr/node_fail.hpp"
 #include "prog/expr/node_group.hpp"
 #include "prog/expr/node_lit_bool.hpp"
+#include "prog/expr/node_lit_float.hpp"
 #include "prog/expr/node_lit_int.hpp"
 #include "prog/expr/node_switch.hpp"
 #include "prog/expr/node_union_check.hpp"
@@ -31,6 +32,55 @@ TEST_CASE("Analyzing switch expressions", "[frontend]") {
     branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
     branches.push_back(prog::expr::litIntNode(output.getProg(), 2));
     branches.push_back(prog::expr::litIntNode(output.getProg(), 3));
+
+    CHECK(
+        funcDef.getExpr() ==
+        *prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches)));
+  }
+
+  SECTION("Get switch expression with conversion on the conditions") {
+    const auto& output = ANALYZE("fun bool(int i) i != 0 "
+                                 "fun f() "
+                                 "  if 1  -> 1 "
+                                 "  if 0  -> 2 "
+                                 "  else  -> 3");
+    REQUIRE(output.isSuccess());
+    const auto& funcDef = GET_FUNC_DEF(output, "f");
+
+    auto conditions = std::vector<prog::expr::NodePtr>{};
+    conditions.push_back(
+        applyConv(output, "int", "bool", prog::expr::litIntNode(output.getProg(), 1)));
+    conditions.push_back(
+        applyConv(output, "int", "bool", prog::expr::litIntNode(output.getProg(), 0)));
+
+    auto branches = std::vector<prog::expr::NodePtr>{};
+    branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
+    branches.push_back(prog::expr::litIntNode(output.getProg(), 2));
+    branches.push_back(prog::expr::litIntNode(output.getProg(), 3));
+
+    CHECK(
+        funcDef.getExpr() ==
+        *prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches)));
+  }
+
+  SECTION("Get switch expression with conversion on the branches") {
+    const auto& output = ANALYZE("fun f() "
+                                 "  if true   -> 1 "
+                                 "  if false  -> 1.0 "
+                                 "  else      -> 3");
+    REQUIRE(output.isSuccess());
+    const auto& funcDef = GET_FUNC_DEF(output, "f");
+
+    auto conditions = std::vector<prog::expr::NodePtr>{};
+    conditions.push_back(prog::expr::litBoolNode(output.getProg(), true));
+    conditions.push_back(prog::expr::litBoolNode(output.getProg(), false));
+
+    auto branches = std::vector<prog::expr::NodePtr>{};
+    branches.push_back(
+        applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 1)));
+    branches.push_back(prog::expr::litFloatNode(output.getProg(), 1.0F));
+    branches.push_back(
+        applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 3)));
 
     CHECK(
         funcDef.getExpr() ==
@@ -97,27 +147,27 @@ TEST_CASE("Analyzing switch expressions", "[frontend]") {
         "fun f(int a) -> int "
         "  if a   -> 1 "
         "  else   -> 2",
-        errNonBoolConditionExpression(src, "int", input::Span{25, 25}));
+        errNoConversionFound(src, "int", "bool", input::Span{25, 25}));
     CHECK_DIAG(
         "fun f() -> int "
         "  if true   -> 1 "
         "  else      -> true",
-        errMismatchedBranchTypes(src, "int", "bool", input::Span{47, 50}));
+        errNoConversionFound(src, "bool", "int", input::Span{34, 50}));
     CHECK_DIAG(
         "fun f() -> int "
         "  if true   -> 1 "
         "  if false  -> false "
         "  else      -> 2",
-        errMismatchedBranchTypes(src, "int", "bool", input::Span{47, 51}));
+        errNoConversionFound(src, "bool", "int", input::Span{34, 51}));
     CHECK_DIAG(
         "fun f() -> int "
         "  if false  -> 2 ",
-        nonExhaustiveSwitchWithoutElse(src, input::Span{17, 30}));
+        errNonExhaustiveSwitchWithoutElse(src, input::Span{17, 30}));
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) -> int "
         "  if u is float _ -> 1 ",
-        nonExhaustiveSwitchWithoutElse(src, input::Span{41, 60}));
+        errNonExhaustiveSwitchWithoutElse(src, input::Span{41, 60}));
   }
 }
 

--- a/tests/frontend/get_unary_expr_test.cpp
+++ b/tests/frontend/get_unary_expr_test.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
 #include "frontend/diag_defs.hpp"
 #include "helpers.hpp"
-#include "prog/expr/node_call.hpp"
 #include "prog/expr/node_const.hpp"
 #include "prog/expr/node_lit_int.hpp"
 #include "prog/operator.hpp"

--- a/tests/frontend/helpers.hpp
+++ b/tests/frontend/helpers.hpp
@@ -2,6 +2,7 @@
 #include "catch2/catch.hpp"
 #include "frontend/analysis.hpp"
 #include "frontend/source.hpp"
+#include "prog/expr/node_call.hpp"
 
 namespace frontend {
 
@@ -43,5 +44,17 @@ namespace frontend {
     const std::vector<frontend::Diag> expectedDiags = {__VA_ARGS__};                               \
     CHECK_THAT(diags, Catch::UnorderedEquals(expectedDiags));                                      \
   }
+
+inline auto applyConv(
+    const Output& output,
+    const std::string& fromType,
+    const std::string& toType,
+    prog::expr::NodePtr childExpr) -> prog::expr::NodePtr {
+  auto conv     = GET_CONV(output, fromType, toType);
+  auto convArgs = std::vector<prog::expr::NodePtr>{};
+  convArgs.push_back(std::move(childExpr));
+
+  return prog::expr::callExprNode(output.getProg(), *conv, std::move(convArgs));
+}
 
 } // namespace frontend

--- a/tests/frontend/overload_test.cpp
+++ b/tests/frontend/overload_test.cpp
@@ -1,6 +1,5 @@
 #include "catch2/catch.hpp"
 #include "helpers.hpp"
-#include "prog/expr/node_call.hpp"
 
 namespace frontend {
 

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -85,17 +85,17 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
   }
 
   SECTION("Conditional operator") {
-    const auto& output = ANALYZE("fun f() 1 > 2 ? 42 : 1337");
+    const auto& output = ANALYZE("fun f() 1 > 2 ? 42 : 1337.0");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "int"));
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "float"));
   }
 
   SECTION("Switch") {
     const auto& output = ANALYZE("fun f() "
                                  "if 1 > 2  -> 1 "
-                                 "else      -> 2");
+                                 "else      -> 2.0");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "int"));
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "float"));
   }
 
   SECTION("Call") {


### PR DESCRIPTION
In switches (and conditional operators) the frontend finds a type that all branches are convertible to and applies said conversions.

In the following snippet the return type of `makeCircleOrLine` is `Shape` as both `Circle` and `Line` are convertible to `Shape`.
```
union Shape = Circle, Line

struct Circle = float radius
struct Line = float length

fun makeCircleOrLine(bool line, float v)
  if line -> Line(v)
  else    -> Circle(v)
```