### PR TITLE
Feature/tail calls

### DIFF
--- a/include/backend/builder.hpp
+++ b/include/backend/builder.hpp
@@ -68,10 +68,8 @@ public:
   auto addJump(std::string label) -> void;
   auto addJumpIf(std::string label) -> void;
 
-  auto addCall(std::string label) -> void;
-  auto addCallTail(std::string label) -> void;
-  auto addCallDyn() -> void;
-  auto addCallDynTail() -> void;
+  auto addCall(std::string label, bool tail) -> void;
+  auto addCallDyn(bool tail) -> void;
   auto addRet() -> void;
 
   auto addDup() -> void;

--- a/include/backend/builder.hpp
+++ b/include/backend/builder.hpp
@@ -69,7 +69,9 @@ public:
   auto addJumpIf(std::string label) -> void;
 
   auto addCall(std::string label) -> void;
+  auto addCallTail(std::string label) -> void;
   auto addCallDyn() -> void;
+  auto addCallDynTail() -> void;
   auto addRet() -> void;
 
   auto addDup() -> void;

--- a/include/vm/opcode.hpp
+++ b/include/vm/opcode.hpp
@@ -56,9 +56,11 @@ enum class OpCode : uint8_t {
   Jump   = 220,
   JumpIf = 221,
 
-  Call    = 230,
-  CallDyn = 231,
-  Ret     = 232,
+  Call        = 230,
+  CallTail    = 231,
+  CallDyn     = 232,
+  CallDynTail = 233,
+  Ret         = 234,
 
   Dup = 240,
   Pop = 241,

--- a/src/backend/builder.cpp
+++ b/src/backend/builder.cpp
@@ -159,7 +159,14 @@ auto Builder::addCall(std::string label) -> void {
   writeIpOffset(std::move(label));
 }
 
+auto Builder::addCallTail(std::string label) -> void {
+  writeOpCode(vm::OpCode::CallTail);
+  writeIpOffset(std::move(label));
+}
+
 auto Builder::addCallDyn() -> void { writeOpCode(vm::OpCode::CallDyn); }
+
+auto Builder::addCallDynTail() -> void { writeOpCode(vm::OpCode::CallDynTail); }
 
 auto Builder::addRet() -> void { writeOpCode(vm::OpCode::Ret); }
 

--- a/src/backend/builder.cpp
+++ b/src/backend/builder.cpp
@@ -154,19 +154,14 @@ auto Builder::addJumpIf(std::string label) -> void {
   writeIpOffset(std::move(label));
 }
 
-auto Builder::addCall(std::string label) -> void {
-  writeOpCode(vm::OpCode::Call);
+auto Builder::addCall(std::string label, bool tail) -> void {
+  writeOpCode(tail ? vm::OpCode::CallTail : vm::OpCode::Call);
   writeIpOffset(std::move(label));
 }
 
-auto Builder::addCallTail(std::string label) -> void {
-  writeOpCode(vm::OpCode::CallTail);
-  writeIpOffset(std::move(label));
+auto Builder::addCallDyn(bool tail) -> void {
+  writeOpCode(tail ? vm::OpCode::CallDynTail : vm::OpCode::CallDyn);
 }
-
-auto Builder::addCallDyn() -> void { writeOpCode(vm::OpCode::CallDyn); }
-
-auto Builder::addCallDynTail() -> void { writeOpCode(vm::OpCode::CallDynTail); }
 
 auto Builder::addRet() -> void { writeOpCode(vm::OpCode::Ret); }
 

--- a/src/backend/dasm/disassembler.cpp
+++ b/src/backend/dasm/disassembler.cpp
@@ -58,6 +58,7 @@ auto disassembleInstructions(const vm::Assembly& assembly) -> std::vector<Instru
     case vm::OpCode::ConvFloatString:
     case vm::OpCode::PrintString:
     case vm::OpCode::CallDyn:
+    case vm::OpCode::CallDynTail:
     case vm::OpCode::Ret:
     case vm::OpCode::Fail:
     case vm::OpCode::Dup:
@@ -69,6 +70,7 @@ auto disassembleInstructions(const vm::Assembly& assembly) -> std::vector<Instru
     case vm::OpCode::Jump:
     case vm::OpCode::JumpIf:
     case vm::OpCode::Call:
+    case vm::OpCode::CallTail:
       result.push_back(Instruction(opCode, ipOffset, {assembly.readUInt32(ipOffset + 1)}));
       ipOffset += 4;
       continue;

--- a/src/backend/generator.cpp
+++ b/src/backend/generator.cpp
@@ -35,9 +35,10 @@ generateFunc(Builder* builder, const prog::Program& program, const prog::sym::Fu
   }
 
   // Generate the function body.
-  auto genExpr = internal::GenExpr{program, builder};
+  auto genExpr = internal::GenExpr{program, builder, true};
   func.getExpr().accept(&genExpr);
 
+  // Note: Due to tail calls this return might never be executed.
   builder->addRet();
   builder->addFail(); // Add a fail between sections to aid in detecting invalid programs.
 }
@@ -51,7 +52,7 @@ generateExecStmt(Builder* builder, const prog::Program& program, const prog::sym
 
   // Generate the arguments to the action.
   for (const auto& arg : exec.getArgs()) {
-    auto genExpr = internal::GenExpr{program, builder};
+    auto genExpr = internal::GenExpr{program, builder, false};
     arg->accept(&genExpr);
   }
 

--- a/src/backend/internal/gen_expr.hpp
+++ b/src/backend/internal/gen_expr.hpp
@@ -7,7 +7,7 @@ namespace backend::internal {
 
 class GenExpr final : public prog::expr::NodeVisitor {
 public:
-  GenExpr(const prog::Program& program, Builder* builder);
+  GenExpr(const prog::Program& program, Builder* builder, bool tail);
 
   auto visit(const prog::expr::AssignExprNode& n) -> void override;
   auto visit(const prog::expr::SwitchExprNode& n) -> void override;
@@ -29,8 +29,9 @@ public:
 private:
   const prog::Program& m_program;
   Builder* m_builder;
+  bool m_tail;
 
-  auto genSubExpr(const prog::expr::Node& n) -> void;
+  auto genSubExpr(const prog::expr::Node& n, bool tail) -> void;
 };
 
 } // namespace backend::internal

--- a/src/backend/internal/gen_type_eq.cpp
+++ b/src/backend/internal/gen_type_eq.cpp
@@ -33,7 +33,7 @@ static auto generateStructFieldEquality(
     break;
   case prog::sym::TypeKind::UserStruct:
   case prog::sym::TypeKind::UserUnion:
-    builder->addCall(getUserTypeEqLabel(typeDecl.getId()));
+    builder->addCall(getUserTypeEqLabel(typeDecl.getId()), false);
     break;
   }
 

--- a/src/vm/internal/exec_scope.cpp
+++ b/src/vm/internal/exec_scope.cpp
@@ -29,9 +29,16 @@ auto ExecScope::readFloat() -> float {
 }
 
 auto ExecScope::reserveConsts(ConstStack* stack, unsigned int amount) -> void {
-  assert(m_constsPtr == nullptr);
-  m_constsCount = amount;
-  m_constsPtr   = stack->reserve(amount);
+  if (m_constsPtr == nullptr) {
+    m_constsCount = amount;
+    m_constsPtr   = stack->reserve(amount);
+  } else {
+    const auto extraAmount = amount - m_constsCount;
+    if (extraAmount > 0) {
+      m_constsCount = amount;
+      stack->reserve(extraAmount);
+    }
+  }
 }
 
 auto ExecScope::releaseConsts(ConstStack* stack) -> void {

--- a/src/vm/opcode.cpp
+++ b/src/vm/opcode.cpp
@@ -141,8 +141,14 @@ auto operator<<(std::ostream& out, const OpCode& rhs) -> std::ostream& {
   case OpCode::Call:
     out << "call";
     break;
+  case OpCode::CallTail:
+    out << "call-tail";
+    break;
   case OpCode::CallDyn:
     out << "call-dyn";
+    break;
+  case OpCode::CallDynTail:
+    out << "call-dyn-tail";
     break;
   case OpCode::Ret:
     out << "ret";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(tests
   backend/group_expr_test.cpp
   backend/literals_test.cpp
   backend/switch_expr_test.cpp
+  backend/tail_calls_test.cpp
   backend/user_struct_test.cpp
   backend/user_union_test.cpp
 

--- a/tests/backend/call_dyn_expr_test.cpp
+++ b/tests/backend/call_dyn_expr_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Generate assembly for call dynamic expressions", "[backend]") {
           builder->addLoadLitInt(42);
           builder->addLoadLitInt(1337);
           builder->addLoadConst(0);
-          builder->addCallDyn();
+          builder->addCallDyn(false);
 
           builder->addConvIntString();
           builder->addPrintString();
@@ -66,7 +66,7 @@ TEST_CASE("Generate assembly for call dynamic expressions", "[backend]") {
       builder->addLoadLitIp("anon func");
       builder->addMakeStruct(2);
 
-      builder->addCallDyn();
+      builder->addCallDyn(false);
       builder->addConvIntString();
       builder->addPrintString();
       builder->addRet();
@@ -103,7 +103,7 @@ TEST_CASE("Generate assembly for call dynamic expressions", "[backend]") {
           builder->addLoadLitIp("anon func");
           builder->addMakeStruct(2);
 
-          builder->addCallDyn();
+          builder->addCallDyn(false);
           builder->addConvFloatString();
           builder->addPrintString();
           builder->addRet();

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -273,7 +273,7 @@ TEST_CASE("Generate assembly for call expressions", "[backend]") {
           builder->label("print");
           builder->addLoadLitInt(42);
           builder->addLoadLitInt(1337);
-          builder->addCall("test");
+          builder->addCall("test", false);
           builder->addConvIntString();
           builder->addPrintString();
           builder->addRet();

--- a/tests/backend/tail_calls_test.cpp
+++ b/tests/backend/tail_calls_test.cpp
@@ -1,0 +1,138 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+
+namespace backend {
+
+TEST_CASE("Generate assembly for tail calls", "[backend]") {
+
+  SECTION("Tail recursion") {
+    CHECK_PROG(
+        "fun test(int a) -> int a > 0 ? test(0) : a "
+        "print(string(test(42)))",
+        [](backend::Builder* builder) -> void {
+          builder->label("test");
+          builder->addReserveConsts(1);
+          builder->addStoreConst(0);
+          builder->addLoadConst(0);
+          builder->addLoadLitInt(0);
+          builder->addCheckGtInt();
+          builder->addJumpIf("true");
+
+          builder->addLoadConst(0);
+          builder->addJump("false");
+
+          builder->label("true");
+          builder->addLoadLitInt(0);
+          builder->addCall("test", true);
+
+          builder->label("false");
+          builder->addRet();
+          builder->addFail();
+
+          builder->label("print");
+          builder->addLoadLitInt(42);
+          builder->addCall("test", false);
+          builder->addConvIntString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+
+          builder->addEntryPoint("print");
+        });
+  }
+
+  SECTION("Tail call") {
+    CHECK_PROG(
+        "fun f1() -> int 42 "
+        "fun f2() -> int f1() "
+        "print(string(f2()))",
+        [](backend::Builder* builder) -> void {
+          builder->label("f2");
+          builder->addCall("f1", true);
+          builder->addRet();
+          builder->addFail();
+
+          builder->label("f1");
+          builder->addLoadLitInt(42);
+          builder->addRet();
+          builder->addFail();
+
+          builder->label("print");
+          builder->addCall("f2", false);
+          builder->addConvIntString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+
+          builder->addEntryPoint("print");
+        });
+  }
+
+  SECTION("Tail call at end of group expression") {
+    CHECK_PROG(
+        "fun f1(int i) -> int i "
+        "fun f2() -> int v = 42; f1(v) "
+        "print(string(f2()))",
+        [](backend::Builder* builder) -> void {
+          builder->label("f2");
+          builder->addReserveConsts(1);
+          builder->addLoadLitInt(42);
+          builder->addDup();
+          builder->addStoreConst(0);
+          builder->addPop();
+          builder->addLoadConst(0);
+          builder->addCall("f1", true);
+          builder->addRet();
+          builder->addFail();
+
+          builder->label("f1");
+          builder->addReserveConsts(1);
+          builder->addStoreConst(0);
+          builder->addLoadConst(0);
+          builder->addRet();
+          builder->addFail();
+
+          builder->label("print");
+          builder->addCall("f2", false);
+          builder->addConvIntString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+
+          builder->addEntryPoint("print");
+        });
+  }
+
+  SECTION("Dynamic tail call") {
+    CHECK_PROG(
+        "fun f1() -> int 42 "
+        "fun f2(delegate{int} func) -> int func() "
+        "print(string(f2(f1)))",
+        [](backend::Builder* builder) -> void {
+          builder->label("f2");
+          builder->addReserveConsts(1);
+          builder->addStoreConst(0);
+          builder->addLoadConst(0);
+          builder->addCallDyn(true);
+          builder->addRet();
+          builder->addFail();
+
+          builder->label("f1");
+          builder->addLoadLitInt(42);
+          builder->addRet();
+          builder->addFail();
+
+          builder->label("print");
+          builder->addLoadLitIp("f1");
+          builder->addCall("f2", false);
+          builder->addConvIntString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+
+          builder->addEntryPoint("print");
+        });
+  }
+}
+
+} // namespace backend

--- a/tests/backend/user_struct_test.cpp
+++ b/tests/backend/user_struct_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Generating assembly for user-structs", "[backend]") {
           builder->addMakeStruct(2);
 
           // Call the equality function and print the result.
-          builder->addCall("UserEq");
+          builder->addCall("UserEq", false);
           builder->addConvBoolString();
           builder->addPrintString();
           builder->addRet();

--- a/tests/backend/user_union_test.cpp
+++ b/tests/backend/user_union_test.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Generating assembly for user-unions", "[backend]") {
           builder->addMakeStruct(2);
 
           // Call equality function and print the result.
-          builder->addCall("ValEq");
+          builder->addCall("ValEq", false);
           builder->addConvBoolString();
           builder->addPrintString();
           builder->addRet();

--- a/tests/vm/call_test.cpp
+++ b/tests/vm/call_test.cpp
@@ -9,14 +9,14 @@ TEST_CASE("Execute calls", "[vm]") {
       [](backend::Builder* builder) -> void {
         builder->label("section1");
         builder->addLoadLitInt(0);
-        builder->addCall("section2");
+        builder->addCall("section2", false);
         builder->addConvIntString();
         builder->addPrintString();
         builder->addRet();
 
         builder->label("section2");
         builder->addJumpIf("section2-true");
-        builder->addCall("section3");
+        builder->addCall("section3", false);
         builder->addRet();
 
         builder->label("section2-true");
@@ -25,7 +25,7 @@ TEST_CASE("Execute calls", "[vm]") {
 
         builder->label("section3");
         builder->addLoadLitInt(1);
-        builder->addCall("section2");
+        builder->addCall("section2", false);
         builder->addRet();
 
         builder->addEntryPoint("section1");
@@ -36,14 +36,14 @@ TEST_CASE("Execute calls", "[vm]") {
       [](backend::Builder* builder) -> void {
         builder->label("section1");
         builder->addLoadLitInt(0);
-        builder->addCall("section2");
+        builder->addCall("section2", false);
         builder->addConvIntString();
         builder->addPrintString();
         builder->addRet();
 
         builder->label("section2");
         builder->addJumpIf("section2-true");
-        builder->addCallTail("section3");
+        builder->addCall("section3", true);
 
         builder->label("section2-true");
         builder->addLoadLitInt(1337);
@@ -51,7 +51,7 @@ TEST_CASE("Execute calls", "[vm]") {
 
         builder->label("section3");
         builder->addLoadLitInt(1);
-        builder->addCallTail("section2");
+        builder->addCall("section2", true);
 
         builder->addEntryPoint("section1");
       },
@@ -63,7 +63,7 @@ TEST_CASE("Execute calls", "[vm]") {
 
         // Call raw instruction pointer.
         builder->addLoadLitIp("section2");
-        builder->addCallDyn();
+        builder->addCallDyn(false);
 
         builder->addConvIntString();
         builder->addPrintString();
@@ -83,7 +83,7 @@ TEST_CASE("Execute calls", "[vm]") {
 
         // Call raw instruction pointer.
         builder->addLoadLitIp("section2");
-        builder->addCallDyn();
+        builder->addCallDyn(false);
 
         builder->addConvIntString();
         builder->addPrintString();
@@ -92,7 +92,7 @@ TEST_CASE("Execute calls", "[vm]") {
         builder->label("section2");
         builder->addLoadLitInt(1337);
         builder->addLoadLitIp("section3");
-        builder->addCallDynTail();
+        builder->addCallDyn(true);
 
         builder->label("section3");
         builder->addLoadLitInt(1337);
@@ -106,7 +106,7 @@ TEST_CASE("Execute calls", "[vm]") {
   CHECK_PROG(
       [](backend::Builder* builder) -> void {
         builder->label("section1");
-        builder->addCall("section2");
+        builder->addCall("section2", false);
         builder->addConvIntString();
         builder->addPrintString();
         builder->addRet();
@@ -117,7 +117,7 @@ TEST_CASE("Execute calls", "[vm]") {
         builder->addLoadLitInt(42);
         builder->addLoadLitIp("section3");
         builder->addMakeStruct(2);
-        builder->addCallDynTail();
+        builder->addCallDyn(true);
 
         builder->label("section3");
         builder->addLoadLitInt(1337);
@@ -138,7 +138,7 @@ TEST_CASE("Execute calls", "[vm]") {
         builder->addMakeStruct(2);
 
         // Call closure struct.
-        builder->addCallDyn();
+        builder->addCallDyn(false);
 
         builder->addConvIntString();
         builder->addPrintString();

--- a/tests/vm/consts_test.cpp
+++ b/tests/vm/consts_test.cpp
@@ -36,6 +36,29 @@ TEST_CASE("Execute constants", "[vm]") {
       },
       "42",
       "1337");
+
+  CHECK_EXPR(
+      [](backend::Builder* builder) -> void {
+        // First reserve one const.
+        builder->addReserveConsts(1);
+        builder->addLoadLitInt(42);
+        builder->addStoreConst(0);
+
+        // Now reserve two.
+        builder->addReserveConsts(2);
+        builder->addLoadLitInt(1337);
+        builder->addStoreConst(1);
+
+        builder->addLoadConst(0);
+        builder->addConvIntString();
+        builder->addPrintString();
+
+        builder->addLoadConst(1);
+        builder->addConvIntString();
+        builder->addPrintString();
+      },
+      "42",
+      "1337");
 }
 
 } // namespace vm

--- a/tests/vm/error_test.cpp
+++ b/tests/vm/error_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Runtime errors", "[vm]") {
     CHECK_PROG_THROWS(
         [](backend::Builder* builder) -> void {
           builder->label("func");
-          builder->addCall("func");
+          builder->addCall("func", false);
 
           builder->addEntryPoint("func");
         },
@@ -48,7 +48,7 @@ TEST_CASE("Runtime errors", "[vm]") {
         [](backend::Builder* builder) -> void {
           builder->label("func");
           builder->addReserveConsts(10);
-          builder->addCall("func");
+          builder->addCall("func", false);
 
           builder->addEntryPoint("func");
         },


### PR DESCRIPTION
This adds tail call optimisation, meaning that calls at the end of a function do not increase the call-stack but instead operate in the same stack frame. 

Consider the following program:
```
fun factorial(int n)
  factItr(1, n)

fun factItr(int product, int n)
  if n < 2  -> product
  else      -> factItr(product * n, n - 1)

print(
  "fact1: " + factorial(1) + "\n" +
  "fact2: " + factorial(2) + "\n" +
  "fact3: " + factorial(3) + "\n" +
  "fact4: " + factorial(4) + "\n" +
  "fact5: " + factorial(5) + "\n" +
  "fact6: " + factorial(6) + "\n" +
  "fact7: " + factorial(7) + "\n" +
  "fact8: " + factorial(8) + "\n" +
  "fact9: " + factorial(9) + "\n" +
  "fact10: " + factorial(10))
```
Both calls in the function happen at the end of the function, meaning they can be tail optimised.

Conceptually the `factItr` function turns into this:
```
fun factItr(int product, int n)
  while (n >= 2) {
    product = product * n
    n = n - 1
  }
``` 
The following instructions are generated for `factItr`:
```
  0    reserve-consts      2
  2    store-const         1
  4    store-const         0
  6    load-const          1
  8    load-int-small      2
  10   check-le-int        
  11   jump-if             35
  16   load-const          0
  18   load-const          1
  20   mul-int             
  21   load-const          1
  23   load-int-1          
  24   sub-int             
  25   call-tail           0
  30   jump                37
  35   load-const          0
  37   ret                 
  38   fail                
```
