### PR TITLE
Add support for instance calls

### DIFF
--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -55,6 +55,10 @@ private:
   [[nodiscard]] auto getChildExprs(const parse::Node& n, unsigned int skipAmount = 0U)
       -> std::optional<std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>>;
 
+  [[nodiscard]] auto getChildExprs(
+      const parse::Node& n, const parse::Node* additionalNode, unsigned int skipAmount = 0U)
+      -> std::optional<std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>>;
+
   [[nodiscard]] auto
   getSubExpr(const parse::Node& n, prog::sym::TypeId typeHint, bool checkedConstsAccess = false)
       -> prog::expr::NodePtr;

--- a/src/frontend/internal/get_identifier.cpp
+++ b/src/frontend/internal/get_identifier.cpp
@@ -1,7 +1,13 @@
 #include "internal/get_identifier.hpp"
+#include "parse/node_expr_field.hpp"
 #include "parse/node_expr_id.hpp"
 
 namespace frontend::internal {
+
+GetIdentifier::GetIdentifier() :
+    m_instance{nullptr}, m_identifier{std::nullopt}, m_typeParams{std::nullopt} {}
+
+auto GetIdentifier::getInstance() const noexcept -> const parse::Node* { return m_instance; }
 
 auto GetIdentifier::getIdentifier() const noexcept -> const std::optional<lex::Token>& {
   return m_identifier;
@@ -14,6 +20,11 @@ auto GetIdentifier::getTypeParams() const noexcept -> const std::optional<parse:
 auto GetIdentifier::visit(const parse::IdExprNode& n) -> void {
   m_identifier = n.getId();
   m_typeParams = n.getTypeParams();
+}
+
+auto GetIdentifier::visit(const parse::FieldExprNode& n) -> void {
+  m_instance   = &n[0];
+  m_identifier = n.getId();
 }
 
 } // namespace frontend::internal

--- a/src/frontend/internal/get_identifier.hpp
+++ b/src/frontend/internal/get_identifier.hpp
@@ -1,21 +1,27 @@
 #pragma once
 #include "lex/token.hpp"
+#include "parse/node.hpp"
 #include "parse/node_visitor_optional.hpp"
 #include "parse/type_param_list.hpp"
+#include "prog/program.hpp"
 #include <optional>
 
 namespace frontend::internal {
 
 class GetIdentifier final : public parse::OptionalNodeVisitor {
 public:
-  GetIdentifier() = default;
+  GetIdentifier();
 
+  [[nodiscard]] auto getInstance() const noexcept -> const parse::Node*;
   [[nodiscard]] auto getIdentifier() const noexcept -> const std::optional<lex::Token>&;
   [[nodiscard]] auto getTypeParams() const noexcept -> const std::optional<parse::TypeParamList>&;
 
   auto visit(const parse::IdExprNode& n) -> void override;
 
+  auto visit(const parse::FieldExprNode& n) -> void override;
+
 private:
+  const parse::Node* m_instance;
   std::optional<lex::Token> m_identifier;
   std::optional<parse::TypeParamList> m_typeParams;
 };

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -71,6 +71,7 @@ auto TypeInferExpr::visit(const parse::BinaryExprNode& n) -> void {
 auto TypeInferExpr::visit(const parse::CallExprNode& n) -> void {
   auto getIdVisitor = GetIdentifier{};
   n[0].accept(&getIdVisitor);
+  auto* instance  = getIdVisitor.getInstance();
   auto identifier = getIdVisitor.getIdentifier();
   auto typeParams = getIdVisitor.getTypeParams();
 
@@ -84,6 +85,9 @@ auto TypeInferExpr::visit(const parse::CallExprNode& n) -> void {
 
   auto argTypes = std::vector<prog::sym::TypeId>{};
   argTypes.reserve(n.getChildCount());
+  if (instance) {
+    argTypes.push_back(inferSubExpr(*instance));
+  }
   for (auto i = 1U; i < n.getChildCount(); ++i) {
     argTypes.push_back(inferSubExpr(n[i]));
   }

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -201,6 +201,20 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "bool"));
   }
 
+  SECTION("Instance function call") {
+    const auto& output = ANALYZE("fun double(int i) i * 2 "
+                                 "fun f() (42).double()");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "int"));
+  }
+
+  SECTION("Instance function call with arguments") {
+    const auto& output = ANALYZE("fun test(int a, string b) a.string() + b "
+                                 "fun f() (42).test(\"test\")");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "string"));
+  }
+
   SECTION("Dynamic call") {
     const auto& output = ANALYZE("fun f(delegate{int, int} op) op(1)");
     REQUIRE(output.isSuccess());


### PR DESCRIPTION
Add support for providing the first argument for a function on the left hand side (`[firstArg].funcName([otherArgs]`). 
```
fun double(int i)
  i * 2

print(i = 42; i.double())
```
A more complicated example:
```
struct None
union Option{T} = T, None

fun string{T}(Option{T} o)
  o is T v ? v.string() : "none"

fun isDigit(char c)
  c >= '0' && c <= '9'

fun parseInt(char c)  -> Option{int}
  if c.isDigit()  -> int(c) - '0'
  else            -> None()

fun parseInt(string str)
  str.parseIntImpl(0, 0)

fun parseIntImpl(string str, int idx, int ac) -> Option{int}
  if idx >= str.length()           -> idx == 0 ? None() : ac
  if str[idx].parseInt() is int v  -> str.parseIntImpl(idx + 1, ac * 10 + v)
  else                             -> None()

print("1337".parseInt().string()      + '\n') // Output: 1337
print("13a37".parseInt().string()     + '\n') // Output: none
print("001".parseInt().string()       + '\n') // Output: 1
print("21232345".parseInt().string()  + '\n') // Output: 21232345
print("".parseInt().string()          + '\n') // Output: none
```