### PR TITLE
Use relative id's in union code gen

### DIFF
--- a/include/prog/sym/union_def.hpp
+++ b/include/prog/sym/union_def.hpp
@@ -20,6 +20,7 @@ public:
   [[nodiscard]] auto getId() const noexcept -> const TypeId&;
   [[nodiscard]] auto getTypes() const noexcept -> const std::vector<sym::TypeId>&;
   [[nodiscard]] auto hasType(sym::TypeId type) const noexcept -> bool;
+  [[nodiscard]] auto getTypeIndex(sym::TypeId type) const -> unsigned int;
 
 private:
   sym::TypeId m_id;

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -57,8 +57,7 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   const auto& funcDecl = m_program.getFuncDecl(n.getFunc());
   if (funcDecl.getKind() == prog::sym::FuncKind::MakeUnion) {
     // Union is an exception where the type-id needs to be on the stack before the argument.
-    auto type = n[0].getType();
-    m_builder->addLoadLitInt(static_cast<int32_t>(type.getNum()));
+    m_builder->addLoadLitInt(getUnionTypeId(m_program, n.getType(), n[0].getType()));
   }
 
   // Push the arguments on the stack.
@@ -243,7 +242,7 @@ auto GenExpr::visit(const prog::expr::UnionCheckExprNode& n) -> void {
 
   // Test if the union is the correct type.
   m_builder->addLoadStructField(0);
-  m_builder->addLoadLitInt(static_cast<int32_t>(n.getTargetType().getNum()));
+  m_builder->addLoadLitInt(getUnionTypeId(m_program, n[0].getType(), n.getTargetType()));
   m_builder->addCheckEqInt();
 }
 
@@ -259,7 +258,7 @@ auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
 
   // Test if the union is the correct type.
   m_builder->addLoadStructField(0);
-  m_builder->addLoadLitInt(static_cast<int32_t>(n.getTargetType().getNum()));
+  m_builder->addLoadLitInt(getUnionTypeId(m_program, n[0].getType(), n.getTargetType()));
   m_builder->addCheckEqInt();
   m_builder->addJumpIf(typeEqLabel);
 

--- a/src/backend/internal/gen_type_eq.cpp
+++ b/src/backend/internal/gen_type_eq.cpp
@@ -100,11 +100,9 @@ auto generateUnionEquality(
   // Check which type the union is.
   builder->label(sameTypeLabel);
   for (auto i = 0U; i != unionDef.getTypes().size(); ++i) {
-    const auto& type = unionDef.getTypes()[i];
-
     builder->addLoadConst(0);
     builder->addLoadStructField(0);
-    builder->addLoadLitInt(static_cast<int32_t>(type.getNum()));
+    builder->addLoadLitInt(i);
     builder->addCheckEqInt();
 
     // If its this type then jump to the value check for that type.

--- a/src/backend/internal/utilities.cpp
+++ b/src/backend/internal/utilities.cpp
@@ -32,4 +32,19 @@ auto getFieldId(prog::sym::FieldId fieldId) -> uint8_t {
   return static_cast<uint8_t>(fieldNum);
 }
 
+auto getUnionTypeId(
+    const prog::Program& prog, prog::sym::TypeId unionType, prog::sym::TypeId targetType)
+    -> uint8_t {
+  const auto& typeDef = prog.getTypeDef(unionType);
+  if (!std::holds_alternative<prog::sym::UnionDef>(typeDef)) {
+    throw std::logic_error{"Child expression has to be of a union type"};
+  }
+  const auto& unionDef = std::get<prog::sym::UnionDef>(typeDef);
+  const auto index     = unionDef.getTypeIndex(targetType);
+  if (index > std::numeric_limits<uint8_t>::max()) {
+    throw std::logic_error{"More then 256 types in one union are not supported"};
+  }
+  return static_cast<uint8_t>(index);
+}
+
 } // namespace backend::internal

--- a/src/backend/internal/utilities.hpp
+++ b/src/backend/internal/utilities.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "prog/program.hpp"
 #include "prog/sym/const_id.hpp"
 #include "prog/sym/field_id.hpp"
 #include "prog/sym/func_id.hpp"
@@ -14,5 +15,9 @@ auto getUserTypeEqLabel(prog::sym::TypeId typeId) -> std::string;
 auto getConstId(prog::sym::ConstId constId) -> uint8_t;
 
 auto getFieldId(prog::sym::FieldId fieldId) -> uint8_t;
+
+auto getUnionTypeId(
+    const prog::Program& prog, prog::sym::TypeId unionType, prog::sym::TypeId targetType)
+    -> uint8_t;
 
 } // namespace backend::internal

--- a/src/prog/sym/union_def.cpp
+++ b/src/prog/sym/union_def.cpp
@@ -13,4 +13,12 @@ auto UnionDef::hasType(sym::TypeId type) const noexcept -> bool {
   return std::find(m_types.begin(), m_types.end(), type) != m_types.end();
 }
 
+auto UnionDef::getTypeIndex(sym::TypeId type) const -> unsigned int {
+  const auto itr = std::find(m_types.begin(), m_types.end(), type);
+  if (itr == m_types.end()) {
+    throw std::invalid_argument{"Given type is not part of the union"};
+  }
+  return itr - m_types.begin();
+}
+
 } // namespace prog::sym

--- a/tests/backend/user_union_test.cpp
+++ b/tests/backend/user_union_test.cpp
@@ -10,9 +10,6 @@ TEST_CASE("Generating assembly for user-unions", "[backend]") {
         "union Val = int, float "
         "print(Val(1) == Val(1.0))",
         [](backend::Builder* builder) -> void {
-          const auto intTypeId   = 1;
-          const auto floatTypeId = 2;
-
           // --- Union equality function start.
           builder->label("ValEq");
           // Store both unions as consts.
@@ -36,14 +33,14 @@ TEST_CASE("Generating assembly for user-unions", "[backend]") {
           // Check if the union type is int.
           builder->addLoadConst(0);
           builder->addLoadStructField(0);
-          builder->addLoadLitInt(intTypeId);
+          builder->addLoadLitInt(0); // 0 because 'int' is the first type in the union.
           builder->addCheckEqInt();
           builder->addJumpIf("int");
 
           // Check if the union type is float.
           builder->addLoadConst(0);
           builder->addLoadStructField(0);
-          builder->addLoadLitInt(floatTypeId);
+          builder->addLoadLitInt(1); // 1 because 'float' is the second type in the union.
           builder->addCheckEqInt();
           builder->addJumpIf("float");
 
@@ -82,12 +79,12 @@ TEST_CASE("Generating assembly for user-unions", "[backend]") {
           // --- Print statement start.
           builder->label("print");
           // Make union with int 'Val(1)'.
-          builder->addLoadLitInt(intTypeId);
+          builder->addLoadLitInt(0); // 0 because 'int' is the first type in the union.
           builder->addLoadLitInt(1);
           builder->addMakeStruct(2);
 
           // Make union with float 'Val(1.0)'.
-          builder->addLoadLitInt(floatTypeId);
+          builder->addLoadLitInt(1); // 1 because 'float' is the second type in the union.
           builder->addLoadLitFloat(1.0F);
           builder->addMakeStruct(2);
 


### PR DESCRIPTION
Instead of using the absolute type-id as the union tag this now uses a relative id within the union. Its a bit more performant as we can use smaller arguments in assembly to represent the types.

But another benefit is that it's more deterministic, for example an option type could always have first field being `0` mean that it holds no value and first field being `1` could mean that there is a value in the second field.