### PR TITLE
ColonColon operator

### DIFF
--- a/include/lex/token_kind.hpp
+++ b/include/lex/token_kind.hpp
@@ -25,6 +25,7 @@ enum class TokenKind {
   OpSemi,
   OpQMark,
   OpDot,
+  OpColonColon,
   SepOpenParen,
   SepCloseParen,
   SepOpenCurly,

--- a/include/prog/operator.hpp
+++ b/include/prog/operator.hpp
@@ -18,6 +18,7 @@ enum class Operator {
   LeEq,
   Gt,
   GtEq,
+  ColonColon,
 };
 
 auto getFuncName(Operator op) -> std::string;

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -53,6 +53,8 @@ namespace frontend::internal {
     return prog::Operator::Gt;
   case lex::TokenKind::OpGtEq:
     return prog::Operator::GtEq;
+  case lex::TokenKind::OpColonColon:
+    return prog::Operator::ColonColon;
   default:
     return std::nullopt;
   }
@@ -88,6 +90,8 @@ namespace frontend::internal {
     return ">";
   case prog::Operator::GtEq:
     return ">=";
+  case prog::Operator::ColonColon:
+    return "::";
   }
   return "__unknown";
 }

--- a/src/lex/lexer.cpp
+++ b/src/lex/lexer.cpp
@@ -143,6 +143,10 @@ auto LexerImpl::next() -> Token {
     case ',':
       return basicToken(TokenKind::SepComma, input::Span{m_inputPos});
     case ':':
+      if (peekChar(0) == ':') {
+        consumeChar();
+        return basicToken(TokenKind::OpColonColon, input::Span{m_inputPos - 1, m_inputPos});
+      }
       return basicToken(TokenKind::SepColon, input::Span{m_inputPos});
     case ' ':
     case '\t':

--- a/src/lex/token_cat.cpp
+++ b/src/lex/token_cat.cpp
@@ -51,6 +51,7 @@ auto lookupCat(const TokenKind kind) -> TokenCat {
   case TokenKind::OpSemi:
   case TokenKind::OpQMark:
   case TokenKind::OpDot:
+  case TokenKind::OpColonColon:
     return TokenCat::Operator;
   case TokenKind::SepOpenParen:
   case TokenKind::SepCloseParen:

--- a/src/lex/token_kind.cpp
+++ b/src/lex/token_kind.cpp
@@ -64,6 +64,9 @@ auto operator<<(std::ostream& out, const TokenKind& rhs) -> std::ostream& {
   case TokenKind::OpDot:
     out << "dot";
     break;
+  case TokenKind::OpColonColon:
+    out << "coloncolon";
+    break;
   case TokenKind::SepOpenParen:
     out << "open-paren";
     break;

--- a/src/parse/op_precedence.cpp
+++ b/src/parse/op_precedence.cpp
@@ -24,6 +24,7 @@ auto getRhsOpPrecedence(const lex::Token& token) -> int {
     return multiplicativePrecedence;
   case lex::TokenKind::OpPlus:
   case lex::TokenKind::OpMinus:
+  case lex::TokenKind::OpColonColon:
     return additivePrecedence;
   case lex::TokenKind::OpLe:
   case lex::TokenKind::OpLeEq:
@@ -48,6 +49,15 @@ auto getRhsOpPrecedence(const lex::Token& token) -> int {
     [[fallthrough]];
   default:
     return 0;
+  }
+}
+
+auto isRightAssociative(const lex::Token& token) -> bool {
+  switch (token.getKind()) {
+  case lex::TokenKind::OpColonColon:
+    return true;
+  default:
+    return false;
   }
 }
 

--- a/src/parse/op_precedence.hpp
+++ b/src/parse/op_precedence.hpp
@@ -20,4 +20,6 @@ auto getLhsOpPrecedence(const lex::Token& token) -> int;
 
 auto getRhsOpPrecedence(const lex::Token& token) -> int;
 
+auto isRightAssociative(const lex::Token& token) -> bool;
+
 } // namespace parse

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -205,9 +205,11 @@ auto ParserImpl::nextExpr(const int minPrecedence) -> NodePtr {
   while (true) {
     // Handle binary operators, precedence controls if we should keep recursing or let the next
     // iteration handle them.
-    const auto& nextToken    = peekToken(0);
-    const auto rhsPrecedence = getRhsOpPrecedence(nextToken);
-    if (rhsPrecedence == 0 || rhsPrecedence <= minPrecedence) {
+    const auto& nextToken       = peekToken(0);
+    const auto rhsPrecedence    = getRhsOpPrecedence(nextToken);
+    const auto rightAssociative = isRightAssociative(nextToken);
+    if (rhsPrecedence == 0 || rhsPrecedence < minPrecedence ||
+        (!rightAssociative && rhsPrecedence == minPrecedence)) {
       break;
     }
 

--- a/src/prog/operator.cpp
+++ b/src/prog/operator.cpp
@@ -33,6 +33,8 @@ auto getFuncName(Operator op) -> std::string {
     return "__op_gt";
   case Operator::GtEq:
     return "__op_gteq";
+  case Operator::ColonColon:
+    return "__op_coloncolon";
   }
   throw std::invalid_argument("Unknown operator");
 }

--- a/tests/lex/operators_test.cpp
+++ b/tests/lex/operators_test.cpp
@@ -24,6 +24,7 @@ TEST_CASE("Lexing operators", "[lex]") {
   CHECK_TOKENS(";", basicToken(TokenKind::OpSemi));
   CHECK_TOKENS("?", basicToken(TokenKind::OpQMark));
   CHECK_TOKENS(".", basicToken(TokenKind::OpDot));
+  CHECK_TOKENS("::", basicToken(TokenKind::OpColonColon));
 }
 
 } // namespace lex

--- a/tests/parse/expr_binary_test.cpp
+++ b/tests/parse/expr_binary_test.cpp
@@ -40,6 +40,9 @@ TEST_CASE("Parsing binary operators", "[parse]") {
                             unaryExprNode(MINUS, INT(5)),
                             MINUS,
                             binaryExprNode(INT(2), STAR, INT(3))))))));
+    CHECK_EXPR(
+        "1 :: 2 :: 3",
+        binaryExprNode(INT(1), COLONCOLON, binaryExprNode(INT(2), COLONCOLON, INT(3))));
   }
 
   SECTION("Errors") {

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -31,6 +31,7 @@ namespace parse {
 #define SEMI lex::basicToken(lex::TokenKind::OpSemi)
 #define QMARK lex::basicToken(lex::TokenKind::OpQMark)
 #define DOT lex::basicToken(lex::TokenKind::OpDot)
+#define COLONCOLON lex::basicToken(lex::TokenKind::OpColonColon)
 #define SEMIS(COUNT) std::vector<lex::Token>(COUNT, lex::basicToken(lex::TokenKind::OpSemi))
 #define OPAREN lex::basicToken(lex::TokenKind::SepOpenParen)
 #define CPAREN lex::basicToken(lex::TokenKind::SepCloseParen)


### PR DESCRIPTION
Adds a user overloadable '::' operator. It's not used by any build-in types and its a right associative binary operator, which makes it very useful to created linked lists with:
```
struct End
struct ListNode{T} =
  T val,
  List{T} next

union List{T} = ListNode{T}, End

fun concat{T}(List{T} a, List{T} b) -> List{T}
  if a is ListNode{T} n -> ListNode{T}(n.val, concat(n.next, b))
  if a is End _         -> b

fun ::{T}(T a, T b) -> List{T}
  a :: ListNode{T}(b, End())

fun ::{T}(T val, List{T} l) -> List{T}
  ListNode{T}(val, l)

fun +{T}(List{T} a, List{T} b)
  concat(a, b)

fun string{T}(List{T} l)
  if l is ListNode{T} n -> string(n.val) + (n.next is ListNode{T} _ ? "," + string(n.next) : "")
  if l is End _         -> ""

print(
  a = 1 :: 2 :: 3 :: 4 :: 5 :: 6;
  b = 1 :: 2 :: 3 :: 4 :: 5 :: 6;
  string(a + b))
``` 