### PR TITLE
Feature/comments

### DIFF
--- a/apps/lexdiag/main.cpp
+++ b/apps/lexdiag/main.cpp
@@ -67,6 +67,7 @@ auto getFgColor(const lex::Token& token) -> rang::fg {
   case tc::Keyword:
     return rang::fg::blue;
   case tc::Identifier:
+  case tc::Comment:
     return rang::fg::green;
   case tc::Error:
   case tc::Unknown:
@@ -84,6 +85,7 @@ auto getBgColor(const lex::Token& token) -> rang::bg {
   case tc::Literal:
   case tc::Keyword:
   case tc::Identifier:
+  case tc::Comment:
   case tc::Unknown:
     return rang::bg::reset;
   case tc::Error:

--- a/apps/parsediag/get_color.hpp
+++ b/apps/parsediag/get_color.hpp
@@ -10,6 +10,11 @@ public:
 
   [[nodiscard]] auto getBgColor() const noexcept -> rang::bg { return m_bg; }
 
+  auto visit(const parse::CommentNode & /*unused*/) -> void override {
+    m_fg = rang::fg::green;
+    m_bg = rang::bg::reset;
+  }
+
   auto visit(const parse::ErrorNode & /*unused*/) -> void override {
     m_fg = rang::fg::reset;
     m_bg = rang::bg::red;

--- a/apps/progdiag/main.cpp
+++ b/apps/progdiag/main.cpp
@@ -67,8 +67,8 @@ auto printTypeDecls(const prog::Program& prog) -> void {
 
 auto printFuncDecls(const prog::Program& prog) -> void {
   const auto idColWidth    = 10;
-  const auto nameColWidth  = 20;
-  const auto inputColWidth = 30;
+  const auto nameColWidth  = 30;
+  const auto inputColWidth = 25;
 
   std::cout << rang::style::bold << "Function declarations:\n" << rang::style::reset;
   for (auto funcItr = prog.beginFuncDecls(); funcItr != prog.endFuncDecls(); ++funcItr) {

--- a/include/lex/lexer.hpp
+++ b/include/lex/lexer.hpp
@@ -21,6 +21,7 @@ private:
   auto nextLitNumber(char mostSignficantChar) -> Token;
   auto nextLitStr() -> Token;
   auto nextWordToken(char startingChar) -> Token;
+  auto nextLineComment() -> Token;
 
   auto consumeChar() -> char;
   auto peekChar(size_t ahead) -> char&;

--- a/include/lex/token.hpp
+++ b/include/lex/token.hpp
@@ -71,4 +71,6 @@ auto keywordToken(Keyword keyword, input::Span span = input::Span{0}) -> Token;
 
 auto identiferToken(std::string id, input::Span span = input::Span{0}) -> Token;
 
+auto lineCommentToken(std::string comment, input::Span span = input::Span{0}) -> Token;
+
 } // namespace lex

--- a/include/lex/token_cat.hpp
+++ b/include/lex/token_cat.hpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-enum class TokenCat { Operator, Seperator, Literal, Keyword, Identifier, Error, Unknown };
+enum class TokenCat { Operator, Seperator, Literal, Keyword, Identifier, Comment, Error, Unknown };
 
 auto lookupCat(TokenKind kind) -> TokenCat;
 

--- a/include/lex/token_kind.hpp
+++ b/include/lex/token_kind.hpp
@@ -42,6 +42,7 @@ enum class TokenKind {
   LitString,
   Keyword,
   Identifier,
+  LineComment,
   Discard,
   Error
 };

--- a/include/lex/token_payload_comment.hpp
+++ b/include/lex/token_payload_comment.hpp
@@ -26,7 +26,9 @@ public:
 private:
   const std::string m_comment;
 
-  auto print(std::ostream& out) const -> std::ostream& override { return out << m_comment; }
+  auto print(std::ostream& out) const -> std::ostream& override {
+    return out << '\'' << m_comment << '\'';
+  }
 };
 
 } // namespace lex

--- a/include/lex/token_payload_comment.hpp
+++ b/include/lex/token_payload_comment.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include "lex/token_payload.hpp"
+
+namespace lex {
+
+class CommentTokenPayload final : public TokenPayload {
+public:
+  CommentTokenPayload() = delete;
+  explicit CommentTokenPayload(std::string comment) : m_comment{std::move(comment)} {}
+
+  auto operator==(const TokenPayload& rhs) const noexcept -> bool override {
+    const auto castedRhs = dynamic_cast<const CommentTokenPayload*>(&rhs);
+    return castedRhs != nullptr && m_comment == castedRhs->m_comment;
+  }
+
+  auto operator!=(const TokenPayload& rhs) const noexcept -> bool override {
+    return !CommentTokenPayload::operator==(rhs);
+  }
+
+  [[nodiscard]] auto clone() -> std::unique_ptr<TokenPayload> override {
+    return std::make_unique<CommentTokenPayload>(*this);
+  }
+
+  [[nodiscard]] auto getValue() const noexcept -> const std::string& { return m_comment; }
+
+private:
+  const std::string m_comment;
+
+  auto print(std::ostream& out) const -> std::ostream& override { return out << m_comment; }
+};
+
+} // namespace lex

--- a/include/parse/node_comment.hpp
+++ b/include/parse/node_comment.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include "lex/token.hpp"
+#include "parse/node.hpp"
+#include <vector>
+
+namespace parse {
+
+class CommentNode final : public Node {
+  friend auto commentNode(lex::Token comment) -> NodePtr;
+
+public:
+  CommentNode() = delete;
+
+  auto operator==(const Node& rhs) const noexcept -> bool override;
+  auto operator!=(const Node& rhs) const noexcept -> bool override;
+
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
+  [[nodiscard]] auto getChildCount() const -> unsigned int override;
+  [[nodiscard]] auto getSpan() const -> input::Span override;
+
+  auto accept(NodeVisitor* visitor) const -> void override;
+
+private:
+  const lex::Token m_comment;
+
+  explicit CommentNode(lex::Token comment);
+
+  auto print(std::ostream& out) const -> std::ostream& override;
+};
+
+// Factories.
+auto commentNode(lex::Token comment) -> NodePtr;
+
+} // namespace parse

--- a/include/parse/node_visitor.hpp
+++ b/include/parse/node_visitor.hpp
@@ -2,6 +2,7 @@
 
 namespace parse {
 
+class CommentNode;
 class ErrorNode;
 class BinaryExprNode;
 class CallExprNode;
@@ -25,6 +26,7 @@ class UnionDeclStmtNode;
 
 class NodeVisitor {
 public:
+  virtual auto visit(const CommentNode& n) -> void         = 0;
   virtual auto visit(const ErrorNode& n) -> void           = 0;
   virtual auto visit(const BinaryExprNode& n) -> void      = 0;
   virtual auto visit(const CallExprNode& n) -> void        = 0;

--- a/include/parse/node_visitor_deep.hpp
+++ b/include/parse/node_visitor_deep.hpp
@@ -5,6 +5,7 @@ namespace parse {
 
 class DeepNodeVisitor : public NodeVisitor {
 public:
+  auto visit(const CommentNode& n) -> void override;
   auto visit(const ErrorNode& n) -> void override;
   auto visit(const BinaryExprNode& n) -> void override;
   auto visit(const CallExprNode& n) -> void override;

--- a/include/parse/node_visitor_optional.hpp
+++ b/include/parse/node_visitor_optional.hpp
@@ -5,6 +5,7 @@ namespace parse {
 
 class OptionalNodeVisitor : public NodeVisitor {
 public:
+  auto visit(const CommentNode & /*unused*/) -> void override {}
   auto visit(const ErrorNode & /*unused*/) -> void override {}
   auto visit(const BinaryExprNode & /*unused*/) -> void override {}
   auto visit(const CallExprNode & /*unused*/) -> void override {}

--- a/include/parse/nodes.hpp
+++ b/include/parse/nodes.hpp
@@ -1,3 +1,4 @@
+#include "parse/node_comment.hpp"
 #include "parse/node_error.hpp"
 #include "parse/node_expr_binary.hpp"
 #include "parse/node_expr_call.hpp"

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -21,6 +21,7 @@ protected:
 private:
   std::deque<lex::Token> m_readBuffer;
 
+  auto nextComment() -> NodePtr;
   auto nextStmtFuncDecl() -> NodePtr;
   auto nextStmtStructDecl() -> NodePtr;
   auto nextStmtUnionDecl() -> NodePtr;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ target_include_directories(lex PRIVATE lex)
 # Parser.
 add_library(parse STATIC
   parse/error.cpp
+  parse/node_comment.cpp
   parse/node_error.cpp
   parse/node_expr_binary.cpp
   parse/node_expr_call.cpp

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -39,6 +39,10 @@ GetExpr::GetExpr(
 
 auto GetExpr::getValue() -> prog::expr::NodePtr& { return m_expr; }
 
+auto GetExpr::visit(const parse::CommentNode & /*unused*/) -> void {
+  throw std::logic_error{"GetExpr is not implemented for this node type"};
+}
+
 auto GetExpr::visit(const parse::ErrorNode & /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -19,6 +19,7 @@ public:
   [[nodiscard]] auto getDiags() const noexcept -> const std::vector<Diag>&;
   [[nodiscard]] auto getValue() -> prog::expr::NodePtr&;
 
+  auto visit(const parse::CommentNode& n) -> void override;
   auto visit(const parse::ErrorNode& n) -> void override;
   auto visit(const parse::BinaryExprNode& n) -> void override;
   auto visit(const parse::CallExprNode& n) -> void override;

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -23,6 +23,10 @@ TypeInferExpr::TypeInferExpr(
 
 auto TypeInferExpr::getInferredType() const noexcept -> prog::sym::TypeId { return m_type; }
 
+auto TypeInferExpr::visit(const parse::CommentNode & /*unused*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
 auto TypeInferExpr::visit(const parse::ErrorNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -15,6 +15,7 @@ public:
 
   [[nodiscard]] auto getInferredType() const noexcept -> prog::sym::TypeId;
 
+  auto visit(const parse::CommentNode& n) -> void override;
   auto visit(const parse::ErrorNode& n) -> void override;
   auto visit(const parse::BinaryExprNode& n) -> void override;
   auto visit(const parse::CallExprNode& n) -> void override;

--- a/src/lex/token.cpp
+++ b/src/lex/token.cpp
@@ -1,5 +1,6 @@
 #include "lex/token.hpp"
 #include "lex/token_payload.hpp"
+#include "lex/token_payload_comment.hpp"
 #include "lex/token_payload_error.hpp"
 #include "lex/token_payload_id.hpp"
 #include "lex/token_payload_keyword.hpp"
@@ -108,6 +109,11 @@ auto keywordToken(Keyword keyword, const input::Span span) -> Token {
 auto identiferToken(std::string id, const input::Span span) -> Token {
   return Token{
       TokenKind::Identifier, std::make_unique<IdentifierTokenPayload>(std::move(id)), span};
+}
+
+auto lineCommentToken(std::string comment, const input::Span span) -> Token {
+  return Token{
+      TokenKind::LineComment, std::make_unique<CommentTokenPayload>(std::move(comment)), span};
 }
 
 } // namespace lex

--- a/src/lex/token_cat.cpp
+++ b/src/lex/token_cat.cpp
@@ -19,6 +19,9 @@ auto operator<<(std::ostream& out, const TokenCat& rhs) -> std::ostream& {
   case TokenCat::Identifier:
     out << "identifier";
     break;
+  case TokenCat::Comment:
+    out << "comment";
+    break;
   case TokenCat::Error:
     out << "error";
     break;
@@ -74,6 +77,8 @@ auto lookupCat(const TokenKind kind) -> TokenCat {
   case TokenKind::Identifier:
   case TokenKind::Discard:
     return TokenCat::Identifier;
+  case TokenKind::LineComment:
+    return TokenCat::Comment;
   case TokenKind::Error:
     return TokenCat::Error;
   case TokenKind::End:

--- a/src/lex/token_kind.cpp
+++ b/src/lex/token_kind.cpp
@@ -118,6 +118,9 @@ auto operator<<(std::ostream& out, const TokenKind& rhs) -> std::ostream& {
   case TokenKind::Identifier:
     out << "identifier";
     break;
+  case TokenKind::LineComment:
+    out << "line-comment";
+    break;
   case TokenKind::Error:
     out << "error";
     break;

--- a/src/parse/node_comment.cpp
+++ b/src/parse/node_comment.cpp
@@ -1,0 +1,36 @@
+#include "parse/node_comment.hpp"
+#include "utilities.hpp"
+
+namespace parse {
+
+CommentNode::CommentNode(lex::Token comment) : m_comment{std::move(comment)} {}
+
+auto CommentNode::operator==(const Node& rhs) const noexcept -> bool {
+  const auto r = dynamic_cast<const CommentNode*>(&rhs);
+  return r != nullptr && m_comment == r->m_comment;
+}
+
+auto CommentNode::operator!=(const Node& rhs) const noexcept -> bool {
+  return !CommentNode::operator==(rhs);
+}
+
+auto CommentNode::operator[](unsigned int /* unused */) const -> const Node& {
+  throw std::out_of_range("No child at given index");
+}
+
+auto CommentNode::getChildCount() const -> unsigned int { return 0; }
+
+auto CommentNode::getSpan() const -> input::Span { return m_comment.getSpan(); }
+
+auto CommentNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
+
+auto CommentNode::print(std::ostream& out) const -> std::ostream& {
+  return out << "// " << m_comment;
+}
+
+// Factories.
+auto commentNode(lex::Token comment) -> NodePtr {
+  return std::unique_ptr<CommentNode>{new CommentNode{std::move(comment)}};
+}
+
+} // namespace parse

--- a/src/parse/node_visitor_deep.cpp
+++ b/src/parse/node_visitor_deep.cpp
@@ -9,6 +9,8 @@ static auto visitChildren(const Node* n, DeepNodeVisitor* visitor) {
   }
 }
 
+auto DeepNodeVisitor::visit(const CommentNode& n) -> void { visitChildren(&n, this); }
+
 auto DeepNodeVisitor::visit(const ErrorNode& n) -> void { visitChildren(&n, this); }
 
 auto DeepNodeVisitor::visit(const BinaryExprNode& n) -> void { visitChildren(&n, this); }

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -30,6 +30,10 @@ auto ParserImpl::nextStmt() -> NodePtr {
     }
   }
 
+  if (peekToken(0).getKind() == lex::TokenKind::LineComment) {
+    return nextComment();
+  }
+
   return nextStmtExec();
 }
 
@@ -39,6 +43,8 @@ auto ParserImpl::nextExpr() -> NodePtr {
   }
   return nextExpr(0);
 }
+
+auto ParserImpl::nextComment() -> NodePtr { return commentNode(consumeToken()); }
 
 auto ParserImpl::nextStmtFuncDecl() -> NodePtr {
   auto kw       = consumeToken();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(tests
   input/span_test.cpp
 
   lex/category_test.cpp
+  lex/comment_test.cpp
   lex/identifier_test.cpp
   lex/iterator_test.cpp
   lex/keyword_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(tests
   lex/seperators_test.cpp
   lex/utilities_test.cpp
 
+  parse/comment_test.cpp
   parse/error_test.cpp
   parse/expr_binary_test.cpp
   parse/expr_call_test.cpp

--- a/tests/lex/comment_test.cpp
+++ b/tests/lex/comment_test.cpp
@@ -1,0 +1,27 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "lex/error.hpp"
+
+namespace lex {
+
+TEST_CASE("Lexing comments", "[lex]") {
+
+  SECTION("Valid") {
+    CHECK_TOKENS("//hello world", lineCommentToken("hello world"));
+    CHECK_TOKENS("// hello world", lineCommentToken(" hello world"));
+    CHECK_TOKENS("// hello \" world \" !@#", lineCommentToken(" hello \" world \" !@#"));
+    CHECK_TOKENS("// hello\n 42 ", lineCommentToken(" hello"), litIntToken(42));
+  }
+
+  SECTION("Sequences") {
+    CHECK_TOKENS("// hello\n// world ", lineCommentToken(" hello"), lineCommentToken(" world "));
+    CHECK_TOKENS("// hello\n 42 ", lineCommentToken(" hello"), litIntToken(42));
+  }
+
+  SECTION("Spans") {
+    CHECK_SPANS("// hello world ", input::Span{0, 14});
+    CHECK_SPANS(" // hello\n// world ", input::Span{1, 9});
+  }
+}
+
+} // namespace lex

--- a/tests/parse/comment_test.cpp
+++ b/tests/parse/comment_test.cpp
@@ -1,0 +1,28 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "parse/error.hpp"
+#include "parse/node_comment.hpp"
+
+namespace parse {
+
+TEST_CASE("Parsing comments", "[parse]") {
+
+  CHECK_STMT("// Hello world", commentNode(COMMENT(" Hello world")));
+  CHECK_STMT(
+      "// Hello\n"
+      "struct s = int a\n"
+      "// World",
+      commentNode(COMMENT(" Hello")),
+      structDeclStmtNode(
+          STRUCT,
+          ID("s"),
+          std::nullopt,
+          EQ,
+          {StructDeclStmtNode::FieldSpec(TYPE("int"), ID("a"))},
+          COMMAS(0)),
+      commentNode(COMMENT(" World")));
+
+  SECTION("Spans") { CHECK_STMT_SPAN(" // Hello world ", input::Span(1, 15)); }
+}
+
+} // namespace parse

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -54,6 +54,7 @@ namespace parse {
 #define END lex::endToken()
 
 #define ID(ID) lex::identiferToken(ID)
+#define COMMENT(MSG) lex::lineCommentToken(MSG)
 #define TYPE(NAME, ...)                                                                            \
   NUM_ARGS(__VA_ARGS__) == 0                                                                       \
       ? Type(ID(NAME))                                                                             \


### PR DESCRIPTION
Adds support for top-level line comments.
```
// Top level comments
// are now
print("supported")
```
Comments are added to the parse-tree, reason is that that way we preserve all tokens in the parse-tree which will make it easier for future tooling.
That is also the reason why only root-level comments are supported, that and the fact that comments inside statements are ugly :).