### PR TITLE
Infer template types in struct constructors based on args

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(frontend STATIC
   frontend/internal/func_template.cpp
   frontend/internal/type_substitution_table.cpp
   frontend/internal/typeinfer_expr.cpp
+  frontend/internal/typeinfer_typesub.cpp
   frontend/internal/typeinfer_user_funcs.cpp
   frontend/internal/union_template.cpp
   frontend/internal/utilities.cpp

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -64,7 +64,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   }
 
   // For conversions validate that correct types are returned.
-  const auto isConv = isConversion(m_context, name);
+  const auto isConv = isType(m_context, name);
   if (isConv) {
     const auto nonTemplConvType = m_context->getProg()->lookupType(name);
     if (nonTemplConvType) {

--- a/src/frontend/internal/func_template.hpp
+++ b/src/frontend/internal/func_template.hpp
@@ -42,9 +42,6 @@ private:
 
   [[nodiscard]] auto createSubTable(const prog::sym::TypeSet& typeParams) const
       -> TypeSubstitutionTable;
-
-  [[nodiscard]] auto inferSubType(const std::string& subType, const prog::sym::TypeSet& argTypes)
-      -> std::optional<prog::sym::TypeId>;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/func_template_table.cpp
+++ b/src/frontend/internal/func_template_table.cpp
@@ -43,11 +43,9 @@ auto FuncTemplateTable::inferParamsAndInstantiate(
   }
   auto result = std::vector<const FuncTemplateInst*>{};
   for (auto& funcTemplate : itr->second) {
-    if (funcTemplate.getArgumentCount() == argTypes.getCount()) {
-      const auto inferredTypeParams = funcTemplate.inferTypeParams(argTypes);
-      if (inferredTypeParams) {
-        result.push_back(funcTemplate.instantiate(*inferredTypeParams));
-      }
+    const auto inferredTypeParams = funcTemplate.inferTypeParams(argTypes);
+    if (inferredTypeParams) {
+      result.push_back(funcTemplate.instantiate(*inferredTypeParams));
     }
   }
   return result;

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -73,8 +73,6 @@ private:
 
   [[nodiscard]] auto isExhaustive(const std::vector<prog::expr::NodePtr>& conditions) const -> bool;
 
-  [[nodiscard]] auto isType(const std::string& name) const -> bool;
-
   [[nodiscard]] auto getFunctionsInclConversions(
       const lex::Token& nameToken,
       const std::optional<parse::TypeParamList>& typeParams,

--- a/src/frontend/internal/struct_template.hpp
+++ b/src/frontend/internal/struct_template.hpp
@@ -17,6 +17,9 @@ public:
 
   StructTemplate() = delete;
 
+  [[nodiscard]] auto inferTypeParams(const prog::sym::TypeSet& constructorArgTypes)
+      -> std::optional<prog::sym::TypeSet> override;
+
 private:
   const parse::StructDeclStmtNode& m_parseNode;
 

--- a/src/frontend/internal/type_template_base.hpp
+++ b/src/frontend/internal/type_template_base.hpp
@@ -19,7 +19,10 @@ public:
   [[nodiscard]] auto getTemplateName() const -> const std::string&;
   [[nodiscard]] auto getTypeParamCount() const -> unsigned int;
 
-  auto instantiate(const prog::sym::TypeSet& typeParams) -> const TypeTemplateInst*;
+  [[nodiscard]] virtual auto inferTypeParams(const prog::sym::TypeSet& constructorArgTypes)
+      -> std::optional<prog::sym::TypeSet> = 0;
+
+  [[nodiscard]] auto instantiate(const prog::sym::TypeSet& typeParams) -> const TypeTemplateInst*;
 
 protected:
   TypeTemplateBase(Context* context, std::string name, std::vector<std::string> typeSubs);

--- a/src/frontend/internal/type_template_table.hpp
+++ b/src/frontend/internal/type_template_table.hpp
@@ -35,6 +35,10 @@ public:
   [[nodiscard]] auto instantiate(const std::string& name, const prog::sym::TypeSet& typeParams)
       -> std::optional<const TypeTemplateInst*>;
 
+  [[nodiscard]] auto
+  inferParamsAndInstantiate(const std::string& name, const prog::sym::TypeSet& constructorArgTypes)
+      -> std::optional<const TypeTemplateInst*>;
+
 private:
   std::unordered_map<std::string, StructTemplate> m_structs;
   std::unordered_map<std::string, UnionTemplate> m_unions;
@@ -49,6 +53,13 @@ private:
       std::unordered_map<std::string, T>* templates,
       const std::string& name,
       const prog::sym::TypeSet& typeParams) const -> std::optional<const TypeTemplateInst*>;
+
+  template <typename T>
+  auto inferParamsAndInstantiate(
+      std::unordered_map<std::string, T>* templates,
+      const std::string& name,
+      const prog::sym::TypeSet& constructorArgTypes) const
+      -> std::optional<const TypeTemplateInst*>;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_typesub.cpp
+++ b/src/frontend/internal/typeinfer_typesub.cpp
@@ -1,0 +1,44 @@
+#include "typeinfer_typesub.hpp"
+
+namespace frontend::internal {
+
+auto getPathsToTypeSub(
+    const std::string& subType, const parse::Type& parsetype, const TypePath& path)
+    -> std::vector<TypePath> {
+  if (getName(parsetype.getId()) == subType) {
+    return {path};
+  }
+  std::vector<TypePath> result = {};
+  const auto* paramList        = parsetype.getParamList();
+  if (paramList != nullptr) {
+    for (auto paramInd = 0U; paramInd != paramList->getCount(); ++paramInd) {
+      auto childPath = path;
+      childPath.push_back(paramInd);
+      auto childResult = getPathsToTypeSub(subType, (*paramList)[paramInd], childPath);
+      result.insert(result.end(), childResult.begin(), childResult.end());
+    }
+  }
+  return result;
+}
+
+auto resolvePathToTypeSub(
+    const Context& context,
+    TypePath::const_iterator begin,
+    TypePath::const_iterator end,
+    prog::sym::TypeId type) -> std::optional<prog::sym::TypeId> {
+  if (begin == end) {
+    return type;
+  }
+  const auto info = context.getTypeInfo(type);
+  if (!info || !info->hasParams()) {
+    return std::nullopt;
+  }
+  const auto& params = *info->getParams();
+  const auto index   = *begin;
+  if (index >= params.getCount()) {
+    return std::nullopt;
+  }
+  return resolvePathToTypeSub(context, ++begin, end, params[index]);
+}
+
+} // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_typesub.hpp
+++ b/src/frontend/internal/typeinfer_typesub.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include "internal/utilities.hpp"
+#include "parse/type_param_list.hpp"
+
+namespace frontend::internal {
+
+using TypePath = typename std::vector<unsigned int>;
+
+[[nodiscard]] auto
+getPathsToTypeSub(const std::string& subType, const parse::Type& parsetype, const TypePath& path)
+    -> std::vector<TypePath>;
+
+[[nodiscard]] auto resolvePathToTypeSub(
+    const Context& context,
+    TypePath::const_iterator begin,
+    TypePath::const_iterator end,
+    prog::sym::TypeId type) -> std::optional<prog::sym::TypeId>;
+
+template <typename TypeSpec>
+[[nodiscard]] auto inferSubTypeFromSpecs(
+    const Context& context,
+    const std::string& subType,
+    const std::vector<TypeSpec>& typeSpecs,
+    const prog::sym::TypeSet& inputTypes) -> std::optional<prog::sym::TypeId> {
+
+  /* Given a set of type specifications (like a argument list of a function or a field list of a
+  struct) this will attempt to infer the type of the given substitution based on a set of input
+  types. */
+
+  std::optional<prog::sym::TypeId> result = std::nullopt;
+  for (auto typeInd = 0U; typeInd != typeSpecs.size(); ++typeInd) {
+    const auto& typeSpec = typeSpecs[typeInd];
+    for (const auto& path : getPathsToTypeSub(subType, typeSpec.getType(), {})) {
+      const auto& inferredType =
+          resolvePathToTypeSub(context, path.begin(), path.end(), inputTypes[typeInd]);
+      if (!inferredType) {
+        return std::nullopt;
+      }
+      if (!result) {
+        result = inferredType;
+      } else if (result != inferredType) {
+        return std::nullopt;
+      }
+    }
+  }
+  return result;
+}
+
+} // namespace frontend::internal

--- a/src/frontend/internal/union_template.cpp
+++ b/src/frontend/internal/union_template.cpp
@@ -11,6 +11,12 @@ UnionTemplate::UnionTemplate(
     const parse::UnionDeclStmtNode& parseNode) :
     TypeTemplateBase{context, std::move(name), std::move(typeSubs)}, m_parseNode{parseNode} {}
 
+auto UnionTemplate::inferTypeParams(const prog::sym::TypeSet & /* unused */)
+    -> std::optional<prog::sym::TypeSet> {
+  // Not implemented atm.
+  return std::nullopt;
+}
+
 auto UnionTemplate::setupInstance(TypeTemplateInst* instance) -> void {
   const auto mangledName = mangleName(getContext(), getTemplateName(), instance->m_typeParams);
   const auto subTable    = createSubTable(instance->m_typeParams);

--- a/src/frontend/internal/union_template.hpp
+++ b/src/frontend/internal/union_template.hpp
@@ -16,6 +16,9 @@ public:
 
   UnionTemplate() = delete;
 
+  [[nodiscard]] auto inferTypeParams(const prog::sym::TypeSet& constructorArgTypes)
+      -> std::optional<prog::sym::TypeSet> override;
+
 private:
   const parse::UnionDeclStmtNode& m_parseNode;
 

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -100,9 +100,22 @@ namespace frontend::internal {
   return "__unknown";
 }
 
+[[nodiscard]] auto getOrInstType(
+    Context* context,
+    const TypeSubstitutionTable* subTable,
+    const lex::Token& nameToken,
+    const std::optional<parse::TypeParamList>& typeParams,
+    const prog::sym::TypeSet& constructorArgs) -> std::optional<prog::sym::TypeId>;
+
 [[nodiscard]] auto
 getOrInstType(Context* context, const TypeSubstitutionTable* subTable, const parse::Type& parseType)
     -> std::optional<prog::sym::TypeId>;
+
+[[nodiscard]] auto instType(
+    Context* context,
+    const TypeSubstitutionTable* subTable,
+    const lex::Token& nameToken,
+    const parse::TypeParamList& typeParams) -> std::optional<prog::sym::TypeId>;
 
 [[nodiscard]] auto getRetType(
     Context* context, const TypeSubstitutionTable* subTable, const parse::FuncDeclStmtNode& n)
@@ -138,6 +151,6 @@ getSubstitutionParams(Context* context, const parse::TypeSubstitutionList& subLi
 mangleName(Context* context, const std::string& name, const prog::sym::TypeSet& typeParams)
     -> std::string;
 
-[[nodiscard]] auto isConversion(Context* context, const std::string& name) -> bool;
+[[nodiscard]] auto isType(Context* context, const std::string& name) -> bool;
 
 } // namespace frontend::internal

--- a/tests/frontend/define_user_types_test.cpp
+++ b/tests/frontend/define_user_types_test.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Analyzing user-type definitions", "[frontend]") {
         "struct s{T} = T T "
         "struct s2 = s{int} s",
         errFieldNameConflictsWithTypeSubstitution(src, "T", input::Span{16, 16}),
-        errInvalidTypeInstantiation(src, input::Span{30, 35}));
+        errInvalidTypeInstantiation(src, input::Span{30, 30}));
   }
 
   SECTION("Union diagnostics") {

--- a/tests/frontend/user_type_templates_test.cpp
+++ b/tests/frontend/user_type_templates_test.cpp
@@ -32,6 +32,28 @@ TEST_CASE("Analyzing user-type templates", "[frontend]") {
             std::move(fArgs)));
   }
 
+  SECTION("Construct templated type with inferred type params") {
+    const auto& output = ANALYZE("struct tuple{T1, T2} = T1 a, T2 b "
+                                 "fun f() tuple(1, \"hello world\")");
+    REQUIRE(output.isSuccess());
+
+    const auto& fDef = GET_FUNC_DEF(output, "f");
+    auto fArgs       = std::vector<prog::expr::NodePtr>{};
+    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
+    fArgs.push_back(prog::expr::litStringNode(output.getProg(), "hello world"));
+
+    CHECK(
+        fDef.getExpr() ==
+        *prog::expr::callExprNode(
+            output.getProg(),
+            GET_FUNC_ID(
+                output,
+                "tuple__int_string",
+                GET_TYPE_ID(output, "int"),
+                GET_TYPE_ID(output, "string")),
+            std::move(fArgs)));
+  }
+
   SECTION("Conversion to templated type") {
     const auto& output = ANALYZE("struct tuple{T1, T2} = T1 a, T2 b "
                                  "fun tuple{T}(T a) tuple{T, bool}(a, false) "


### PR DESCRIPTION
When calling a templated struct constructor without explicit type parameters attempt to infer the type parameters based on the constructor args (struct fields).
```
struct Pair{T1, T2} = T1 a, T2 b

fun add{T1, T2}(Pair{T1, T2} p)
  p.a + p.b

print(add(Pair(1, 2))           + "\n")
print(add(Pair(-.14, .9))       + "\n")
print(add(Pair(13, "hello"))    + "\n")

fun +{T1, T2}(Pair{T1, T2} p1, Pair{T1, T2} p2)
  Pair(p1.a + p2.a, p1.b + p2.b)

print(add(Pair(-.14, .9) + Pair(1.1, 32.76)) + "\n")
```