### PR TITLE
Add identity conversions

### DIFF
--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -3,6 +3,7 @@
 namespace prog::sym {
 
 enum class FuncKind {
+  NoOp,
   User,
 
   AddInt,

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -70,6 +70,17 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
 
   // Either call the user function or the appropriate build-in instruction.
   switch (funcDecl.getKind()) {
+  case prog::sym::FuncKind::NoOp:
+    // Make sure exactly one value is produced on the stack (insert placeholder if function takes no
+    // arguments and add pops if function takes more then 1 argument).
+    if (n.getChildCount() == 0) {
+      m_builder->addLoadLitInt(0);
+    } else {
+      for (auto i = 1U; i < n.getChildCount(); ++i) {
+        m_builder->addPop();
+      }
+    }
+    break;
   case prog::sym::FuncKind::User:
     m_builder->addCall(getLabel(funcDecl.getId()));
     break;

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -111,6 +111,12 @@ Program::Program() :
   m_funcDecls.registerFunc(*this, fk::ConvFloatString, "string", sym::TypeSet{m_float}, m_string);
   m_funcDecls.registerFunc(*this, fk::ConvBoolString, "string", sym::TypeSet{m_bool}, m_string);
 
+  // Register build-in identity conversions (turn into no-ops).
+  m_funcDecls.registerFunc(*this, fk::NoOp, "int", sym::TypeSet{m_int}, m_int);
+  m_funcDecls.registerFunc(*this, fk::NoOp, "float", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerFunc(*this, fk::NoOp, "bool", sym::TypeSet{m_bool}, m_bool);
+  m_funcDecls.registerFunc(*this, fk::NoOp, "string", sym::TypeSet{m_string}, m_string);
+
   // Register build-in explicit conversions.
   m_funcDecls.registerFunc(*this, fk::ConvFloatInt, "toInt", sym::TypeSet{m_float}, m_int);
 

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -282,6 +282,19 @@ TEST_CASE("Generate assembly for call expressions", "[backend]") {
           builder->addEntryPoint("print");
         });
   }
+
+  SECTION("Identity conversions") {
+    CHECK_EXPR_INT(
+        "int(42)", [](backend::Builder* builder) -> void { builder->addLoadLitInt(42); });
+    CHECK_EXPR_FLOAT("float(42.1337)", [](backend::Builder* builder) -> void {
+      builder->addLoadLitFloat(42.1337F); // NOLINT: Magic numbers
+    });
+    CHECK_EXPR_BOOL(
+        "bool(false)", [](backend::Builder* builder) -> void { builder->addLoadLitInt(0); });
+    CHECK_EXPR_STRING("string(\"hello world\")", [](backend::Builder* builder) -> void {
+      builder->addLoadLitString("hello world");
+    });
+  }
 }
 
 } // namespace backend

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -64,8 +64,8 @@ TEST_CASE("Analyzing user-function definitions", "[frontend]") {
         errConstNameConflictsWithConst(src, "a", input::Span{17, 17}));
     CHECK_DIAG("fun f() -> int f2()", errUndeclaredFunc(src, "f2", {}, input::Span{15, 18}));
     CHECK_DIAG(
-        "fun f() -> int int(1)",
-        errUndeclaredTypeOrConversion(src, "int", {"int"}, input::Span{15, 20}));
+        "fun f() -> int bool(1)",
+        errUndeclaredTypeOrConversion(src, "bool", {"int"}, input::Span{15, 21}));
     CHECK_DIAG(
         "fun f() -> int int{float}()",
         errNoTypeOrConversionFoundToInstantiate(src, "int", 1, input::Span{15, 26}));


### PR DESCRIPTION
Useful for function templates, without them the second call in the example below would fail:
```
fun f{T}(string prefix, T val)
  prefix + string(val)

print(f("int: ", 42)                + "\n")
print(f("string: ", "hello world")  + "\n")
```
No code is actually generated for them.