### PR TITLE
Support binary literals

### DIFF
--- a/include/lex/error.hpp
+++ b/include/lex/error.hpp
@@ -13,6 +13,8 @@ namespace lex {
 
 [[nodiscard]] auto errLitHexInvalidChar(input::Span span = input::Span{0}) -> Token;
 
+[[nodiscard]] auto errLitBinaryInvalidChar(input::Span span = input::Span{0}) -> Token;
+
 [[nodiscard]] auto errLitNumberEndsWithSeperator(input::Span span = input::Span{0}) -> Token;
 
 [[nodiscard]] auto errLitNumberEndsWithDecimalPoint(input::Span span = input::Span{0}) -> Token;

--- a/include/lex/lexer.hpp
+++ b/include/lex/lexer.hpp
@@ -20,6 +20,7 @@ private:
 
   auto nextLitNumber(char mostSignficantChar) -> Token;
   auto nextLitIntHex() -> Token;
+  auto nextLitIntBinary() -> Token;
   auto nextLitStr() -> Token;
   auto nextWordToken(char startingChar) -> Token;
   auto nextLineComment() -> Token;

--- a/src/lex/error.cpp
+++ b/src/lex/error.cpp
@@ -23,6 +23,10 @@ auto errLitHexInvalidChar(const input::Span span) -> Token {
   return errorToken("Hex integer literal contains an invalid character", span);
 }
 
+auto errLitBinaryInvalidChar(const input::Span span) -> Token {
+  return errorToken("Binary integer literal contains an invalid character", span);
+}
+
 auto errLitNumberEndsWithSeperator(const input::Span span) -> Token {
   return errorToken("Number literal ends with a seperator character", span);
 }


### PR DESCRIPTION
Add binary literal support to lexer.
```
print((0b10101010 | 0b01010101) == 0b11111111)
```