### PR TITLE
Infer type parameters in union constructor calls

### DIFF
--- a/src/frontend/internal/typeinfer_typesub.hpp
+++ b/src/frontend/internal/typeinfer_typesub.hpp
@@ -23,6 +23,10 @@ template <typename TypeSpec>
     const std::vector<TypeSpec>& typeSpecs,
     const prog::sym::TypeSet& inputTypes) -> std::optional<prog::sym::TypeId> {
 
+  if (typeSpecs.size() != inputTypes.getCount()) {
+    throw std::invalid_argument{"Amount of type specifications and input types have to match"};
+  }
+
   /* Given a set of type specifications (like a argument list of a function or a field list of a
   struct) this will attempt to infer the type of the given substitution based on a set of input
   types. */

--- a/src/frontend/internal/union_template.hpp
+++ b/src/frontend/internal/union_template.hpp
@@ -29,6 +29,9 @@ private:
       const parse::UnionDeclStmtNode& parseNode);
 
   auto setupInstance(TypeTemplateInst* instance) -> void override;
+
+  [[nodiscard]] auto inferSubType(const std::string& subType, const prog::sym::TypeId& inputType)
+      -> std::optional<prog::sym::TypeId>;
 };
 
 } // namespace frontend::internal

--- a/tests/frontend/user_type_templates_test.cpp
+++ b/tests/frontend/user_type_templates_test.cpp
@@ -10,7 +10,7 @@ namespace frontend {
 
 TEST_CASE("Analyzing user-type templates", "[frontend]") {
 
-  SECTION("Construct templated type") {
+  SECTION("Construct templated struct") {
     const auto& output = ANALYZE("struct tuple{T1, T2} = T1 a, T2 b "
                                  "fun f() tuple{int, string}(1, \"hello world\")");
     REQUIRE(output.isSuccess());
@@ -32,7 +32,25 @@ TEST_CASE("Analyzing user-type templates", "[frontend]") {
             std::move(fArgs)));
   }
 
-  SECTION("Construct templated type with inferred type params") {
+  SECTION("Construct templated union") {
+    const auto& output = ANALYZE("struct none "
+                                 "union opt{T} = T, none "
+                                 "fun f() opt{int}(1)");
+    REQUIRE(output.isSuccess());
+
+    const auto& fDef = GET_FUNC_DEF(output, "f");
+    auto fArgs       = std::vector<prog::expr::NodePtr>{};
+    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
+
+    CHECK(
+        fDef.getExpr() ==
+        *prog::expr::callExprNode(
+            output.getProg(),
+            GET_FUNC_ID(output, "opt__int", GET_TYPE_ID(output, "int")),
+            std::move(fArgs)));
+  }
+
+  SECTION("Construct templated struct with inferred type params") {
     const auto& output = ANALYZE("struct tuple{T1, T2} = T1 a, T2 b "
                                  "fun f() tuple(1, \"hello world\")");
     REQUIRE(output.isSuccess());
@@ -54,7 +72,25 @@ TEST_CASE("Analyzing user-type templates", "[frontend]") {
             std::move(fArgs)));
   }
 
-  SECTION("Conversion to templated type") {
+  SECTION("Construct templated union with inferred type param") {
+    const auto& output = ANALYZE("struct none "
+                                 "union opt{T} = T, none "
+                                 "fun f() opt(1)");
+    REQUIRE(output.isSuccess());
+
+    const auto& fDef = GET_FUNC_DEF(output, "f");
+    auto fArgs       = std::vector<prog::expr::NodePtr>{};
+    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
+
+    CHECK(
+        fDef.getExpr() ==
+        *prog::expr::callExprNode(
+            output.getProg(),
+            GET_FUNC_ID(output, "opt__int", GET_TYPE_ID(output, "int")),
+            std::move(fArgs)));
+  }
+
+  SECTION("Conversion to templated struct") {
     const auto& output = ANALYZE("struct tuple{T1, T2} = T1 a, T2 b "
                                  "fun tuple{T}(T a) tuple{T, bool}(a, false) "
                                  "fun f() tuple{int}(1)");


### PR DESCRIPTION
When calling a templated union constructor without explicit type parameters attempt to infer the type parameters based on the constructor arg.
```
struct None
union Option{T} = T, None

fun add{T}(Option{T} a, Option{T} b)
  a is T aVal && b is T bVal ? aVal + bVal : T()

print(add(Option(45), Option(1.0)))
```