### PR TITLE
Infer types in template function calls

### DIFF
--- a/include/parse/type_param_list.hpp
+++ b/include/parse/type_param_list.hpp
@@ -18,6 +18,10 @@ public:
   auto operator==(const TypeParamList& rhs) const noexcept -> bool;
   auto operator!=(const TypeParamList& rhs) const noexcept -> bool;
 
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Type&;
+
+  [[nodiscard]] auto getCount() const -> unsigned int;
+
   [[nodiscard]] auto begin() const -> iterator;
   [[nodiscard]] auto end() const -> iterator;
 

--- a/src/frontend/internal/func_template.hpp
+++ b/src/frontend/internal/func_template.hpp
@@ -16,10 +16,14 @@ public:
 
   [[nodiscard]] auto getTemplateName() const -> const std::string&;
   [[nodiscard]] auto getTypeParamCount() const -> unsigned int;
+  [[nodiscard]] auto getArgumentCount() const -> unsigned int;
   [[nodiscard]] auto getRetType(const prog::sym::TypeSet& typeParams)
       -> std::optional<prog::sym::TypeId>;
 
-  auto instantiate(const prog::sym::TypeSet& typeParams) -> const FuncTemplateInst*;
+  [[nodiscard]] auto inferTypeParams(const prog::sym::TypeSet& argTypes)
+      -> std::optional<prog::sym::TypeSet>;
+
+  [[nodiscard]] auto instantiate(const prog::sym::TypeSet& typeParams) -> const FuncTemplateInst*;
 
 private:
   Context* m_context;
@@ -38,6 +42,9 @@ private:
 
   [[nodiscard]] auto createSubTable(const prog::sym::TypeSet& typeParams) const
       -> TypeSubstitutionTable;
+
+  [[nodiscard]] auto inferSubType(const std::string& subType, const prog::sym::TypeSet& argTypes)
+      -> std::optional<prog::sym::TypeId>;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/func_template_table.hpp
+++ b/src/frontend/internal/func_template_table.hpp
@@ -23,7 +23,13 @@ public:
   auto instantiate(const std::string& name, const prog::sym::TypeSet& typeParams)
       -> std::vector<const FuncTemplateInst*>;
 
+  auto inferParamsAndInstantiate(const std::string& name, const prog::sym::TypeSet& argTypes)
+      -> std::vector<const FuncTemplateInst*>;
+
   auto getRetType(const std::string& name, const prog::sym::TypeSet& typeParams)
+      -> std::optional<prog::sym::TypeId>;
+
+  auto inferParamsAndGetRetType(const std::string& name, const prog::sym::TypeSet& argTypes)
       -> std::optional<prog::sym::TypeId>;
 
 private:

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -70,7 +70,16 @@ private:
 
   [[nodiscard]] auto isType(const std::string& name) const -> bool;
 
-  [[nodiscard]] auto getFunctions(const parse::CallExprNode& n) -> std::vector<prog::sym::FuncId>;
+  [[nodiscard]] auto getFunctionsInclConversions(
+      const lex::Token& nameToken,
+      const std::optional<parse::TypeParamList>& typeParams,
+      const prog::sym::TypeSet& argTypes) -> std::vector<prog::sym::FuncId>;
+
+  [[nodiscard]] auto getFunctions(
+      const std::string& funcName,
+      const std::optional<parse::TypeParamList>& typeParams,
+      const prog::sym::TypeSet& argTypes,
+      input::Span span) -> std::vector<prog::sym::FuncId>;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -43,7 +43,7 @@ private:
   prog::sym::TypeId m_type;
 
   auto inferSubExpr(const parse::Node& n) -> prog::sym::TypeId;
-  auto inferFuncCall(const std::string& funcName, std::vector<prog::sym::TypeId> argTypes)
+  auto inferFuncCall(const std::string& funcName, const prog::sym::TypeSet& argTypes)
       -> prog::sym::TypeId;
 
   auto setConstType(const lex::Token& constId, prog::sym::TypeId type) -> void;

--- a/src/parse/type_param_list.cpp
+++ b/src/parse/type_param_list.cpp
@@ -18,6 +18,15 @@ auto TypeParamList::operator!=(const TypeParamList& rhs) const noexcept -> bool 
   return !TypeParamList::operator==(rhs);
 }
 
+auto TypeParamList::operator[](unsigned int i) const -> const Type& {
+  if (i >= m_params.size()) {
+    throw std::out_of_range{"No parameter at given index"};
+  }
+  return m_params[i];
+}
+
+auto TypeParamList::getCount() const -> unsigned int { return m_params.size(); }
+
 auto TypeParamList::begin() const -> iterator { return m_params.begin(); }
 
 auto TypeParamList::end() const -> iterator { return m_params.end(); }

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -136,7 +136,7 @@ TEST_CASE("Analyzing user-function declarations", "[frontend]") {
         "fun s{T}(T a) -> T a "
         "fun f() s{int}(1)",
         errIncorrectReturnTypeInConvFunc(src, "s", "int", input::Span{30, 49}),
-        errInvalidFuncInstantiation(src, input::Span{59, 67}));
+        errInvalidFuncInstantiation(src, input::Span{59, 59}));
     CHECK_DIAG(
         "fun -(int i) -> int 1",
         errDuplicateFuncDeclaration(src, "operator-minus", input::Span{0, 20}));

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -69,18 +69,18 @@ TEST_CASE("Analyzing user-function definitions", "[frontend]") {
         "fun f{T}(T T) -> T T "
         "fun f2() -> int f{int}(1)",
         errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{11, 11}),
-        errInvalidFuncInstantiation(src, input::Span{37, 45}));
+        errInvalidFuncInstantiation(src, input::Span{37, 37}));
     CHECK_DIAG(
         "fun f{T}(T T) -> T T "
         "fun f2() f{int}(1)",
         errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{11, 11}),
-        errInvalidFuncInstantiation(src, input::Span{30, 38}));
+        errInvalidFuncInstantiation(src, input::Span{30, 30}));
     CHECK_DIAG(
         "fun f{T}(T i) -> T "
         "  T = i * 2; i "
         "fun f2() -> int f{int}(1)",
         errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{21, 21}),
-        errInvalidFuncInstantiation(src, input::Span{50, 58}));
+        errInvalidFuncInstantiation(src, input::Span{50, 50}));
   }
 }
 


### PR DESCRIPTION
```
fun add{T, Y}(T a, Y b)
  a + b

print(add(1, 42.1))
```

This also enables defining templated operator overloads.