### PR TITLE
Substituting constructors in template functions

### DIFF
--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -54,6 +54,10 @@ auto TypeInferExpr::visit(const parse::CallExprNode& n) -> void {
   const auto funcName = getName(n.getFunc());
 
   // Check if this is calling a constructor / conversion.
+  if (m_typeSubTable != nullptr && m_typeSubTable->lookupType(funcName)) {
+    m_type = *m_typeSubTable->lookupType(funcName);
+    return;
+  }
   if (isType(funcName)) {
     const auto isTemplType          = m_context->getTypeTemplates()->hasType(funcName);
     const auto synthesisedParseType = (isTemplType && n.getTypeParams())

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -147,6 +147,14 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
         GET_TYPE_ID(output, "tuple__int_bool"));
   }
 
+  SECTION("Substituted constructor") {
+    const auto& output = ANALYZE("struct s = int a "
+                                 "fun factory{T}(int i) T(i) "
+                                 "fun f() factory{s}(42)");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "s"));
+  }
+
   SECTION("Diagnostics") {
     CHECK_DIAG(
         "fun f1() f2() "

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -115,6 +115,23 @@ TEST_CASE("Analyzing user-function templates", "[frontend]") {
             GET_FUNC_ID(output, "ft__string", GET_TYPE_ID(output, "int")),
             std::move(args3)));
   }
+
+  SECTION("Substituted constructor") {
+    const auto& output = ANALYZE("struct s = int a "
+                                 "fun factory{T}(int i) -> T T(i) "
+                                 "fun f() -> s factory{s}(1)");
+    REQUIRE(output.isSuccess());
+
+    const auto& fDef = GET_FUNC_DEF(output, "factory__s", GET_TYPE_ID(output, "int"));
+    auto fArgs       = std::vector<prog::expr::NodePtr>{};
+    fArgs.push_back(prog::expr::constExprNode(fDef.getConsts(), *fDef.getConsts().lookup("i")));
+    CHECK(
+        fDef.getExpr() ==
+        *prog::expr::callExprNode(
+            output.getProg(),
+            GET_FUNC_ID(output, "s", GET_TYPE_ID(output, "int")),
+            std::move(fArgs)));
+  }
 }
 
 } // namespace frontend


### PR DESCRIPTION
Allows creating generic factory functions
```
struct User =
  string FirstName,
  string LastName

struct Player =
  string FirstName,
  string LastName

fun factory{T}(string firstName, string lastName)
  T(firstName, lastName)

fun string(User user)
  user.FirstName + ", " + user.LastName

fun string(Player player)
  player.FirstName + ", " + player.LastName

print(factory{User}("hello", "world") + "\n")
print(factory{Player}("john", "doe"))
```