### PR TITLE
Add default constructors for build-in types

### DIFF
--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -44,6 +44,11 @@ enum class FuncKind {
   ConvFloatString,
   ConvBoolString,
 
+  DefInt,
+  DefFloat,
+  DefBool,
+  DefString,
+
   MakeStruct,
   MakeUnion,
 

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -189,6 +189,19 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     m_builder->addConvBoolString();
     break;
 
+  case prog::sym::FuncKind::DefInt:
+    m_builder->addLoadLitInt(0);
+    break;
+  case prog::sym::FuncKind::DefFloat:
+    m_builder->addLoadLitFloat(.0);
+    break;
+  case prog::sym::FuncKind::DefBool:
+    m_builder->addLoadLitInt(0);
+    break;
+  case prog::sym::FuncKind::DefString:
+    m_builder->addLoadLitString("");
+    break;
+
   case prog::sym::FuncKind::MakeStruct: {
     auto fieldCount = n.getChildCount();
     if (fieldCount == 0U) {

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -99,6 +99,12 @@ Program::Program() :
   m_funcDecls.registerFunc(
       *this, fk::CheckNEqString, getFuncName(op::BangEq), sym::TypeSet{m_string, m_string}, m_bool);
 
+  // Register build-in default constructors.
+  m_funcDecls.registerFunc(*this, fk::DefInt, "int", sym::TypeSet{}, m_int);
+  m_funcDecls.registerFunc(*this, fk::DefFloat, "float", sym::TypeSet{}, m_float);
+  m_funcDecls.registerFunc(*this, fk::DefBool, "bool", sym::TypeSet{}, m_bool);
+  m_funcDecls.registerFunc(*this, fk::DefString, "string", sym::TypeSet{}, m_string);
+
   // Register build-in implicit conversions.
   m_funcDecls.registerFunc(*this, fk::ConvIntFloat, "float", sym::TypeSet{m_int}, m_float);
   m_funcDecls.registerFunc(*this, fk::ConvIntString, "string", sym::TypeSet{m_int}, m_string);

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -246,6 +246,15 @@ TEST_CASE("Generate assembly for call expressions", "[backend]") {
     });
   }
 
+  SECTION("Default constructors") {
+    CHECK_EXPR_INT("int()", [](backend::Builder* builder) -> void { builder->addLoadLitInt(0); });
+    CHECK_EXPR_FLOAT(
+        "float()", [](backend::Builder* builder) -> void { builder->addLoadLitFloat(.0); });
+    CHECK_EXPR_BOOL("bool()", [](backend::Builder* builder) -> void { builder->addLoadLitInt(0); });
+    CHECK_EXPR_STRING(
+        "string()", [](backend::Builder* builder) -> void { builder->addLoadLitString(""); });
+  }
+
   SECTION("User functions") {
     CHECK_PROG(
         "fun test(int a, int b) -> int a + b "


### PR DESCRIPTION
Useful in templated functions to default construct a build-in value:
```
struct Null
union Option{T} = T, Null

fun add{T}(Option{T} a, Option{T} b)
  if a is T aV && b is T bV -> aV + bV
  else                      -> T()

print(add{int}(42, 1337))
```