### PR TITLE
Support hex literals

### DIFF
--- a/include/lex/error.hpp
+++ b/include/lex/error.hpp
@@ -11,6 +11,8 @@ namespace lex {
 
 [[nodiscard]] auto errLitNumberInvalidChar(input::Span span = input::Span{0}) -> Token;
 
+[[nodiscard]] auto errLitHexInvalidChar(input::Span span = input::Span{0}) -> Token;
+
 [[nodiscard]] auto errLitNumberEndsWithSeperator(input::Span span = input::Span{0}) -> Token;
 
 [[nodiscard]] auto errLitNumberEndsWithDecimalPoint(input::Span span = input::Span{0}) -> Token;

--- a/include/lex/lexer.hpp
+++ b/include/lex/lexer.hpp
@@ -19,6 +19,7 @@ private:
   std::deque<char> m_readBuffer;
 
   auto nextLitNumber(char mostSignficantChar) -> Token;
+  auto nextLitIntHex() -> Token;
   auto nextLitStr() -> Token;
   auto nextWordToken(char startingChar) -> Token;
   auto nextLineComment() -> Token;

--- a/src/lex/error.cpp
+++ b/src/lex/error.cpp
@@ -19,6 +19,10 @@ auto errLitNumberInvalidChar(const input::Span span) -> Token {
   return errorToken("Number literal contains an invalid character", span);
 }
 
+auto errLitHexInvalidChar(const input::Span span) -> Token {
+  return errorToken("Hex integer literal contains an invalid character", span);
+}
+
 auto errLitNumberEndsWithSeperator(const input::Span span) -> Token {
   return errorToken("Number literal ends with a seperator character", span);
 }

--- a/tests/lex/litint_test.cpp
+++ b/tests/lex/litint_test.cpp
@@ -13,15 +13,39 @@ TEST_CASE("Lexing integer literals", "[lex]") {
     CHECK_TOKENS("2147483647", litIntToken(2147483647));
   }
 
+  SECTION("Hex values") {
+    CHECK_TOKENS("0x", litIntToken(0));
+    CHECK_TOKENS("0X", litIntToken(0));
+    CHECK_TOKENS("0x0", litIntToken(0));
+    CHECK_TOKENS("0X0", litIntToken(0));
+    CHECK_TOKENS("0x4", litIntToken(0x4));
+    CHECK_TOKENS("0xF", litIntToken(0xF));
+    CHECK_TOKENS("0xFF", litIntToken(0xFF));
+    CHECK_TOKENS("0x7FFFFFFF", litIntToken(0x7FFFFFFF));
+    CHECK_TOKENS("0xf", litIntToken(0xf));
+    CHECK_TOKENS("0xFf", litIntToken(0xFf));
+    CHECK_TOKENS("0x7FffFfFf", litIntToken(0x7FffFfFf));
+    CHECK_TOKENS("0x2A", litIntToken(42));
+    CHECK_TOKENS("0x539", litIntToken(1337));
+    CHECK_TOKENS("0x1E240", litIntToken(0x1E240));
+  }
+
   SECTION("Sequences") {
     CHECK_TOKENS("0 0", litIntToken(0), litIntToken(0));
     CHECK_TOKENS("1 2 3", litIntToken(1), litIntToken(2), litIntToken(3));
     CHECK_TOKENS("1,2", litIntToken(1), basicToken(TokenKind::SepComma), litIntToken(2));
+
+    CHECK_TOKENS("0x 0x123", litIntToken(0), litIntToken(0x123));
+    CHECK_TOKENS("0x1 0x2 0x3", litIntToken(1), litIntToken(2), litIntToken(3));
+    CHECK_TOKENS("0xF,0Xf", litIntToken(15), basicToken(TokenKind::SepComma), litIntToken(15));
   }
 
   SECTION("Digit seperators") {
     CHECK_TOKENS("1_000", litIntToken(1000));
     CHECK_TOKENS("1_2___3", litIntToken(123));
+
+    CHECK_TOKENS("0xF_F_F", litIntToken(0xFFF));
+    CHECK_TOKENS("0xA_B___C", litIntToken(0xABC));
   }
 
   SECTION("Errors") {
@@ -32,6 +56,13 @@ TEST_CASE("Lexing integer literals", "[lex]") {
     CHECK_TOKENS("13a4\a2", errLitNumberInvalidChar());
     CHECK_TOKENS("0a", errLitNumberInvalidChar());
     CHECK_TOKENS("0_", errLitNumberEndsWithSeperator());
+
+    CHECK_TOKENS("0x8FFFFFFF", errLitIntTooBig());
+    CHECK_TOKENS("0xFFFFFFFFFFFFFFFFFF2", errLitIntTooBig());
+    CHECK_TOKENS("0x13ga4a2", errLitHexInvalidChar());
+    CHECK_TOKENS("0x13a4好2", errLitHexInvalidChar());
+    CHECK_TOKENS("0x13a4\a2", errLitHexInvalidChar());
+    CHECK_TOKENS("0x_", errLitNumberEndsWithSeperator());
   }
 
   SECTION("Spans") {
@@ -41,6 +72,13 @@ TEST_CASE("Lexing integer literals", "[lex]") {
     CHECK_SPANS("99999999999999999999", input::Span{0, 19});
     CHECK_SPANS("12a12", input::Span{0, 4});
     CHECK_SPANS("11____", input::Span{0, 5});
+
+    CHECK_SPANS(" 0x1F2F3 ", input::Span{1, 7});
+    CHECK_SPANS(" 0xF1A2C3  0x", input::Span{1, 8}, input::Span{11, 12});
+    CHECK_SPANS("0xA__B__C", input::Span{0, 8});
+    CHECK_SPANS("0x123456789ABCDEF", input::Span{0, 16});
+    CHECK_SPANS("0xhelloworld", input::Span{0, 11});
+    CHECK_SPANS("0xa____", input::Span{0, 6});
   }
 }
 


### PR DESCRIPTION
Add hex literal support to lexer.
```
print(0xFF)
```