### PR TITLE
Enum support

### DIFF
--- a/apps/parsediag/get_color.hpp
+++ b/apps/parsediag/get_color.hpp
@@ -100,6 +100,11 @@ public:
     m_bg = rang::bg::reset;
   }
 
+  auto visit(const parse::EnumDeclStmtNode & /*unused*/) -> void override {
+    m_fg = rang::fg::yellow;
+    m_bg = rang::bg::reset;
+  }
+
   auto visit(const parse::ExecStmtNode & /*unused*/) -> void override {
     m_fg = rang::fg::blue;
     m_bg = rang::bg::reset;

--- a/apps/progdiag/get_expr_color.hpp
+++ b/apps/progdiag/get_expr_color.hpp
@@ -64,6 +64,8 @@ public:
 
   auto visit(const prog::expr::LitCharNode & /*unused*/) -> void override { m_fg = rang::fg::cyan; }
 
+  auto visit(const prog::expr::LitEnumNode & /*unused*/) -> void override { m_fg = rang::fg::cyan; }
+
 private:
   rang::fg m_fg{};
 };

--- a/apps/progdiag/main.cpp
+++ b/apps/progdiag/main.cpp
@@ -144,6 +144,12 @@ auto printTypeDefs(const prog::Program& prog) -> void {
         std::cout << "  " << rang::fg::yellow << rang::style::bold << std::setw(nameColWidth)
                   << std::left << typeName << rang::style::reset << '\n';
       }
+    } else if (std::holds_alternative<prog::sym::EnumDef>(typeDef)) {
+      const auto& enumDef = std::get<prog::sym::EnumDef>(typeDef);
+      for (const auto& entry : enumDef) {
+        std::cout << "  " << rang::fg::yellow << rang::style::bold << std::setw(nameColWidth)
+                  << std::left << entry.first << rang::style::reset << entry.second << '\n';
+      }
     } else if (std::holds_alternative<prog::sym::DelegateDef>(typeDef)) {
       const auto& delegateDef = std::get<prog::sym::DelegateDef>(typeDef);
       std::stringstream inputStr;

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -47,6 +47,10 @@ errFieldNameConflictsWithType(const Source& src, const std::string& name, input:
     const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
     -> Diag;
 
+[[nodiscard]] auto errStaticFieldNotFoundOnType(
+    const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
+    -> Diag;
+
 [[nodiscard]] auto errDuplicateTypeInUnion(
     const Source& src,
     const std::string& typeName,
@@ -67,6 +71,10 @@ errDuplicateEntryNameInEnum(const Source& src, const std::string& entryName, inp
 
 [[nodiscard]] auto
 errDuplicateEntryValueInEnum(const Source& src, int32_t entryValue, input::Span span) -> Diag;
+
+[[nodiscard]] auto errValueNotFoundInEnum(
+    const Source& src, const std::string& entryName, const std::string& enumName, input::Span span)
+    -> Diag;
 
 [[nodiscard]] auto errIncorrectReturnTypeInConvFunc(
     const Source& src, const std::string& name, const std::string& returnedType, input::Span span)

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -61,6 +61,13 @@ errFieldNameConflictsWithType(const Source& src, const std::string& name, input:
 
 [[nodiscard]] auto errUncheckedIsExpressionWithConst(const Source& src, input::Span span) -> Diag;
 
+[[nodiscard]] auto
+errDuplicateEntryNameInEnum(const Source& src, const std::string& entryName, input::Span span)
+    -> Diag;
+
+[[nodiscard]] auto
+errDuplicateEntryValueInEnum(const Source& src, int32_t entryValue, input::Span span) -> Diag;
+
 [[nodiscard]] auto errIncorrectReturnTypeInConvFunc(
     const Source& src, const std::string& name, const std::string& returnedType, input::Span span)
     -> Diag;

--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -5,7 +5,7 @@
 
 namespace lex {
 
-enum class Keyword { Fun, Lambda, Struct, Union, If, Else, Is };
+enum class Keyword { Fun, Lambda, Struct, Union, Enum, If, Else, Is };
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream&;
 

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "lex/token.hpp"
 #include "parse/node.hpp"
+#include "parse/node_stmt_enum_decl.hpp"
 #include "parse/node_stmt_func_decl.hpp"
 #include "parse/node_stmt_struct_decl.hpp"
 #include "parse/type_param_list.hpp"
@@ -35,6 +36,13 @@ errInvalidAnonFuncExpr(lex::Token kw, const ArgumentListDecl& argList, NodePtr b
     std::optional<TypeSubstitutionList> typeSubs,
     lex::Token eq,
     const std::vector<Type>& types,
+    std::vector<lex::Token> commas) -> NodePtr;
+
+[[nodiscard]] auto errInvalidStmtEnumDecl(
+    lex::Token kw,
+    lex::Token id,
+    lex::Token eq,
+    const std::vector<EnumDeclStmtNode::EntrySpec>& entries,
     std::vector<lex::Token> commas) -> NodePtr;
 
 [[nodiscard]] auto errInvalidStmtExec(

--- a/include/parse/node_stmt_enum_decl.hpp
+++ b/include/parse/node_stmt_enum_decl.hpp
@@ -1,0 +1,92 @@
+#pragma once
+#include "lex/token.hpp"
+#include "parse/node.hpp"
+#include "parse/type.hpp"
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace parse {
+
+class EnumDeclStmtNode final : public Node {
+public:
+  class ValueSpec final {
+  public:
+    ValueSpec(lex::Token colon, lex::Token value);
+
+    auto operator==(const ValueSpec& rhs) const noexcept -> bool;
+
+    [[nodiscard]] auto getColon() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto getValue() const noexcept -> const lex::Token&;
+
+    [[nodiscard]] auto validate() const noexcept -> bool;
+
+  private:
+    lex::Token m_colon;
+    lex::Token m_value;
+  };
+
+  class EntrySpec final {
+  public:
+    EntrySpec(lex::Token identifier, std::optional<ValueSpec> value);
+
+    auto operator==(const EntrySpec& rhs) const noexcept -> bool;
+
+    [[nodiscard]] auto getSpan() const -> input::Span;
+    [[nodiscard]] auto getIdentifier() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto getValueSpec() const noexcept -> const std::optional<ValueSpec>&;
+
+    [[nodiscard]] auto validate() const noexcept -> bool;
+
+  private:
+    lex::Token m_identifier;
+    std::optional<ValueSpec> m_value;
+  };
+
+  friend auto enumDeclStmtNode(
+      lex::Token kw,
+      lex::Token id,
+      lex::Token eq,
+      std::vector<EnumDeclStmtNode::EntrySpec> entries,
+      std::vector<lex::Token> commas) -> NodePtr;
+
+  EnumDeclStmtNode() = delete;
+
+  auto operator==(const Node& rhs) const noexcept -> bool override;
+  auto operator!=(const Node& rhs) const noexcept -> bool override;
+
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
+  [[nodiscard]] auto getChildCount() const -> unsigned int override;
+  [[nodiscard]] auto getSpan() const -> input::Span override;
+
+  [[nodiscard]] auto getId() const -> const lex::Token&;
+  [[nodiscard]] auto getEntries() const -> const std::vector<EntrySpec>&;
+
+  auto accept(NodeVisitor* visitor) const -> void override;
+
+private:
+  const lex::Token m_kw;
+  const lex::Token m_id;
+  const lex::Token m_eq;
+  const std::vector<EntrySpec> m_entries;
+  const std::vector<lex::Token> m_commas;
+
+  EnumDeclStmtNode(
+      lex::Token kw,
+      lex::Token id,
+      lex::Token eq,
+      std::vector<EntrySpec> entries,
+      std::vector<lex::Token> commas);
+
+  auto print(std::ostream& out) const -> std::ostream& override;
+};
+
+// Factories.
+auto enumDeclStmtNode(
+    lex::Token kw,
+    lex::Token id,
+    lex::Token eq,
+    std::vector<EnumDeclStmtNode::EntrySpec> entries,
+    std::vector<lex::Token> commas) -> NodePtr;
+
+} // namespace parse

--- a/include/parse/node_stmt_enum_decl.hpp
+++ b/include/parse/node_stmt_enum_decl.hpp
@@ -12,17 +12,20 @@ class EnumDeclStmtNode final : public Node {
 public:
   class ValueSpec final {
   public:
-    ValueSpec(lex::Token colon, lex::Token value);
+    ValueSpec(lex::Token colon, std::optional<lex::Token> minus, lex::Token value);
 
     auto operator==(const ValueSpec& rhs) const noexcept -> bool;
 
     [[nodiscard]] auto getColon() const noexcept -> const lex::Token&;
-    [[nodiscard]] auto getValue() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto getMinusToken() const noexcept -> const std::optional<lex::Token>&;
+    [[nodiscard]] auto getValueToken() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto getValue() const noexcept -> int32_t;
 
     [[nodiscard]] auto validate() const noexcept -> bool;
 
   private:
     lex::Token m_colon;
+    std::optional<lex::Token> m_minus;
     lex::Token m_value;
   };
 

--- a/include/parse/node_visitor.hpp
+++ b/include/parse/node_visitor.hpp
@@ -20,6 +20,7 @@ class SwitchExprElseNode;
 class SwitchExprIfNode;
 class SwitchExprNode;
 class UnaryExprNode;
+class EnumDeclStmtNode;
 class ExecStmtNode;
 class FuncDeclStmtNode;
 class StructDeclStmtNode;
@@ -45,6 +46,7 @@ public:
   virtual auto visit(const SwitchExprIfNode& n) -> void    = 0;
   virtual auto visit(const SwitchExprNode& n) -> void      = 0;
   virtual auto visit(const UnaryExprNode& n) -> void       = 0;
+  virtual auto visit(const EnumDeclStmtNode& n) -> void    = 0;
   virtual auto visit(const ExecStmtNode& n) -> void        = 0;
   virtual auto visit(const FuncDeclStmtNode& n) -> void    = 0;
   virtual auto visit(const StructDeclStmtNode& n) -> void  = 0;

--- a/include/parse/node_visitor_deep.hpp
+++ b/include/parse/node_visitor_deep.hpp
@@ -23,6 +23,7 @@ public:
   auto visit(const SwitchExprIfNode& n) -> void override;
   auto visit(const SwitchExprNode& n) -> void override;
   auto visit(const UnaryExprNode& n) -> void override;
+  auto visit(const EnumDeclStmtNode& n) -> void override;
   auto visit(const ExecStmtNode& n) -> void override;
   auto visit(const FuncDeclStmtNode& n) -> void override;
   auto visit(const StructDeclStmtNode& n) -> void override;

--- a/include/parse/node_visitor_optional.hpp
+++ b/include/parse/node_visitor_optional.hpp
@@ -23,6 +23,7 @@ public:
   auto visit(const SwitchExprIfNode & /*unused*/) -> void override {}
   auto visit(const SwitchExprNode & /*unused*/) -> void override {}
   auto visit(const UnaryExprNode & /*unused*/) -> void override {}
+  auto visit(const EnumDeclStmtNode & /*unused*/) -> void override {}
   auto visit(const ExecStmtNode & /*unused*/) -> void override {}
   auto visit(const FuncDeclStmtNode & /*unused*/) -> void override {}
   auto visit(const StructDeclStmtNode & /*unused*/) -> void override {}

--- a/include/parse/nodes.hpp
+++ b/include/parse/nodes.hpp
@@ -16,6 +16,7 @@
 #include "parse/node_expr_switch_else.hpp"
 #include "parse/node_expr_switch_if.hpp"
 #include "parse/node_expr_unary.hpp"
+#include "parse/node_stmt_enum_decl.hpp"
 #include "parse/node_stmt_exec.hpp"
 #include "parse/node_stmt_func_decl.hpp"
 #include "parse/node_stmt_struct_decl.hpp"

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -26,6 +26,7 @@ private:
   auto nextStmtFuncDecl() -> NodePtr;
   auto nextStmtStructDecl() -> NodePtr;
   auto nextStmtUnionDecl() -> NodePtr;
+  auto nextStmtEnumDecl() -> NodePtr;
   auto nextStmtExec() -> NodePtr;
 
   auto nextExpr(int minPrecedence) -> NodePtr;

--- a/include/prog/expr/node_lit_enum.hpp
+++ b/include/prog/expr/node_lit_enum.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "prog/expr/node.hpp"
+#include "prog/program.hpp"
+
+namespace prog::expr {
+
+class LitEnumNode final : public Node {
+  friend auto litEnumNode(const Program& program, sym::TypeId enumType, std::string name)
+      -> NodePtr;
+
+public:
+  LitEnumNode() = delete;
+
+  auto operator==(const Node& rhs) const noexcept -> bool override;
+  auto operator!=(const Node& rhs) const noexcept -> bool override;
+
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
+  [[nodiscard]] auto getChildCount() const -> unsigned int override;
+  [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
+  [[nodiscard]] auto toString() const -> std::string override;
+
+  [[nodiscard]] auto getName() const noexcept -> const std::string&;
+  [[nodiscard]] auto getVal() const noexcept -> int32_t;
+
+  auto accept(NodeVisitor* visitor) const -> void override;
+
+private:
+  sym::TypeId m_type;
+  std::string m_name;
+  int32_t m_val;
+
+  LitEnumNode(sym::TypeId type, std::string entryName, int32_t val);
+};
+
+// Factories.
+auto litEnumNode(const Program& prog, sym::TypeId enumType, std::string name) -> NodePtr;
+
+} // namespace prog::expr

--- a/include/prog/expr/node_visitor.hpp
+++ b/include/prog/expr/node_visitor.hpp
@@ -19,6 +19,7 @@ class LitFuncNode;
 class LitIntNode;
 class LitStringNode;
 class LitCharNode;
+class LitEnumNode;
 
 class NodeVisitor {
 public:
@@ -39,6 +40,7 @@ public:
   virtual auto visit(const LitIntNode& n) -> void         = 0;
   virtual auto visit(const LitStringNode& n) -> void      = 0;
   virtual auto visit(const LitCharNode& n) -> void        = 0;
+  virtual auto visit(const LitEnumNode& n) -> void        = 0;
 };
 
 } // namespace prog::expr

--- a/include/prog/expr/nodes.hpp
+++ b/include/prog/expr/nodes.hpp
@@ -8,6 +8,7 @@
 #include "prog/expr/node_group.hpp"
 #include "prog/expr/node_lit_bool.hpp"
 #include "prog/expr/node_lit_char.hpp"
+#include "prog/expr/node_lit_enum.hpp"
 #include "prog/expr/node_lit_float.hpp"
 #include "prog/expr/node_lit_func.hpp"
 #include "prog/expr/node_lit_int.hpp"

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -108,15 +108,17 @@ public:
   [[nodiscard]] auto getTypeDef(sym::TypeId id) const -> const sym::TypeDefTable::typeDef&;
   [[nodiscard]] auto getFuncDef(sym::FuncId id) const -> const sym::FuncDef&;
 
-  auto declareUserStruct(std::string name) -> sym::TypeId;
-  auto declareUserUnion(std::string name) -> sym::TypeId;
-  auto declareUserDelegate(std::string name) -> sym::TypeId;
-  auto declareUserFunc(std::string name, sym::TypeSet input, sym::TypeId output) -> sym::FuncId;
+  auto declareStruct(std::string name) -> sym::TypeId;
+  auto declareUnion(std::string name) -> sym::TypeId;
+  auto declareEnum(std::string name) -> sym::TypeId;
+  auto declareDelegate(std::string name) -> sym::TypeId;
+  auto declareFunc(std::string name, sym::TypeSet input, sym::TypeId output) -> sym::FuncId;
 
-  auto defineUserStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void;
-  auto defineUserUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> void;
-  auto defineUserDelegate(sym::TypeId id, sym::TypeSet input, sym::TypeId output) -> void;
-  auto defineUserFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
+  auto defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void;
+  auto defineUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> void;
+  auto defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t> entries) -> void;
+  auto defineDelegate(sym::TypeId id, sym::TypeSet input, sym::TypeId output) -> void;
+  auto defineFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
 
   auto
   addExecStmt(sym::ActionId action, sym::ConstDeclTable consts, std::vector<expr::NodePtr> args)

--- a/include/prog/sym/enum_def.hpp
+++ b/include/prog/sym/enum_def.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include "prog/sym/type_id.hpp"
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace prog::sym {
+
+class EnumDef final {
+  friend class TypeDefTable;
+
+public:
+  using iterator = typename std::unordered_map<std::string, int32_t>::const_iterator;
+
+  EnumDef()                       = delete;
+  EnumDef(const EnumDef& rhs)     = delete;
+  EnumDef(EnumDef&& rhs) noexcept = default;
+  ~EnumDef()                      = default;
+
+  auto operator=(const EnumDef& rhs) -> EnumDef& = delete;
+  auto operator=(EnumDef&& rhs) noexcept -> EnumDef& = delete;
+
+  [[nodiscard]] auto begin() const -> iterator;
+  [[nodiscard]] auto end() const -> iterator;
+
+  [[nodiscard]] auto getId() const noexcept -> const TypeId&;
+  [[nodiscard]] auto getValue(const std::string& name) const noexcept -> std::optional<int32_t>;
+
+private:
+  sym::TypeId m_id;
+  std::unordered_map<std::string, int32_t> m_entries;
+
+  EnumDef(sym::TypeId id, std::unordered_map<std::string, int32_t> entries);
+};
+
+} // namespace prog::sym

--- a/include/prog/sym/enum_def.hpp
+++ b/include/prog/sym/enum_def.hpp
@@ -25,6 +25,7 @@ public:
   [[nodiscard]] auto end() const -> iterator;
 
   [[nodiscard]] auto getId() const noexcept -> const TypeId&;
+  [[nodiscard]] auto hasEntry(const std::string& name) const noexcept -> bool;
   [[nodiscard]] auto getValue(const std::string& name) const noexcept -> std::optional<int32_t>;
 
 private:

--- a/include/prog/sym/type_def_table.hpp
+++ b/include/prog/sym/type_def_table.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "prog/sym/delegate_def.hpp"
+#include "prog/sym/enum_def.hpp"
 #include "prog/sym/struct_def.hpp"
 #include "prog/sym/type_decl_table.hpp"
 #include "prog/sym/type_id_hasher.hpp"
@@ -11,7 +12,7 @@ namespace prog::sym {
 
 class TypeDefTable final {
 public:
-  using typeDef  = typename std::variant<StructDef, UnionDef, DelegateDef>;
+  using typeDef  = typename std::variant<StructDef, UnionDef, EnumDef, DelegateDef>;
   using iterator = typename std::unordered_map<TypeId, typeDef, TypeIdHasher>::const_iterator;
 
   TypeDefTable()                            = default;
@@ -36,6 +37,11 @@ public:
   auto
   registerUnion(const sym::TypeDeclTable& typeTable, sym::TypeId id, std::vector<sym::TypeId> types)
       -> void;
+
+  auto registerEnum(
+      const sym::TypeDeclTable& typeTable,
+      sym::TypeId id,
+      std::unordered_map<std::string, int32_t> entries) -> void;
 
   auto registerDelegate(
       const sym::TypeDeclTable& typeTable, sym::TypeId id, TypeSet input, TypeId output) -> void;

--- a/include/prog/sym/type_kind.hpp
+++ b/include/prog/sym/type_kind.hpp
@@ -9,9 +9,10 @@ enum class TypeKind {
   Bool,
   String,
   Char,
-  UserStruct,
-  UserUnion,
-  UserDelegate,
+  Struct,
+  Union,
+  Enum,
+  Delegate,
 };
 
 auto operator<<(std::ostream& out, const TypeKind& rhs) -> std::ostream&;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(parse STATIC
   parse/node_expr_switch_else.cpp
   parse/node_expr_switch.cpp
   parse/node_expr_unary.cpp
+  parse/node_stmt_enum_decl.cpp
   parse/node_stmt_exec.cpp
   parse/node_stmt_func_decl.cpp
   parse/node_stmt_struct_decl.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(prog STATIC
   prog/expr/node_field.cpp
   prog/expr/node_group.cpp
   prog/expr/node_lit_bool.cpp
+  prog/expr/node_lit_enum.cpp
   prog/expr/node_lit_float.cpp
   prog/expr/node_lit_func.cpp
   prog/expr/node_lit_int.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(prog STATIC
   prog/sym/const_id.cpp
   prog/sym/const_kind.cpp
   prog/sym/delegate_def.cpp
+  prog/sym/enum_def.cpp
   prog/sym/exec_stmt.cpp
   prog/sym/field_decl_table.cpp
   prog/sym/field_decl.cpp

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -447,6 +447,10 @@ auto GenExpr::visit(const prog::expr::LitCharNode& n) -> void {
   m_builder->addLoadLitInt(n.getVal());
 }
 
+auto GenExpr::visit(const prog::expr::LitEnumNode& n) -> void {
+  m_builder->addLoadLitInt(n.getVal());
+}
+
 auto GenExpr::genSubExpr(const prog::expr::Node& n, bool tail) -> void {
   auto genExpr = GenExpr{m_program, m_builder, tail};
   n.accept(&genExpr);

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -348,7 +348,7 @@ auto GenExpr::visit(const prog::expr::FieldExprNode& n) -> void {
   genSubExpr(n[0], false);
 
   const auto& structType = m_program.getTypeDecl(n[0].getType());
-  if (structType.getKind() != prog::sym::TypeKind::UserStruct) {
+  if (structType.getKind() != prog::sym::TypeKind::Struct) {
     throw std::logic_error{"Field expr node only works on struct types"};
   }
   const auto& structDef = std::get<prog::sym::StructDef>(m_program.getTypeDef(structType.getId()));

--- a/src/backend/internal/gen_expr.hpp
+++ b/src/backend/internal/gen_expr.hpp
@@ -26,6 +26,7 @@ public:
   auto visit(const prog::expr::LitIntNode& n) -> void override;
   auto visit(const prog::expr::LitStringNode& n) -> void override;
   auto visit(const prog::expr::LitCharNode& n) -> void override;
+  auto visit(const prog::expr::LitEnumNode& n) -> void override;
 
 private:
   const prog::Program& m_program;

--- a/src/backend/internal/gen_type_eq.cpp
+++ b/src/backend/internal/gen_type_eq.cpp
@@ -8,6 +8,7 @@ static auto genTypeEquality(Builder* builder, const prog::sym::TypeDecl& typeDec
   case prog::sym::TypeKind::Bool:
   case prog::sym::TypeKind::Int:
   case prog::sym::TypeKind::Char:
+  case prog::sym::TypeKind::Enum:
     builder->addCheckEqInt();
     break;
   case prog::sym::TypeKind::Float:
@@ -16,11 +17,11 @@ static auto genTypeEquality(Builder* builder, const prog::sym::TypeDecl& typeDec
   case prog::sym::TypeKind::String:
     builder->addCheckEqString();
     break;
-  case prog::sym::TypeKind::UserDelegate:
+  case prog::sym::TypeKind::Delegate:
     builder->addCheckEqCallDynTgt();
     break;
-  case prog::sym::TypeKind::UserStruct:
-  case prog::sym::TypeKind::UserUnion:
+  case prog::sym::TypeKind::Struct:
+  case prog::sym::TypeKind::Union:
     builder->addCall(getUserTypeEqLabel(typeDecl.getId()), false);
     break;
   }

--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -45,6 +45,9 @@ auto analyze(const Source& src) -> Output {
   for (const auto& unionDecl : declareUserTypes.getUnions()) {
     defineUserTypes.define(unionDecl.first, unionDecl.second);
   }
+  for (const auto& enumDecl : declareUserTypes.getEnums()) {
+    defineUserTypes.define(enumDecl.first, enumDecl.second);
+  }
   if (context.hasErrors()) {
     return buildOutput(nullptr, context.getDiags());
   }

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -87,6 +87,14 @@ auto errFieldNotFoundOnType(
   return error(src, oss.str(), span);
 }
 
+auto errStaticFieldNotFoundOnType(
+    const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
+    -> Diag {
+  std::ostringstream oss;
+  oss << "Type '" << typeName << "' has no static field named '" << fieldName << '\'';
+  return error(src, oss.str(), span);
+}
+
 auto errDuplicateTypeInUnion(
     const Source& src,
     const std::string& typeName,
@@ -132,6 +140,14 @@ auto errDuplicateEntryNameInEnum(const Source& src, const std::string& entryName
 auto errDuplicateEntryValueInEnum(const Source& src, int32_t entryValue, input::Span span) -> Diag {
   std::ostringstream oss;
   oss << "Value '" << entryValue << "' conflicts with a previous entry in the same enum";
+  return error(src, oss.str(), span);
+}
+
+auto errValueNotFoundInEnum(
+    const Source& src, const std::string& entryName, const std::string& enumName, input::Span span)
+    -> Diag {
+  std::ostringstream oss;
+  oss << "Enum '" << enumName << "' does not contain '" << entryName << '\'';
   return error(src, oss.str(), span);
 }
 

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -103,7 +103,7 @@ auto errDuplicateTypeInUnion(
 
 auto errNonUnionIsExpression(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Left-hand-side of 'is' expression has to be a union type.";
+  oss << "Left-hand-side of 'is' expression has to be a union type";
   return error(src, oss.str(), span);
 }
 
@@ -111,14 +111,27 @@ auto errTypeNotPartOfUnion(
     const Source& src, const std::string& typeName, const std::string& unionName, input::Span span)
     -> Diag {
   std::ostringstream oss;
-  oss << "Type '" << typeName << "' is not part of the union '" << unionName << "'.";
+  oss << "Type '" << typeName << "' is not part of the union '" << unionName << '\'';
   return error(src, oss.str(), span);
 }
 
 auto errUncheckedIsExpressionWithConst(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
   oss << "Unchecked 'is' expression with constant declaration, either use in a checked context or "
-         "discard '_' the const. ";
+         "discard '_' the const";
+  return error(src, oss.str(), span);
+}
+
+auto errDuplicateEntryNameInEnum(const Source& src, const std::string& entryName, input::Span span)
+    -> Diag {
+  std::ostringstream oss;
+  oss << "Name '" << entryName << "' conflicts with a previous entry in the same enum";
+  return error(src, oss.str(), span);
+}
+
+auto errDuplicateEntryValueInEnum(const Source& src, int32_t entryValue, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Value '" << entryValue << "' conflicts with a previous entry in the same enum";
   return error(src, oss.str(), span);
 }
 

--- a/src/frontend/internal/check_union_exhaustiveness.cpp
+++ b/src/frontend/internal/check_union_exhaustiveness.cpp
@@ -69,4 +69,6 @@ auto CheckUnionExhaustiveness::visit(const prog::expr::LitStringNode & /*unused*
 
 auto CheckUnionExhaustiveness::visit(const prog::expr::LitCharNode & /*unused*/) -> void {}
 
+auto CheckUnionExhaustiveness::visit(const prog::expr::LitEnumNode & /*unused*/) -> void {}
+
 } // namespace frontend::internal

--- a/src/frontend/internal/check_union_exhaustiveness.hpp
+++ b/src/frontend/internal/check_union_exhaustiveness.hpp
@@ -28,6 +28,7 @@ public:
   auto visit(const prog::expr::LitIntNode& n) -> void override;
   auto visit(const prog::expr::LitStringNode& n) -> void override;
   auto visit(const prog::expr::LitCharNode& n) -> void override;
+  auto visit(const prog::expr::LitEnumNode& n) -> void override;
 
 private:
   const Context& m_context;

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -101,7 +101,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
 
   // Declare the function in the program.
   const auto funcName = isConv ? getName(*m_context, *retType) : name;
-  auto funcId = m_context->getProg()->declareUserFunc(funcName, input.value(), retType.value());
+  auto funcId         = m_context->getProg()->declareFunc(funcName, input.value(), retType.value());
   m_funcs.emplace_back(funcId, name, n);
 }
 

--- a/src/frontend/internal/declare_user_types.cpp
+++ b/src/frontend/internal/declare_user_types.cpp
@@ -19,6 +19,10 @@ auto DeclareUserTypes::getUnions() const noexcept -> const std::vector<UnionDecl
   return m_unions;
 }
 
+auto DeclareUserTypes::getEnums() const noexcept -> const std::vector<EnumDeclarationInfo>& {
+  return m_enums;
+}
+
 auto DeclareUserTypes::visit(const parse::StructDeclStmtNode& n) -> void {
   // Get type name.
   const auto name = getName(n.getId());
@@ -37,7 +41,7 @@ auto DeclareUserTypes::visit(const parse::StructDeclStmtNode& n) -> void {
   }
 
   // Declare the struct in the program.
-  auto typeId = m_context->getProg()->declareUserStruct(name);
+  auto typeId = m_context->getProg()->declareStruct(name);
   m_structs.emplace_back(typeId, n);
 
   // Keep track of some extra information about the type.
@@ -62,8 +66,23 @@ auto DeclareUserTypes::visit(const parse::UnionDeclStmtNode& n) -> void {
   }
 
   // Declare the union in the program.
-  auto typeId = m_context->getProg()->declareUserUnion(name);
+  auto typeId = m_context->getProg()->declareUnion(name);
   m_unions.emplace_back(typeId, n);
+
+  // Keep track of some extra information about the type.
+  m_context->declareTypeInfo(typeId, TypeInfo{name, n.getSpan()});
+}
+
+auto DeclareUserTypes::visit(const parse::EnumDeclStmtNode& n) -> void {
+  // Get type name.
+  const auto name = getName(n.getId());
+  if (!validateTypeName(n.getId())) {
+    return;
+  }
+
+  // Declare the enum in the program.
+  auto typeId = m_context->getProg()->declareEnum(name);
+  m_enums.emplace_back(typeId, n);
 
   // Keep track of some extra information about the type.
   m_context->declareTypeInfo(typeId, TypeInfo{name, n.getSpan()});

--- a/src/frontend/internal/declare_user_types.hpp
+++ b/src/frontend/internal/declare_user_types.hpp
@@ -11,20 +11,24 @@ public:
       typename std::pair<prog::sym::TypeId, const parse::StructDeclStmtNode&>;
   using UnionDeclarationInfo =
       typename std::pair<prog::sym::TypeId, const parse::UnionDeclStmtNode&>;
+  using EnumDeclarationInfo = typename std::pair<prog::sym::TypeId, const parse::EnumDeclStmtNode&>;
 
   DeclareUserTypes() = delete;
   explicit DeclareUserTypes(Context* context);
 
   [[nodiscard]] auto getStructs() const noexcept -> const std::vector<StructDeclarationInfo>&;
   [[nodiscard]] auto getUnions() const noexcept -> const std::vector<UnionDeclarationInfo>&;
+  [[nodiscard]] auto getEnums() const noexcept -> const std::vector<EnumDeclarationInfo>&;
 
   auto visit(const parse::StructDeclStmtNode& n) -> void override;
   auto visit(const parse::UnionDeclStmtNode& n) -> void override;
+  auto visit(const parse::EnumDeclStmtNode& n) -> void override;
 
 private:
   Context* m_context;
   std::vector<StructDeclarationInfo> m_structs;
   std::vector<UnionDeclarationInfo> m_unions;
+  std::vector<EnumDeclarationInfo> m_enums;
 
   auto validateTypeName(const lex::Token& nameToken) -> bool;
 };

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -43,7 +43,7 @@ auto DefineUserFuncs::define(
   }
 
   if (expr->getType() == funcRetType) {
-    m_context->getProg()->defineUserFunc(id, std::move(consts), std::move(expr));
+    m_context->getProg()->defineFunc(id, std::move(consts), std::move(expr));
     return true;
   }
 
@@ -51,7 +51,7 @@ auto DefineUserFuncs::define(
   if (conv && *conv != id) {
     auto convArgs = std::vector<prog::expr::NodePtr>{};
     convArgs.push_back(std::move(expr));
-    m_context->getProg()->defineUserFunc(
+    m_context->getProg()->defineFunc(
         id,
         std::move(consts),
         prog::expr::callExprNode(*m_context->getProg(), *conv, std::move(convArgs)));

--- a/src/frontend/internal/define_user_types.hpp
+++ b/src/frontend/internal/define_user_types.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "internal/context.hpp"
-#include "internal/struct_template.hpp"
 
 namespace frontend::internal {
 
@@ -11,6 +10,7 @@ public:
 
   auto define(prog::sym::TypeId id, const parse::StructDeclStmtNode& n) -> bool;
   auto define(prog::sym::TypeId id, const parse::UnionDeclStmtNode& n) -> bool;
+  auto define(prog::sym::TypeId id, const parse::EnumDeclStmtNode& n) -> bool;
 
 private:
   Context* m_context;

--- a/src/frontend/internal/delegate_table.cpp
+++ b/src/frontend/internal/delegate_table.cpp
@@ -47,11 +47,10 @@ auto DelegateTable::getDelegate(
   }
 
   // Declare a new delegate.
-  const auto delegateType =
-      context->getProg()->declareUserDelegate(getName(*context, input, output));
+  const auto delegateType = context->getProg()->declareDelegate(getName(*context, input, output));
 
   // Define the delegate.
-  context->getProg()->defineUserDelegate(delegateType, input, output);
+  context->getProg()->defineDelegate(delegateType, input, output);
 
   // Keep track of some extra information about the type.
   auto types = std::vector<prog::sym::TypeId>{};

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -187,7 +187,7 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
 
   // Declare the function in the program.
   instance->m_func =
-      m_context->getProg()->declareUserFunc(funcName, std::move(*funcInput), *instance->m_retType);
+      m_context->getProg()->declareFunc(funcName, std::move(*funcInput), *instance->m_retType);
 
   // Define the function.
   auto defineFuncs = DefineUserFuncs{m_context, &subTable};

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -551,6 +551,10 @@ auto GetExpr::visit(const parse::UnaryExprNode& n) -> void {
   m_expr = prog::expr::callExprNode(*m_context->getProg(), func.value(), std::move(args));
 }
 
+auto GetExpr::visit(const parse::EnumDeclStmtNode & /*unused*/) -> void {
+  throw std::logic_error{"GetExpr is not implemented for this node type"};
+}
+
 auto GetExpr::visit(const parse::ExecStmtNode & /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -71,9 +71,9 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
   auto inputTypeSet = prog::sym::TypeSet{std::move(inputTypes)};
 
   // Declare and define the function in the program.
-  const auto funcId = m_context->getProg()->declareUserFunc(
+  const auto funcId = m_context->getProg()->declareFunc(
       m_context->genAnonFuncName(), std::move(inputTypeSet), getExpr.m_expr->getType());
-  m_context->getProg()->defineUserFunc(funcId, std::move(consts), std::move(getExpr.m_expr));
+  m_context->getProg()->defineFunc(funcId, std::move(consts), std::move(getExpr.m_expr));
 
   // Either create a function literal or a closure, depending on if the anonymous func binds any
   // consts from the parent.
@@ -305,7 +305,7 @@ auto GetExpr::visit(const parse::FieldExprNode& n) -> void {
 
   const auto lhsType      = lhsExpr->getType();
   const auto& lhsTypeDecl = m_context->getProg()->getTypeDecl(lhsType);
-  if (lhsTypeDecl.getKind() != prog::sym::TypeKind::UserStruct) {
+  if (lhsTypeDecl.getKind() != prog::sym::TypeKind::Struct) {
     m_context->reportDiag(errFieldNotFoundOnType(
         m_context->getSrc(), fieldName, getDisplayName(*m_context, lhsType), n.getSpan()));
     return;
@@ -368,7 +368,7 @@ auto GetExpr::visit(const parse::IsExprNode& n) -> void {
   // Validate lhs is a union type.
   const auto lhsType      = lhsExpr->getType();
   const auto& lhsTypeDecl = m_context->getProg()->getTypeDecl(lhsType);
-  if (lhsTypeDecl.getKind() != prog::sym::TypeKind::UserUnion) {
+  if (lhsTypeDecl.getKind() != prog::sym::TypeKind::Union) {
     m_context->reportDiag(errNonUnionIsExpression(m_context->getSrc(), n[0].getSpan()));
     return;
   }

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -36,6 +36,7 @@ public:
   auto visit(const parse::SwitchExprIfNode& n) -> void override;
   auto visit(const parse::SwitchExprNode& n) -> void override;
   auto visit(const parse::UnaryExprNode& n) -> void override;
+  auto visit(const parse::EnumDeclStmtNode& n) -> void override;
   auto visit(const parse::ExecStmtNode& n) -> void override;
   auto visit(const parse::FuncDeclStmtNode& n) -> void override;
   auto visit(const parse::StructDeclStmtNode& n) -> void override;

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -76,6 +76,11 @@ private:
   [[nodiscard]] auto getBinLogicOpExpr(const parse::BinaryExprNode& n, BinLogicOp op)
       -> prog::expr::NodePtr;
 
+  [[nodiscard]] auto getStaticFieldExpr(
+      const lex::Token& nameToken,
+      const std::optional<parse::TypeParamList>& typeParams,
+      const lex::Token& fieldToken) -> prog::expr::NodePtr;
+
   [[nodiscard]] auto getConstExpr(const parse::IdExprNode& n) -> prog::expr::NodePtr;
 
   [[nodiscard]] auto getDynCallExpr(const parse::CallExprNode& n) -> prog::expr::NodePtr;

--- a/src/frontend/internal/get_identifier.cpp
+++ b/src/frontend/internal/get_identifier.cpp
@@ -4,8 +4,11 @@
 
 namespace frontend::internal {
 
-GetIdentifier::GetIdentifier() :
-    m_instance{nullptr}, m_identifier{std::nullopt}, m_typeParams{std::nullopt} {}
+GetIdentifier::GetIdentifier(bool includeInstances) :
+    m_includeInstances{includeInstances},
+    m_instance{nullptr},
+    m_identifier{std::nullopt},
+    m_typeParams{std::nullopt} {}
 
 auto GetIdentifier::getInstance() const noexcept -> const parse::Node* { return m_instance; }
 
@@ -23,8 +26,10 @@ auto GetIdentifier::visit(const parse::IdExprNode& n) -> void {
 }
 
 auto GetIdentifier::visit(const parse::FieldExprNode& n) -> void {
-  m_instance   = &n[0];
-  m_identifier = n.getId();
+  if (m_includeInstances) {
+    m_instance   = &n[0];
+    m_identifier = n.getId();
+  }
 }
 
 } // namespace frontend::internal

--- a/src/frontend/internal/get_identifier.hpp
+++ b/src/frontend/internal/get_identifier.hpp
@@ -10,7 +10,7 @@ namespace frontend::internal {
 
 class GetIdentifier final : public parse::OptionalNodeVisitor {
 public:
-  GetIdentifier();
+  explicit GetIdentifier(bool includeInstances);
 
   [[nodiscard]] auto getInstance() const noexcept -> const parse::Node*;
   [[nodiscard]] auto getIdentifier() const noexcept -> const std::optional<lex::Token>&;
@@ -21,6 +21,7 @@ public:
   auto visit(const parse::FieldExprNode& n) -> void override;
 
 private:
+  bool m_includeInstances;
   const parse::Node* m_instance;
   std::optional<lex::Token> m_identifier;
   std::optional<parse::TypeParamList> m_typeParams;

--- a/src/frontend/internal/struct_template.cpp
+++ b/src/frontend/internal/struct_template.cpp
@@ -40,7 +40,7 @@ auto StructTemplate::setupInstance(TypeTemplateInst* instance) -> void {
   assert(getContext()->getProg()->lookupType(mangledName) == std::nullopt);
 
   // Declare the struct in the program.
-  instance->m_type = getContext()->getProg()->declareUserStruct(mangledName);
+  instance->m_type = getContext()->getProg()->declareStruct(mangledName);
 
   // Define the struct.
   auto defineTypes    = DefineUserTypes{getContext(), &subTable};

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -304,6 +304,10 @@ auto TypeInferExpr::visit(const parse::UnaryExprNode& n) -> void {
   m_type       = inferFuncCall(prog::getFuncName(*op), {argType}, false);
 }
 
+auto TypeInferExpr::visit(const parse::EnumDeclStmtNode & /*unused*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
 auto TypeInferExpr::visit(const parse::ExecStmtNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -193,7 +193,7 @@ auto TypeInferExpr::visit(const parse::FieldExprNode& n) -> void {
   }
 
   // Only structs are supported atm.
-  if (m_context->getProg()->getTypeDecl(lhsType).getKind() != prog::sym::TypeKind::UserStruct) {
+  if (m_context->getProg()->getTypeDecl(lhsType).getKind() != prog::sym::TypeKind::Struct) {
     return;
   }
 

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -54,8 +54,6 @@ private:
 
   auto setConstType(const lex::Token& constId, prog::sym::TypeId type) -> void;
   [[nodiscard]] auto inferConstType(const lex::Token& constId) -> prog::sym::TypeId;
-
-  [[nodiscard]] auto isType(const std::string& name) const -> bool;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -33,6 +33,7 @@ public:
   auto visit(const parse::SwitchExprIfNode& n) -> void override;
   auto visit(const parse::SwitchExprNode& n) -> void override;
   auto visit(const parse::UnaryExprNode& n) -> void override;
+  auto visit(const parse::EnumDeclStmtNode& n) -> void override;
   auto visit(const parse::ExecStmtNode& n) -> void override;
   auto visit(const parse::FuncDeclStmtNode& n) -> void override;
   auto visit(const parse::StructDeclStmtNode& n) -> void override;

--- a/src/frontend/internal/union_template.cpp
+++ b/src/frontend/internal/union_template.cpp
@@ -39,7 +39,7 @@ auto UnionTemplate::setupInstance(TypeTemplateInst* instance) -> void {
   assert(getContext()->getProg()->lookupType(mangledName) == std::nullopt);
 
   // Declare the struct in the program.
-  instance->m_type = getContext()->getProg()->declareUserUnion(mangledName);
+  instance->m_type = getContext()->getProg()->declareUnion(mangledName);
 
   // Define the union.
   auto defineTypes    = DefineUserTypes{getContext(), &subTable};

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -171,8 +171,7 @@ auto getOrInstType(
     Context* context,
     const TypeSubstitutionTable* subTable,
     const lex::Token& nameToken,
-    const std::optional<parse::TypeParamList>& typeParams,
-    const prog::sym::TypeSet& constructorArgs) -> std::optional<prog::sym::TypeId> {
+    const std::optional<parse::TypeParamList>& typeParams) -> std::optional<prog::sym::TypeId> {
 
   const auto typeName = getName(nameToken);
 
@@ -195,8 +194,25 @@ auto getOrInstType(
     return type;
   }
 
+  return std::nullopt;
+}
+
+auto getOrInstType(
+    Context* context,
+    const TypeSubstitutionTable* subTable,
+    const lex::Token& nameToken,
+    const std::optional<parse::TypeParamList>& typeParams,
+    const prog::sym::TypeSet& constructorArgs) -> std::optional<prog::sym::TypeId> {
+
+  // Check if a type can be found / instantiated.
+  const auto result = getOrInstType(context, subTable, nameToken, typeParams);
+  if (result) {
+    return result;
+  }
+
   // Attempt to instantiate a templated type by infering the type parameters based on the
   // constructor arguments.
+  const auto typeName = getName(nameToken);
   const auto typeInstantiation =
       context->getTypeTemplates()->inferParamsAndInstantiate(typeName, constructorArgs);
   if (typeInstantiation) {

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -23,6 +23,12 @@ namespace frontend::internal {
     Context* context,
     const TypeSubstitutionTable* subTable,
     const lex::Token& nameToken,
+    const std::optional<parse::TypeParamList>& typeParams) -> std::optional<prog::sym::TypeId>;
+
+[[nodiscard]] auto getOrInstType(
+    Context* context,
+    const TypeSubstitutionTable* subTable,
+    const lex::Token& nameToken,
     const std::optional<parse::TypeParamList>& typeParams,
     const prog::sym::TypeSet& constructorArgs) -> std::optional<prog::sym::TypeId>;
 

--- a/src/frontend/internal/validate_types.cpp
+++ b/src/frontend/internal/validate_types.cpp
@@ -11,7 +11,7 @@ ValidateTypes::ValidateTypes(Context* context) : m_context{context} {
 
 auto ValidateTypes::validate(prog::sym::TypeId id) -> void {
   const auto& typedecl = m_context->getProg()->getTypeDecl(id);
-  if (typedecl.getKind() == prog::sym::TypeKind::UserStruct) {
+  if (typedecl.getKind() == prog::sym::TypeKind::Struct) {
     const auto typeInfo   = m_context->getTypeInfo(id);
     const auto sourceSpan = typeInfo ? typeInfo->getSourceSpan() : input::Span{0, 0};
     const auto& structDef = std::get<prog::sym::StructDef>(m_context->getProg()->getTypeDef(id));
@@ -42,7 +42,7 @@ auto ValidateTypes::getCyclicField(
       return f.getId();
     }
     const auto& fTypeDecl = m_context->getProg()->getTypeDecl(fType);
-    if (fTypeDecl.getKind() == prog::sym::TypeKind::UserStruct) {
+    if (fTypeDecl.getKind() == prog::sym::TypeKind::Struct) {
       auto childVisitedTypes = visitedTypes;
       childVisitedTypes.insert(fTypeDecl.getId());
 

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -17,6 +17,9 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::Union:
     out << "union";
     break;
+  case Keyword::Enum:
+    out << "enum";
+    break;
   case Keyword::If:
     out << "if";
     break;
@@ -36,6 +39,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
       {"lambda", Keyword::Lambda},
       {"struct", Keyword::Struct},
       {"union", Keyword::Union},
+      {"enum", Keyword::Enum},
       {"if", Keyword::If},
       {"else", Keyword::Else},
       {"is", Keyword::Is},

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -61,13 +61,13 @@ static auto addTokens(const ArgumentListDecl& argList, std::vector<lex::Token>* 
 static auto getError(std::ostream& out, const ArgumentListDecl& argList) -> void {
   if (argList.getOpen().getKind() != lex::TokenKind::SepOpenParen &&
       argList.getOpen().getKind() != lex::TokenKind::OpParenParen) {
-    out << "Expected opening parentheses '(' but got: " << argList.getOpen();
+    out << "Expected opening parentheses '(' but got: '" << argList.getOpen() << '\'';
   } else if (argList.getCommas().size() != (argList.getCount() == 0 ? 0 : argList.getCount() - 1)) {
     out << "Incorrect number of comma's ',' in function declaration";
   } else if (
       argList.getClose().getKind() != lex::TokenKind::SepCloseParen &&
       argList.getClose().getKind() != lex::TokenKind::OpParenParen) {
-    out << "Expected closing parentheses ')' but got: " << argList.getClose();
+    out << "Expected closing parentheses ')' but got: '" << argList.getClose() << '\'';
   } else {
     out << "Invalid argument list";
   }
@@ -83,15 +83,15 @@ auto errInvalidStmtFuncDecl(
 
   std::ostringstream oss;
   if (id.getKind() != lex::TokenKind::Identifier && id.getCat() != lex::TokenCat::Operator) {
-    oss << "Expected function identifier but got: " << id;
+    oss << "Expected function identifier but got: '" << id << '\'';
   } else if (typeSubs && !typeSubs->validate()) {
     oss << "Invalid type substitution parameters";
   } else if (!argList.validate()) {
     getError(oss, argList);
   } else if (retType && retType->getArrow().getKind() != lex::TokenKind::SepArrow) {
-    oss << "Expected return-type seperator (->) but got: " << retType->getArrow();
+    oss << "Expected return-type seperator (->) but got: '" << retType->getArrow() << '\'';
   } else if (retType && !retType->getType().validate()) {
-    oss << "Invalid return-type specification: " << retType->getType();
+    oss << "Invalid return-type specification: '" << retType->getType() << '\'';
   } else {
     oss << "Invalid function declaration";
   }
@@ -143,11 +143,11 @@ auto errInvalidStmtStructDecl(
 
   std::ostringstream oss;
   if (id.getKind() != lex::TokenKind::Identifier) {
-    oss << "Expected struct identifier but got: " << id;
+    oss << "Expected struct identifier but got: '" << id << '\'';
   } else if (typeSubs && !typeSubs->validate()) {
     oss << "Invalid type substitution parameters";
   } else if (eq && eq->getKind() != lex::TokenKind::OpEq) {
-    oss << "Expected equals-sign '=' but got: " << *eq;
+    oss << "Expected equals-sign '=' but got: '" << *eq << '\'';
   } else if (eq && fields.empty()) {
     oss << "Expected at least one field after the equals-sign '=' sign";
   } else if (commas.size() != (fields.empty() ? 0 : fields.size() - 1)) {
@@ -186,11 +186,11 @@ auto errInvalidStmtUnionDecl(
 
   std::ostringstream oss;
   if (id.getKind() != lex::TokenKind::Identifier) {
-    oss << "Expected union identifier but got: " << id;
+    oss << "Expected union identifier but got: '" << id << '\'';
   } else if (typeSubs && !typeSubs->validate()) {
     oss << "Invalid type substitution parameters";
   } else if (eq.getKind() != lex::TokenKind::OpEq) {
-    oss << "Expected equals-sign '=' but got: " << eq;
+    oss << "Expected equals-sign '=' but got: '" << eq << '\'';
   } else if (types.size() < 2) {
     oss << "Union declaration needs at least two types";
   } else if (commas.size() != types.size() - 1) {
@@ -224,9 +224,9 @@ auto errInvalidStmtEnumDecl(
     std::vector<lex::Token> commas) -> NodePtr {
   std::ostringstream oss;
   if (id.getKind() != lex::TokenKind::Identifier) {
-    oss << "Expected union identifier but got: " << id;
+    oss << "Expected union identifier but got: '" << id << '\'';
   } else if (eq.getKind() != lex::TokenKind::OpEq) {
-    oss << "Expected equals-sign '=' but got: " << eq;
+    oss << "Expected equals-sign '=' but got: '" << eq << '\'';
   } else if (entries.empty()) {
     oss << "Enum declaration needs at least one entry";
   } else if (!std::all_of(entries.begin(), entries.end(), [](const auto& entry) {
@@ -247,7 +247,10 @@ auto errInvalidStmtEnumDecl(
     tokens.push_back(entry.getIdentifier());
     if (entry.getValueSpec()) {
       tokens.push_back(entry.getValueSpec()->getColon());
-      tokens.push_back(entry.getValueSpec()->getValue());
+      if (entry.getValueSpec()->getMinusToken()) {
+        tokens.push_back(*entry.getValueSpec()->getMinusToken());
+      }
+      tokens.push_back(entry.getValueSpec()->getValueToken());
     }
   }
   for (auto& comma : commas) {
@@ -267,11 +270,11 @@ auto errInvalidStmtExec(
   std::ostringstream oss;
   if (open.getKind() != lex::TokenKind::SepOpenParen &&
       open.getKind() != lex::TokenKind::OpParenParen) {
-    oss << "Expected opening parentheses '(' but got: " << open;
+    oss << "Expected opening parentheses '(' but got: '" << open << '\'';
   } else if (
       close.getKind() != lex::TokenKind::SepCloseParen &&
       close.getKind() != lex::TokenKind::OpParenParen) {
-    oss << "Expected closing parentheses ')' but got: " << close;
+    oss << "Expected closing parentheses ')' but got: '" << close << '\'';
   } else if (commas.size() != (args.empty() ? 0 : args.size() - 1)) {
     oss << "Incorrect number of comma's ',' in execute statement";
   } else {
@@ -297,14 +300,14 @@ auto errInvalidPrimaryExpr(lex::Token token) -> NodePtr {
   if (token.isEnd()) {
     oss << "Missing primary expression";
   } else {
-    oss << "Invalid primary expression: " << token;
+    oss << "Invalid primary expression: '" << token << '\'';
   }
   return errorNode(oss.str(), std::move(token));
 }
 
 auto errInvalidUnaryOp(lex::Token op, NodePtr rhs) -> NodePtr {
   std::ostringstream oss;
-  oss << "Invalid unary operator: " << op;
+  oss << "Invalid unary operator: '" << op << '\'';
   return errorNode(oss.str(), std::move(op), std::move(rhs));
 }
 
@@ -312,11 +315,11 @@ auto errInvalidParenExpr(lex::Token open, NodePtr expr, lex::Token close) -> Nod
   std::ostringstream oss;
   if (open.getKind() != lex::TokenKind::SepOpenParen &&
       open.getKind() != lex::TokenKind::OpParenParen) {
-    oss << "Expected opening parentheses '(' but got: " << open;
+    oss << "Expected opening parentheses '(' but got: '" << open << '\'';
   } else if (
       close.getKind() != lex::TokenKind::SepCloseParen &&
       close.getKind() != lex::TokenKind::OpParenParen) {
-    oss << "Expected closing parentheses ')' but got: " << close;
+    oss << "Expected closing parentheses ')' but got: '" << close << '\'';
   } else {
     oss << "Invalid parenthesized expression";
   }
@@ -334,9 +337,9 @@ auto errInvalidParenExpr(lex::Token open, NodePtr expr, lex::Token close) -> Nod
 auto errInvalidFieldExpr(NodePtr lhs, lex::Token dot, lex::Token id) -> NodePtr {
   std::ostringstream oss;
   if (dot.getKind() != lex::TokenKind::OpDot) {
-    oss << "Expected dot '.' but got: " << dot;
+    oss << "Expected dot '.' but got: '" << dot << '\'';
   } else if (id.getKind() != lex::TokenKind::Identifier) {
-    oss << "Expected field identifier but got: " << id;
+    oss << "Expected field identifier but got: '" << id << '\'';
   } else {
     oss << "Invalid field expression";
   }
@@ -371,12 +374,12 @@ auto errInvalidIdExpr(lex::Token id, std::optional<TypeParamList> typeParams) ->
 auto errInvalidIsExpr(NodePtr lhs, lex::Token kw, const Type& type, lex::Token id) -> NodePtr {
   std::ostringstream oss;
   if (getKw(kw) != lex::Keyword::Is) {
-    oss << "Expected keyword 'is' but got: " << kw;
+    oss << "Expected keyword 'is' but got: '" << kw << '\'';
   } else if (!type.validate()) {
     oss << "Invalid type identifier: " << type;
   } else if (
       id.getKind() != lex::TokenKind::Identifier && id.getKind() != lex::TokenKind::Discard) {
-    oss << "Expected identifier or discard '_' but got: " << id;
+    oss << "Expected identifier or discard '_' but got: '" << id << '\'';
   } else {
     oss << "Invalid 'is' expression";
   }
@@ -405,11 +408,11 @@ auto errInvalidCallExpr(
   } else if (
       open.getKind() != lex::TokenKind::SepOpenParen &&
       open.getKind() != lex::TokenKind::OpParenParen) {
-    oss << "Expected opening parentheses '(' but got: " << open;
+    oss << "Expected opening parentheses '(' but got: '" << open << '\'';
   } else if (
       close.getKind() != lex::TokenKind::SepCloseParen &&
       close.getKind() != lex::TokenKind::OpParenParen) {
-    oss << "Expected closing parentheses ')' but got: " << close;
+    oss << "Expected closing parentheses ')' but got: '" << close << '\'';
   } else {
     oss << "Invalid call expression";
   }
@@ -443,9 +446,9 @@ auto errInvalidIndexExpr(
   } else if (commas.size() != args.size() - 1) {
     oss << "Incorrect number of comma's ',' in index expression";
   } else if (open.getKind() != lex::TokenKind::SepOpenSquare) {
-    oss << "Expected opening square-bracket '[' but got: " << open;
+    oss << "Expected opening square-bracket '[' but got: '" << open << '\'';
   } else if (close.getKind() != lex::TokenKind::SepCloseSquare) {
-    oss << "Expected closing square-bracket ']' but got: " << close;
+    oss << "Expected closing square-bracket ']' but got: '" << close << '\'';
   } else {
     oss << "Invalid index expression";
   }
@@ -472,9 +475,9 @@ auto errInvalidConditionalExpr(
 
   std::ostringstream oss;
   if (qmark.getKind() != lex::TokenKind::OpQMark) {
-    oss << "Expected question-mark '?' but got: " << qmark;
+    oss << "Expected question-mark '?' but got: '" << qmark << '\'';
   } else if (colon.getKind() != lex::TokenKind::SepColon) {
-    oss << "Expected colon ':' but got: " << colon;
+    oss << "Expected colon ':' but got: '" << colon << '\'';
   } else {
     oss << "Invalid conditional operator";
   }
@@ -494,9 +497,9 @@ auto errInvalidConditionalExpr(
 auto errInvalidSwitchIf(lex::Token kw, NodePtr cond, lex::Token arrow, NodePtr rhs) -> NodePtr {
   std::ostringstream oss;
   if (getKw(kw) != lex::Keyword::If) {
-    oss << "Expected keyword 'if' but got: " << kw;
+    oss << "Expected keyword 'if' but got: '" << kw << '\'';
   } else if (arrow.getKind() != lex::TokenKind::SepArrow) {
-    oss << "Expected arrow '->' but got: " << arrow;
+    oss << "Expected arrow '->' but got: '" << arrow << '\'';
   } else {
     oss << "Invalid if clause";
   }
@@ -515,9 +518,9 @@ auto errInvalidSwitchIf(lex::Token kw, NodePtr cond, lex::Token arrow, NodePtr r
 auto errInvalidSwitchElse(lex::Token kw, lex::Token arrow, NodePtr rhs) -> NodePtr {
   std::ostringstream oss;
   if (getKw(kw) != lex::Keyword::Else) {
-    oss << "Expected keyword 'else' but got: " << kw;
+    oss << "Expected keyword 'else' but got: '" << kw << '\'';
   } else if (arrow.getKind() != lex::TokenKind::SepArrow) {
-    oss << "Expected arrow '->' but got: " << arrow;
+    oss << "Expected arrow '->' but got: '" << arrow << '\'';
   } else {
     oss << "Invalid else clause";
   }

--- a/src/parse/node_stmt_enum_decl.cpp
+++ b/src/parse/node_stmt_enum_decl.cpp
@@ -1,0 +1,120 @@
+#include "parse/node_stmt_enum_decl.hpp"
+#include "utilities.hpp"
+
+namespace parse {
+
+static auto getIdOrErr(const lex::Token& token) {
+  return getId(token).value_or(std::string("err"));
+}
+
+EnumDeclStmtNode::ValueSpec::ValueSpec(lex::Token colon, lex::Token value) :
+    m_colon{std::move(colon)}, m_value{std::move(value)} {}
+
+auto EnumDeclStmtNode::ValueSpec::operator==(const ValueSpec& rhs) const noexcept -> bool {
+  return m_colon == rhs.m_colon && m_value == rhs.m_value;
+}
+
+auto EnumDeclStmtNode::ValueSpec::getColon() const noexcept -> const lex::Token& { return m_colon; }
+
+auto EnumDeclStmtNode::ValueSpec::getValue() const noexcept -> const lex::Token& { return m_value; }
+
+auto EnumDeclStmtNode::ValueSpec::validate() const noexcept -> bool {
+  return m_colon.getKind() == lex::TokenKind::SepColon &&
+      m_value.getKind() == lex::TokenKind::LitInt;
+}
+
+EnumDeclStmtNode::EntrySpec::EntrySpec(lex::Token identifier, std::optional<ValueSpec> value) :
+    m_identifier{std::move(identifier)}, m_value{std::move(value)} {}
+
+auto EnumDeclStmtNode::EntrySpec::operator==(const EntrySpec& rhs) const noexcept -> bool {
+  return m_identifier == rhs.m_identifier && m_value == rhs.m_value;
+}
+
+auto EnumDeclStmtNode::EntrySpec::getSpan() const -> input::Span {
+  return m_value ? input::Span::combine(m_identifier.getSpan(), m_value->getValue().getSpan())
+                 : m_identifier.getSpan();
+}
+
+auto EnumDeclStmtNode::EntrySpec::getIdentifier() const noexcept -> const lex::Token& {
+  return m_identifier;
+}
+
+auto EnumDeclStmtNode::EntrySpec::getValueSpec() const noexcept -> const std::optional<ValueSpec>& {
+  return m_value;
+}
+
+auto EnumDeclStmtNode::EntrySpec::validate() const noexcept -> bool {
+  return m_identifier.getKind() == lex::TokenKind::Identifier &&
+      (m_value == std::nullopt || m_value->validate());
+}
+
+EnumDeclStmtNode::EnumDeclStmtNode(
+    lex::Token kw,
+    lex::Token id,
+    lex::Token eq,
+    std::vector<EntrySpec> entries,
+    std::vector<lex::Token> commas) :
+    m_kw{std::move(kw)},
+    m_id{std::move(id)},
+    m_eq{std::move(eq)},
+    m_entries{std::move(entries)},
+    m_commas{std::move(commas)} {}
+
+auto EnumDeclStmtNode::operator==(const Node& rhs) const noexcept -> bool {
+  const auto r = dynamic_cast<const EnumDeclStmtNode*>(&rhs);
+  return r != nullptr && m_id == r->m_id && m_entries == r->m_entries;
+}
+
+auto EnumDeclStmtNode::operator!=(const Node& rhs) const noexcept -> bool {
+  return !EnumDeclStmtNode::operator==(rhs);
+}
+
+auto EnumDeclStmtNode::operator[](unsigned int /*unused*/) const -> const Node& {
+  throw std::out_of_range{"No child at given index"};
+}
+
+auto EnumDeclStmtNode::getChildCount() const -> unsigned int { return 0; }
+
+auto EnumDeclStmtNode::getSpan() const -> input::Span {
+  return input::Span::combine(m_kw.getSpan(), m_entries.back().getIdentifier().getSpan());
+}
+
+auto EnumDeclStmtNode::getId() const -> const lex::Token& { return m_id; }
+
+auto EnumDeclStmtNode::getEntries() const -> const std::vector<EntrySpec>& { return m_entries; }
+
+auto EnumDeclStmtNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
+
+auto EnumDeclStmtNode::print(std::ostream& out) const -> std::ostream& {
+  out << "enum-" << getIdOrErr(m_id) << '=';
+  for (auto i = 0U; i < m_entries.size(); ++i) {
+    if (i != 0) {
+      out << ",";
+    }
+    const auto& entry = m_entries[i];
+    out << getIdOrErr(entry.getIdentifier());
+    if (entry.getValueSpec()) {
+      out << ':' << entry.getValueSpec()->getValue();
+    }
+  }
+  return out;
+}
+
+// Factories.
+auto enumDeclStmtNode(
+    lex::Token kw,
+    lex::Token id,
+    lex::Token eq,
+    std::vector<EnumDeclStmtNode::EntrySpec> entries,
+    std::vector<lex::Token> commas) -> NodePtr {
+  if (entries.empty()) {
+    throw std::invalid_argument{"Enum needs atleast one field"};
+  }
+  if (commas.size() != entries.size() - 1) {
+    throw std::invalid_argument{"Incorrect number of commas"};
+  }
+  return std::unique_ptr<EnumDeclStmtNode>{new EnumDeclStmtNode{
+      std::move(kw), std::move(id), std::move(eq), std::move(entries), std::move(commas)}};
+}
+
+} // namespace parse

--- a/src/parse/node_stmt_enum_decl.cpp
+++ b/src/parse/node_stmt_enum_decl.cpp
@@ -7,6 +7,8 @@ static auto getIdOrErr(const lex::Token& token) {
   return getId(token).value_or(std::string("err"));
 }
 
+static auto getIntOrDef(const lex::Token& token) { return getInt(token).value_or(-1); }
+
 EnumDeclStmtNode::ValueSpec::ValueSpec(lex::Token colon, lex::Token value) :
     m_colon{std::move(colon)}, m_value{std::move(value)} {}
 
@@ -94,7 +96,7 @@ auto EnumDeclStmtNode::print(std::ostream& out) const -> std::ostream& {
     const auto& entry = m_entries[i];
     out << getIdOrErr(entry.getIdentifier());
     if (entry.getValueSpec()) {
-      out << ':' << entry.getValueSpec()->getValue();
+      out << ':' << getIntOrDef(entry.getValueSpec()->getValue());
     }
   }
   return out;

--- a/src/parse/node_stmt_struct_decl.cpp
+++ b/src/parse/node_stmt_struct_decl.cpp
@@ -36,7 +36,7 @@ StructDeclStmtNode::StructDeclStmtNode(
 
 auto StructDeclStmtNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const StructDeclStmtNode*>(&rhs);
-  return r != nullptr && m_id == r->m_id && m_fields == r->m_fields;
+  return r != nullptr && m_id == r->m_id && m_typeSubs == r->m_typeSubs && m_fields == r->m_fields;
 }
 
 auto StructDeclStmtNode::operator!=(const Node& rhs) const noexcept -> bool {

--- a/src/parse/node_stmt_union_decl.cpp
+++ b/src/parse/node_stmt_union_decl.cpp
@@ -22,7 +22,7 @@ UnionDeclStmtNode::UnionDeclStmtNode(
 
 auto UnionDeclStmtNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const UnionDeclStmtNode*>(&rhs);
-  return r != nullptr && m_id == r->m_id && m_types == r->m_types;
+  return r != nullptr && m_id == r->m_id && m_typeSubs == r->m_typeSubs && m_types == r->m_types;
 }
 
 auto UnionDeclStmtNode::operator!=(const Node& rhs) const noexcept -> bool {

--- a/src/parse/node_visitor_deep.cpp
+++ b/src/parse/node_visitor_deep.cpp
@@ -45,6 +45,8 @@ auto DeepNodeVisitor::visit(const SwitchExprNode& n) -> void { visitChildren(&n,
 
 auto DeepNodeVisitor::visit(const UnaryExprNode& n) -> void { visitChildren(&n, this); }
 
+auto DeepNodeVisitor::visit(const EnumDeclStmtNode& n) -> void { visitChildren(&n, this); }
+
 auto DeepNodeVisitor::visit(const ExecStmtNode& n) -> void { visitChildren(&n, this); }
 
 auto DeepNodeVisitor::visit(const FuncDeclStmtNode& n) -> void { visitChildren(&n, this); }

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -25,6 +25,8 @@ auto ParserImpl::nextStmt() -> NodePtr {
       return nextStmtStructDecl();
     case lex::Keyword::Union:
       return nextStmtUnionDecl();
+    case lex::Keyword::Enum:
+      return nextStmtEnumDecl();
     default:
       break;
     }
@@ -145,17 +147,59 @@ auto ParserImpl::nextStmtUnionDecl() -> NodePtr {
     }
   }
 
-  auto typeSubsValid = !typeSubs || typeSubs->validate();
-  if (getKw(kw) == lex::Keyword::Union && id.getKind() == lex::TokenKind::Identifier &&
-      typeSubsValid && eq.getKind() == lex::TokenKind::OpEq && types.size() >= 2 &&
-      std::all_of(types.begin(), types.end(), [](const auto& t) { return t.validate(); }) &&
-      commas.size() == types.size() - 1) {
+  const auto kwValid       = getKw(kw) == lex::Keyword::Union;
+  const auto idValid       = id.getKind() == lex::TokenKind::Identifier;
+  const auto typeSubsValid = !typeSubs || typeSubs->validate();
+  const auto eqValid       = eq.getKind() == lex::TokenKind::OpEq;
+  const auto typesValid =
+      std::all_of(types.begin(), types.end(), [](const auto& t) { return t.validate(); });
 
+  if (kwValid && idValid && typeSubsValid && eqValid && types.size() >= 2 && typesValid &&
+      commas.size() == types.size() - 1) {
     return unionDeclStmtNode(
         kw, std::move(id), std::move(typeSubs), eq, std::move(types), std::move(commas));
   }
   return errInvalidStmtUnionDecl(
       kw, std::move(id), std::move(typeSubs), eq, types, std::move(commas));
+}
+
+auto ParserImpl::nextStmtEnumDecl() -> NodePtr {
+  auto kw      = consumeToken();
+  auto id      = consumeToken();
+  auto eq      = consumeToken();
+  auto entries = std::vector<EnumDeclStmtNode::EntrySpec>{};
+  auto commas  = std::vector<lex::Token>{};
+  while (peekToken(0).getKind() == lex::TokenKind::Identifier) {
+    auto entryId                                          = consumeToken();
+    std::optional<EnumDeclStmtNode::ValueSpec> entryValue = std::nullopt;
+
+    // Allow consume value specifiers that use '=' instead of ':', reason is that its common in
+    // other languages and this way we can provide a proper error message in that case.
+    if (peekToken(0).getKind() == lex::TokenKind::SepColon ||
+        peekToken(0).getKind() == lex::TokenKind::OpEq) {
+      auto colon = consumeToken();
+      auto value = consumeToken();
+      entryValue = EnumDeclStmtNode::ValueSpec{colon, std::move(value)};
+    }
+    entries.emplace_back(EnumDeclStmtNode::EntrySpec{std::move(entryId), std::move(entryValue)});
+    if (peekToken(0).getKind() == lex::TokenKind::SepComma) {
+      commas.push_back(consumeToken());
+    } else {
+      break;
+    }
+  }
+
+  const auto kwValid = getKw(kw) == lex::Keyword::Enum;
+  const auto idValid = id.getKind() == lex::TokenKind::Identifier;
+  const auto eqValid = eq.getKind() == lex::TokenKind::OpEq;
+  const auto entriesValid =
+      std::all_of(entries.begin(), entries.end(), [](const auto& e) { return e.validate(); });
+  const auto commasValid = commas.size() == entries.size() - 1;
+
+  if (kwValid && idValid && eqValid && !entries.empty() && entriesValid && commasValid) {
+    return enumDeclStmtNode(kw, std::move(id), eq, std::move(entries), std::move(commas));
+  }
+  return errInvalidStmtEnumDecl(kw, std::move(id), eq, entries, std::move(commas));
 }
 
 auto ParserImpl::nextStmtExec() -> NodePtr {
@@ -175,8 +219,9 @@ auto ParserImpl::nextStmtExec() -> NodePtr {
   }
   auto close = empty ? open : consumeToken();
 
-  if (action.getKind() == lex::TokenKind::Identifier && validateParentheses(open, close) &&
-      commas.size() == (args.empty() ? 0 : args.size() - 1)) {
+  const auto idValid     = action.getKind() == lex::TokenKind::Identifier;
+  const auto commasValid = commas.size() == (args.empty() ? 0 : args.size() - 1);
+  if (idValid && validateParentheses(open, close) && commasValid) {
     return execStmtNode(std::move(action), open, std::move(args), std::move(commas), close);
   }
   return errInvalidStmtExec(std::move(action), open, std::move(args), std::move(commas), close);
@@ -305,8 +350,10 @@ auto ParserImpl::nextExprIs(NodePtr lhs) -> NodePtr {
   auto type = nextType();
   auto id   = consumeToken();
 
-  if (getKw(kw) == lex::Keyword::Is && type.validate() &&
-      (id.getKind() == lex::TokenKind::Identifier || id.getKind() == lex::TokenKind::Discard)) {
+  const auto idValid =
+      id.getKind() == lex::TokenKind::Identifier || id.getKind() == lex::TokenKind::Discard;
+
+  if (getKw(kw) == lex::Keyword::Is && type.validate() && idValid) {
     return isExprNode(std::move(lhs), kw, std::move(type), std::move(id));
   }
   return errInvalidIsExpr(std::move(lhs), kw, type, std::move(id));
@@ -328,7 +375,8 @@ auto ParserImpl::nextExprCall(NodePtr lhs) -> NodePtr {
   }
   auto close = empty ? open : consumeToken();
 
-  if (validateParentheses(open, close) && commas.size() == (args.empty() ? 0 : args.size() - 1)) {
+  const auto commasValid = commas.size() == (args.empty() ? 0 : args.size() - 1);
+  if (validateParentheses(open, close) && commasValid) {
     return callExprNode(std::move(lhs), open, std::move(args), std::move(commas), close);
   }
   return errInvalidCallExpr(std::move(lhs), open, std::move(args), std::move(commas), close);
@@ -346,9 +394,10 @@ auto ParserImpl::nextExprIndex(NodePtr lhs) -> NodePtr {
   }
   auto close = consumeToken();
 
-  if (open.getKind() == lex::TokenKind::SepOpenSquare &&
-      close.getKind() == lex::TokenKind::SepCloseSquare && !args.empty() &&
-      commas.size() == args.size() - 1) {
+  const auto openValid   = open.getKind() == lex::TokenKind::SepOpenSquare;
+  const auto closeValid  = close.getKind() == lex::TokenKind::SepCloseSquare;
+  const auto commasValid = commas.size() == args.size() - 1;
+  if (openValid && closeValid && !args.empty() && commasValid) {
     return indexExprNode(std::move(lhs), open, std::move(args), std::move(commas), close);
   }
   return errInvalidIndexExpr(std::move(lhs), open, std::move(args), std::move(commas), close);

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -170,16 +170,18 @@ auto ParserImpl::nextStmtEnumDecl() -> NodePtr {
   auto entries = std::vector<EnumDeclStmtNode::EntrySpec>{};
   auto commas  = std::vector<lex::Token>{};
   while (peekToken(0).getKind() == lex::TokenKind::Identifier) {
-    auto entryId                                          = consumeToken();
-    std::optional<EnumDeclStmtNode::ValueSpec> entryValue = std::nullopt;
+    auto entryId    = consumeToken();
+    auto entryValue = std::optional<EnumDeclStmtNode::ValueSpec>{};
 
     // Allow consume value specifiers that use '=' instead of ':', reason is that its common in
     // other languages and this way we can provide a proper error message in that case.
     if (peekToken(0).getKind() == lex::TokenKind::SepColon ||
         peekToken(0).getKind() == lex::TokenKind::OpEq) {
       auto colon = consumeToken();
+      auto minus = peekToken(0).getKind() == lex::TokenKind::OpMinus ? std::optional{consumeToken()}
+                                                                     : std::nullopt;
       auto value = consumeToken();
-      entryValue = EnumDeclStmtNode::ValueSpec{colon, std::move(value)};
+      entryValue = EnumDeclStmtNode::ValueSpec{colon, std::move(minus), std::move(value)};
     }
     entries.emplace_back(EnumDeclStmtNode::EntrySpec{std::move(entryId), std::move(entryValue)});
     if (peekToken(0).getKind() == lex::TokenKind::SepComma) {

--- a/src/parse/utilities.cpp
+++ b/src/parse/utilities.cpp
@@ -1,6 +1,7 @@
 #include "utilities.hpp"
 #include "lex/token_payload_id.hpp"
 #include "lex/token_payload_keyword.hpp"
+#include "lex/token_payload_lit_int.hpp"
 #include <algorithm>
 #include <iterator>
 
@@ -18,6 +19,13 @@ auto getId(const lex::Token& token) -> std::optional<std::string> {
     return std::nullopt;
   }
   return token.getPayload<lex::IdentifierTokenPayload>()->getIdentifier();
+}
+
+auto getInt(const lex::Token& token) -> std::optional<int32_t> {
+  if (token.getKind() != lex::TokenKind::LitInt) {
+    return std::nullopt;
+  }
+  return token.getPayload<lex::LitIntTokenPayload>()->getValue();
 }
 
 auto getSpan(const std::vector<lex::Token>& tokens) -> std::optional<input::Span> {

--- a/src/parse/utilities.hpp
+++ b/src/parse/utilities.hpp
@@ -8,6 +8,7 @@ namespace parse {
 
 [[nodiscard]] auto getKw(const lex::Token& token) -> std::optional<lex::Keyword>;
 [[nodiscard]] auto getId(const lex::Token& token) -> std::optional<std::string>;
+[[nodiscard]] auto getInt(const lex::Token& token) -> std::optional<int32_t>;
 
 [[nodiscard]] auto getSpan(const std::vector<lex::Token>& tokens) -> std::optional<input::Span>;
 [[nodiscard]] auto getSpan(const std::vector<NodePtr>& nodes) -> std::optional<input::Span>;

--- a/src/prog/expr/node_call_dyn.cpp
+++ b/src/prog/expr/node_call_dyn.cpp
@@ -45,7 +45,7 @@ auto callDynExprNode(const Program& prog, NodePtr lhs, std::vector<NodePtr> args
     throw std::invalid_argument{"Call dyn node cannot contain a null argument"};
   }
   const auto& typeDecl = prog.getTypeDecl(lhs->getType());
-  if (typeDecl.getKind() != sym::TypeKind::UserDelegate) {
+  if (typeDecl.getKind() != sym::TypeKind::Delegate) {
     throw std::invalid_argument{"Lhs expr to dyn call has to be a delegate type"};
   }
   const auto& delegateDef   = std::get<sym::DelegateDef>(prog.getTypeDef(lhs->getType()));

--- a/src/prog/expr/node_closure.cpp
+++ b/src/prog/expr/node_closure.cpp
@@ -47,7 +47,7 @@ auto closureNode(
     throw std::invalid_argument{"Closure node cannot contain a null bound argument"};
   }
   const auto& typeDecl = program.getTypeDecl(type);
-  if (typeDecl.getKind() != sym::TypeKind::UserDelegate) {
+  if (typeDecl.getKind() != sym::TypeKind::Delegate) {
     throw std::invalid_argument{"Type is not a delegate type"};
   }
   const auto& delegateDef = std::get<sym::DelegateDef>(program.getTypeDef(type));

--- a/src/prog/expr/node_field.cpp
+++ b/src/prog/expr/node_field.cpp
@@ -40,7 +40,7 @@ auto FieldExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(
 auto fieldExprNode(const Program& prog, NodePtr lhs, sym::FieldId id) -> NodePtr {
   const auto lhsType      = lhs->getType();
   const auto& lhsTypeDecl = prog.getTypeDecl(lhsType);
-  if (lhsTypeDecl.getKind() != sym::TypeKind::UserStruct) {
+  if (lhsTypeDecl.getKind() != sym::TypeKind::Struct) {
     throw std::invalid_argument{"Fields are only supported on structs"};
   }
   const auto& structDef = std::get<prog::sym::StructDef>(prog.getTypeDef(lhsType));

--- a/src/prog/expr/node_lit_enum.cpp
+++ b/src/prog/expr/node_lit_enum.cpp
@@ -1,0 +1,48 @@
+#include "prog/expr/node_lit_enum.hpp"
+#include <stdexcept>
+
+namespace prog::expr {
+
+LitEnumNode::LitEnumNode(sym::TypeId type, std::string entryName, int32_t val) :
+    m_type{type}, m_name{std::move(entryName)}, m_val{val} {}
+
+auto LitEnumNode::operator==(const Node& rhs) const noexcept -> bool {
+  const auto r = dynamic_cast<const LitEnumNode*>(&rhs);
+  return r != nullptr && m_type == r->m_type && m_val == r->m_val;
+}
+
+auto LitEnumNode::operator!=(const Node& rhs) const noexcept -> bool {
+  return !LitEnumNode::operator==(rhs);
+}
+
+auto LitEnumNode::operator[](unsigned int /*unused*/) const -> const Node& {
+  throw std::out_of_range{"No child at given index"};
+}
+
+auto LitEnumNode::getChildCount() const -> unsigned int { return 0; }
+
+auto LitEnumNode::getType() const noexcept -> sym::TypeId { return m_type; }
+
+auto LitEnumNode::toString() const -> std::string { return m_name; }
+
+auto LitEnumNode::getName() const noexcept -> const std::string& { return m_name; }
+
+auto LitEnumNode::getVal() const noexcept -> int32_t { return m_val; }
+
+auto LitEnumNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
+
+// Factories.
+auto litEnumNode(const Program& prog, sym::TypeId enumType, std::string name) -> NodePtr {
+  const auto& enumTypeDecl = prog.getTypeDecl(enumType);
+  if (enumTypeDecl.getKind() != sym::TypeKind::Enum) {
+    throw std::invalid_argument{"Given type is not an enum"};
+  }
+  const auto& enumDef = std::get<prog::sym::EnumDef>(prog.getTypeDef(enumType));
+  const auto val      = enumDef.getValue(name);
+  if (!val) {
+    throw std::invalid_argument{"Given name is not part of an enum"};
+  }
+  return std::unique_ptr<LitEnumNode>{new LitEnumNode{enumType, std::move(name), *val}};
+}
+
+} // namespace prog::expr

--- a/src/prog/expr/node_lit_func.cpp
+++ b/src/prog/expr/node_lit_func.cpp
@@ -37,7 +37,7 @@ auto LitFuncNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*t
 // Factories.
 auto litFuncNode(const Program& program, sym::TypeId type, sym::FuncId func) -> NodePtr {
   const auto& typeDecl = program.getTypeDecl(type);
-  if (typeDecl.getKind() != sym::TypeKind::UserDelegate) {
+  if (typeDecl.getKind() != sym::TypeKind::Delegate) {
     throw std::invalid_argument{"Type is not a delegate type"};
   }
   const auto& delegateDef = std::get<sym::DelegateDef>(program.getTypeDef(type));

--- a/src/prog/expr/node_union_check.cpp
+++ b/src/prog/expr/node_union_check.cpp
@@ -45,7 +45,7 @@ auto unionCheckExprNode(const Program& prog, NodePtr lhs, sym::TypeId targetType
   }
 
   const auto& exprTypeDecl = prog.getTypeDecl(lhs->getType());
-  if (exprTypeDecl.getKind() != sym::TypeKind::UserUnion) {
+  if (exprTypeDecl.getKind() != sym::TypeKind::Union) {
     throw std::invalid_argument{"Type of the left-hand-side expression needs to be a union type"};
   }
   const auto& exprTypeDef = prog.getTypeDef(lhs->getType());

--- a/src/prog/expr/node_union_get.cpp
+++ b/src/prog/expr/node_union_get.cpp
@@ -51,7 +51,7 @@ auto unionGetExprNode(
   }
 
   const auto& exprTypeDecl = prog.getTypeDecl(lhs->getType());
-  if (exprTypeDecl.getKind() != sym::TypeKind::UserUnion) {
+  if (exprTypeDecl.getKind() != sym::TypeKind::Union) {
     throw std::invalid_argument{"Type of the left-hand-side expression needs to be a union type"};
   }
   const auto& exprTypeDef = prog.getTypeDef(lhs->getType());

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -378,6 +378,30 @@ auto Program::defineUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> voi
 }
 
 auto Program::defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t> entries) -> void {
+  const auto& name = m_typeDecls[id].getName();
+
+  // Register explicit conversion from int.
+  m_funcDecls.registerFunc(*this, sym::FuncKind::NoOp, "to" + name, sym::TypeSet{m_int}, id);
+
+  // Register implicit conversion to int.
+  m_funcDecls.registerFunc(*this, sym::FuncKind::NoOp, "int", sym::TypeSet{id}, m_int);
+
+  // Register bitwise & and | operators.
+  m_funcDecls.registerFunc(
+      *this, sym::FuncKind::OrInt, getFuncName(Operator::Pipe), sym::TypeSet{id, id}, id);
+  m_funcDecls.registerFunc(
+      *this, sym::FuncKind::AndInt, getFuncName(Operator::Amp), sym::TypeSet{id, id}, id);
+
+  // Register (in)equality functions.
+  m_funcDecls.registerFunc(
+      *this, sym::FuncKind::CheckEqInt, getFuncName(Operator::EqEq), sym::TypeSet{id, id}, m_bool);
+  m_funcDecls.registerFunc(
+      *this,
+      sym::FuncKind::CheckNEqInt,
+      getFuncName(Operator::BangEq),
+      sym::TypeSet{id, id},
+      m_bool);
+
   // Register enum definition.
   m_typeDefs.registerEnum(m_typeDecls, id, std::move(entries));
 }

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -266,7 +266,7 @@ auto Program::isDelegate(sym::TypeId id) const -> bool {
     return false;
   }
   const auto& typeDecl = getTypeDecl(id);
-  return typeDecl.getKind() == sym::TypeKind::UserDelegate;
+  return typeDecl.getKind() == sym::TypeKind::Delegate;
 }
 
 auto Program::isCallable(sym::FuncId func, const std::vector<expr::NodePtr>& args) const -> bool {
@@ -280,7 +280,7 @@ auto Program::isCallable(sym::TypeId delegate, const std::vector<expr::NodePtr>&
     return false;
   }
   const auto& typeDecl = getTypeDecl(delegate);
-  if (typeDecl.getKind() != sym::TypeKind::UserDelegate) {
+  if (typeDecl.getKind() != sym::TypeKind::Delegate) {
     return false;
   }
   const auto& delegateDef = std::get<sym::DelegateDef>(getTypeDef(delegate));
@@ -303,25 +303,28 @@ auto Program::getTypeDef(sym::TypeId id) const -> const sym::TypeDefTable::typeD
   return m_typeDefs[id];
 }
 
-auto Program::declareUserStruct(std::string name) -> sym::TypeId {
-  return m_typeDecls.registerType(sym::TypeKind::UserStruct, std::move(name));
+auto Program::declareStruct(std::string name) -> sym::TypeId {
+  return m_typeDecls.registerType(sym::TypeKind::Struct, std::move(name));
 }
 
-auto Program::declareUserUnion(std::string name) -> sym::TypeId {
-  return m_typeDecls.registerType(sym::TypeKind::UserUnion, std::move(name));
+auto Program::declareUnion(std::string name) -> sym::TypeId {
+  return m_typeDecls.registerType(sym::TypeKind::Union, std::move(name));
 }
 
-auto Program::declareUserDelegate(std::string name) -> sym::TypeId {
-  return m_typeDecls.registerType(sym::TypeKind::UserDelegate, std::move(name));
+auto Program::declareEnum(std::string name) -> sym::TypeId {
+  return m_typeDecls.registerType(sym::TypeKind::Enum, std::move(name));
 }
 
-auto Program::declareUserFunc(std::string name, sym::TypeSet input, sym::TypeId output)
-    -> sym::FuncId {
+auto Program::declareDelegate(std::string name) -> sym::TypeId {
+  return m_typeDecls.registerType(sym::TypeKind::Delegate, std::move(name));
+}
+
+auto Program::declareFunc(std::string name, sym::TypeSet input, sym::TypeId output) -> sym::FuncId {
   return m_funcDecls.registerFunc(
       *this, sym::FuncKind::User, std::move(name), std::move(input), output);
 }
 
-auto Program::defineUserStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void {
+auto Program::defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void {
   auto fieldTypes = std::vector<sym::TypeId>{};
   for (const auto& field : fields) {
     fieldTypes.push_back(field.getType());
@@ -349,7 +352,7 @@ auto Program::defineUserStruct(sym::TypeId id, sym::FieldDeclTable fields) -> vo
   m_typeDefs.registerStruct(m_typeDecls, id, std::move(fields));
 }
 
-auto Program::defineUserUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> void {
+auto Program::defineUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> void {
   // Register constructor functions for each type.
   const auto& name = m_typeDecls[id].getName();
   for (const auto& type : types) {
@@ -374,12 +377,16 @@ auto Program::defineUserUnion(sym::TypeId id, std::vector<sym::TypeId> types) ->
   m_typeDefs.registerUnion(m_typeDecls, id, std::move(types));
 }
 
-auto Program::defineUserDelegate(sym::TypeId id, sym::TypeSet input, sym::TypeId output) -> void {
+auto Program::defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t> entries) -> void {
+  // Register enum definition.
+  m_typeDefs.registerEnum(m_typeDecls, id, std::move(entries));
+}
+
+auto Program::defineDelegate(sym::TypeId id, sym::TypeSet input, sym::TypeId output) -> void {
   m_typeDefs.registerDelegate(m_typeDecls, id, std::move(input), output);
 }
 
-auto Program::defineUserFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr)
-    -> void {
+auto Program::defineFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void {
   m_funcDefs.registerFunc(m_funcDecls, id, std::move(consts), std::move(expr));
 }
 

--- a/src/prog/sym/enum_def.cpp
+++ b/src/prog/sym/enum_def.cpp
@@ -11,6 +11,10 @@ auto EnumDef::end() const -> iterator { return m_entries.end(); }
 
 auto EnumDef::getId() const noexcept -> const TypeId& { return m_id; }
 
+auto EnumDef::hasEntry(const std::string& name) const noexcept -> bool {
+  return m_entries.find(name) != m_entries.end();
+}
+
 auto EnumDef::getValue(const std::string& name) const noexcept -> std::optional<int32_t> {
   const auto itr = m_entries.find(name);
   return itr == m_entries.end() ? std::nullopt : std::optional{itr->second};

--- a/src/prog/sym/enum_def.cpp
+++ b/src/prog/sym/enum_def.cpp
@@ -1,0 +1,19 @@
+#include "prog/sym/enum_def.hpp"
+
+namespace prog::sym {
+
+EnumDef::EnumDef(sym::TypeId id, std::unordered_map<std::string, int32_t> entries) :
+    m_id{id}, m_entries{std::move(entries)} {}
+
+auto EnumDef::begin() const -> iterator { return m_entries.begin(); }
+
+auto EnumDef::end() const -> iterator { return m_entries.end(); }
+
+auto EnumDef::getId() const noexcept -> const TypeId& { return m_id; }
+
+auto EnumDef::getValue(const std::string& name) const noexcept -> std::optional<int32_t> {
+  const auto itr = m_entries.find(name);
+  return itr == m_entries.end() ? std::nullopt : std::optional{itr->second};
+}
+
+} // namespace prog::sym

--- a/src/prog/sym/type_def_table.cpp
+++ b/src/prog/sym/type_def_table.cpp
@@ -21,7 +21,7 @@ auto TypeDefTable::end() const -> iterator { return m_types.end(); }
 
 auto TypeDefTable::registerStruct(
     const sym::TypeDeclTable& typeTable, sym::TypeId id, sym::FieldDeclTable fields) -> void {
-  if (typeTable[id].getKind() != sym::TypeKind::UserStruct) {
+  if (typeTable[id].getKind() != sym::TypeKind::Struct) {
     throw std::invalid_argument{"Type has not been declared as being a user-defined struct"};
   }
   auto itr = m_types.find(id);
@@ -33,7 +33,7 @@ auto TypeDefTable::registerStruct(
 
 auto TypeDefTable::registerUnion(
     const sym::TypeDeclTable& typeTable, sym::TypeId id, std::vector<sym::TypeId> types) -> void {
-  if (typeTable[id].getKind() != sym::TypeKind::UserUnion) {
+  if (typeTable[id].getKind() != sym::TypeKind::Union) {
     throw std::invalid_argument{"Type has not been declared as being a user-defined union"};
   }
   if (types.size() < 2) {
@@ -46,9 +46,26 @@ auto TypeDefTable::registerUnion(
   m_types.insert({id, UnionDef{id, std::move(types)}});
 }
 
+auto TypeDefTable::registerEnum(
+    const sym::TypeDeclTable& typeTable,
+    sym::TypeId id,
+    std::unordered_map<std::string, int32_t> entries) -> void {
+  if (typeTable[id].getKind() != sym::TypeKind::Enum) {
+    throw std::invalid_argument{"Type has not been declared as being a user-defined enum"};
+  }
+  if (entries.empty()) {
+    throw std::invalid_argument{"Enum needs at least one entry"};
+  }
+  auto itr = m_types.find(id);
+  if (itr != m_types.end()) {
+    throw std::logic_error{"Type already has a definition registered"};
+  }
+  m_types.insert({id, EnumDef{id, std::move(entries)}});
+}
+
 auto TypeDefTable::registerDelegate(
     const sym::TypeDeclTable& typeTable, sym::TypeId id, TypeSet input, TypeId output) -> void {
-  if (typeTable[id].getKind() != sym::TypeKind::UserDelegate) {
+  if (typeTable[id].getKind() != sym::TypeKind::Delegate) {
     throw std::invalid_argument{"Type has not been declared as being a user-defined delegate"};
   }
   auto itr = m_types.find(id);

--- a/src/prog/sym/type_kind.cpp
+++ b/src/prog/sym/type_kind.cpp
@@ -19,13 +19,16 @@ auto operator<<(std::ostream& out, const TypeKind& rhs) -> std::ostream& {
   case TypeKind::Char:
     out << "char";
     break;
-  case TypeKind::UserStruct:
+  case TypeKind::Struct:
     out << "struct";
     break;
-  case TypeKind::UserUnion:
+  case TypeKind::Union:
     out << "union";
     break;
-  case TypeKind::UserDelegate:
+  case TypeKind::Enum:
+    out << "enum";
+    break;
+  case TypeKind::Delegate:
     out << "delegate";
     break;
   }

--- a/src/vm/opcode.cpp
+++ b/src/vm/opcode.cpp
@@ -88,7 +88,7 @@ auto operator<<(std::ostream& out, const OpCode& rhs) -> std::ostream& {
     out << "and-int";
     break;
   case OpCode::OrInt:
-    out << "or-float";
+    out << "or-int";
     break;
   case OpCode::XorInt:
     out << "xor-int";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ add_executable(tests
   parse/expr_switch_test.cpp
   parse/expr_unary_test.cpp
   parse/iterator_test.cpp
+  parse/stmt_enum_decl_test.cpp
   parse/stmt_exec_test.cpp
   parse/stmt_func_decl_test.cpp
   parse/stmt_struct_decl_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(tests
   frontend/get_call_expr_test.cpp
   frontend/get_conditional_expr_test.cpp
   frontend/get_const_expr_test.cpp
+  frontend/get_enum_expr_test.cpp
   frontend/get_field_expr_test.cpp
   frontend/get_group_expr_test.cpp
   frontend/get_index_expr_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,12 +18,13 @@ add_executable(tests
   backend/call_dyn_expr_test.cpp
   backend/call_expr_test.cpp
   backend/constants_test.cpp
+  backend/enum_test.cpp
   backend/group_expr_test.cpp
   backend/literals_test.cpp
+  backend/struct_test.cpp
   backend/switch_expr_test.cpp
   backend/tail_calls_test.cpp
-  backend/user_struct_test.cpp
-  backend/user_union_test.cpp
+  backend/union_test.cpp
 
   frontend/anon_func_test.cpp
   frontend/declare_user_funcs_test.cpp

--- a/tests/backend/enum_test.cpp
+++ b/tests/backend/enum_test.cpp
@@ -1,0 +1,75 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+
+namespace backend {
+
+TEST_CASE("Generating assembly for enums", "[backend]") {
+
+  SECTION("Create and convert to int") {
+    CHECK_PROG(
+        "enum E = a : 42 "
+        "print(E.a == 1337)",
+        [](backend::Builder* builder) -> void {
+          // --- Print statement start.
+          builder->label("print");
+          builder->addLoadLitInt(42);
+          builder->addLoadLitInt(1337);
+          builder->addCheckEqInt();
+
+          builder->addConvBoolString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+          // --- Print statement end.
+
+          builder->addEntryPoint("print");
+        });
+  }
+
+  SECTION("Bitwise ops") {
+    CHECK_PROG(
+        "enum E = a:0b01, b:0b10, ab:0b11 "
+        "print((E.a | E.b) == E.ab)",
+        [](backend::Builder* builder) -> void {
+          // --- Print statement start.
+          builder->label("print");
+          builder->addLoadLitInt(0b01);
+          builder->addLoadLitInt(0b10);
+          builder->addOrInt();
+
+          builder->addLoadLitInt(0b11);
+          builder->addCheckEqInt();
+
+          builder->addConvBoolString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+          // --- Print statement end.
+
+          builder->addEntryPoint("print");
+        });
+  }
+
+  SECTION("Convert from int") {
+    CHECK_PROG(
+        "enum E = a "
+        "print(toE(0) == E.a)",
+        [](backend::Builder* builder) -> void {
+          // --- Print statement start.
+          builder->label("print");
+          builder->addLoadLitInt(0); // Conversion is a no-op at runtime.
+          builder->addLoadLitInt(0);
+          builder->addCheckEqInt();
+
+          builder->addConvBoolString();
+          builder->addPrintString();
+          builder->addRet();
+          builder->addFail();
+          // --- Print statement end.
+
+          builder->addEntryPoint("print");
+        });
+  }
+}
+
+} // namespace backend

--- a/tests/backend/struct_test.cpp
+++ b/tests/backend/struct_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generating assembly for user-structs", "[backend]") {
+TEST_CASE("Generating assembly for structs", "[backend]") {
 
   SECTION("Create user struct and check for equality") {
     CHECK_PROG(

--- a/tests/backend/union_test.cpp
+++ b/tests/backend/union_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generating assembly for user-unions", "[backend]") {
+TEST_CASE("Generating assembly for unions", "[backend]") {
 
   SECTION("Create user union and check for equality") {
     CHECK_PROG(

--- a/tests/frontend/declare_user_types_test.cpp
+++ b/tests/frontend/declare_user_types_test.cpp
@@ -69,6 +69,12 @@ TEST_CASE("Analyzing user-type declarations", "[frontend]") {
     CHECK(TYPE_EXISTS(output, "s2"));
   }
 
+  SECTION("Declare basic enum") {
+    const auto& output = ANALYZE("enum e = a, b, c");
+    REQUIRE(output.isSuccess());
+    CHECK(TYPE_EXISTS(output, "e"));
+  }
+
   SECTION("Diagnostics") {
     CHECK_DIAG("struct int = bool i", errTypeAlreadyDeclared(src, "int", input::Span{7, 9}));
     CHECK_DIAG("union int = int, bool", errTypeAlreadyDeclared(src, "int", input::Span{6, 8}));
@@ -99,6 +105,9 @@ TEST_CASE("Analyzing user-type declarations", "[frontend]") {
         "union s{T} = T, bool "
         "struct s{T} = T t",
         errTypeTemplateAlreadyDeclared(src, "s", input::Span{28, 28}));
+    CHECK_DIAG("enum int = a", errTypeAlreadyDeclared(src, "int", input::Span{5, 7}));
+    CHECK_DIAG("enum delegate = a", errTypeNameIsReserved(src, "delegate", input::Span{5, 12}));
+    CHECK_DIAG("enum print = a", errTypeNameConflictsWithAction(src, "print", input::Span{5, 9}));
   }
 }
 

--- a/tests/frontend/get_enum_expr_test.cpp
+++ b/tests/frontend/get_enum_expr_test.cpp
@@ -1,0 +1,30 @@
+#include "catch2/catch.hpp"
+#include "frontend/diag_defs.hpp"
+#include "helpers.hpp"
+#include "prog/expr/node_lit_enum.hpp"
+
+namespace frontend {
+
+TEST_CASE("Analyzing enum expressions", "[frontend]") {
+
+  SECTION("Get enum entry") {
+    const auto& output = ANALYZE("enum E = a, b "
+                                 "fun f() E.a");
+    REQUIRE(output.isSuccess());
+
+    CHECK(
+        GET_FUNC_DEF(output, "f").getExpr() ==
+        *prog::expr::litEnumNode(output.getProg(), GET_TYPE_ID(output, "E"), "a"));
+  }
+
+  SECTION("Diagnostics") {
+    CHECK_DIAG(
+        "fun f() -> int int.a", errStaticFieldNotFoundOnType(src, "a", "int", input::Span{19, 19}));
+    CHECK_DIAG(
+        "enum E = a, c "
+        "fun f() -> int E.b",
+        errValueNotFoundInEnum(src, "b", "E", input::Span{31, 31}));
+  }
+}
+
+} // namespace frontend

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -79,6 +79,13 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
         GET_TYPE_ID(output, "int"));
   }
 
+  SECTION("Enum entry") {
+    const auto& output = ANALYZE("enum E = a, b "
+                                 "fun f() E.a");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "E"));
+  }
+
   SECTION("Logic and operator") {
     const auto& output = ANALYZE("fun f() true && false");
     REQUIRE(output.isSuccess());

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -8,6 +8,7 @@ TEST_CASE("Lexing keywords", "[lex]") {
   CHECK_TOKENS("lambda", keywordToken(Keyword::Lambda));
   CHECK_TOKENS("struct", keywordToken(Keyword::Struct));
   CHECK_TOKENS("union", keywordToken(Keyword::Union));
+  CHECK_TOKENS("enum", keywordToken(Keyword::Enum));
   CHECK_TOKENS("if", keywordToken(Keyword::If));
   CHECK_TOKENS("else", keywordToken(Keyword::Else));
   CHECK_TOKENS("is", keywordToken(Keyword::Is));

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -52,10 +52,12 @@ namespace parse {
 #define LAMBDA lex::keywordToken(lex::Keyword::Lambda)
 #define STRUCT lex::keywordToken(lex::Keyword::Struct)
 #define UNION lex::keywordToken(lex::Keyword::Union)
+#define ENUM lex::keywordToken(lex::Keyword::Enum)
 #define IF lex::keywordToken(lex::Keyword::If)
 #define ELSE lex::keywordToken(lex::Keyword::Else)
 #define IS lex::keywordToken(lex::Keyword::Is)
 #define END lex::endToken()
+#define INT_TOK(VAL) lex::litIntToken(VAL)
 
 #define ID(ID) lex::identiferToken(ID)
 #define COMMENT(MSG) lex::lineCommentToken(MSG)

--- a/tests/parse/stmt_enum_decl_test.cpp
+++ b/tests/parse/stmt_enum_decl_test.cpp
@@ -27,7 +27,8 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
           ENUM,
           ID("e"),
           EQ,
-          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}}},
+          {EnumDeclStmtNode::EntrySpec{
+              ID("a"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(1)}}},
           COMMAS(0)));
   CHECK_STMT(
       "enum e = a : 1, b : 2",
@@ -35,8 +36,10 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
           ENUM,
           ID("e"),
           EQ,
-          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
-           EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(2)}}},
+          {EnumDeclStmtNode::EntrySpec{
+               ID("a"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{
+               ID("b"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(2)}}},
           COMMAS(1)));
   CHECK_STMT(
       "enum e = a : 1, b : 1",
@@ -44,8 +47,10 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
           ENUM,
           ID("e"),
           EQ,
-          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
-           EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}}},
+          {EnumDeclStmtNode::EntrySpec{
+               ID("a"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{
+               ID("b"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(1)}}},
           COMMAS(1)));
   CHECK_STMT(
       "enum e = a, b : 2",
@@ -54,7 +59,8 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
           ID("e"),
           EQ,
           {EnumDeclStmtNode::EntrySpec{ID("a"), std::nullopt},
-           EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(2)}}},
+           EnumDeclStmtNode::EntrySpec{
+               ID("b"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(2)}}},
           COMMAS(1)));
   CHECK_STMT(
       "enum e = a : 1, b",
@@ -62,8 +68,30 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
           ENUM,
           ID("e"),
           EQ,
-          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
+          {EnumDeclStmtNode::EntrySpec{
+               ID("a"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(1)}},
            EnumDeclStmtNode::EntrySpec{ID("b"), std::nullopt}},
+          COMMAS(1)));
+  CHECK_STMT(
+      "enum e = a : -1, b",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"),
+                                       EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{ID("b"), std::nullopt}},
+          COMMAS(1)));
+  CHECK_STMT(
+      "enum e = a : -1, b : -999",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"),
+                                       EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{ID("b"),
+                                       EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(999)}}},
           COMMAS(1)));
 
   SECTION("Errors") {
@@ -80,7 +108,8 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
             ENUM,
             ID("e"),
             EQ,
-            {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, END}}},
+            {EnumDeclStmtNode::EntrySpec{ID("a"),
+                                         EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, END}}},
             COMMAS(0)));
     CHECK_STMT(
         "enum e = a : 1, b :",
@@ -88,8 +117,10 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
             ENUM,
             ID("e"),
             EQ,
-            {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
-             EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, END}}},
+            {EnumDeclStmtNode::EntrySpec{
+                 ID("a"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(1)}},
+             EnumDeclStmtNode::EntrySpec{ID("b"),
+                                         EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, END}}},
             COMMAS(1)));
   }
 

--- a/tests/parse/stmt_enum_decl_test.cpp
+++ b/tests/parse/stmt_enum_decl_test.cpp
@@ -1,0 +1,102 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "parse/error.hpp"
+#include "parse/node_stmt_enum_decl.hpp"
+#include <optional>
+
+namespace parse {
+
+TEST_CASE("Parsing enum declaration statements", "[parse]") {
+
+  CHECK_STMT(
+      "enum e = a",
+      enumDeclStmtNode(
+          ENUM, ID("e"), EQ, {EnumDeclStmtNode::EntrySpec{ID("a"), std::nullopt}}, COMMAS(0)));
+  CHECK_STMT(
+      "enum e = a, b",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"), std::nullopt},
+           EnumDeclStmtNode::EntrySpec{ID("b"), std::nullopt}},
+          COMMAS(1)));
+  CHECK_STMT(
+      "enum e = a : 1",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}}},
+          COMMAS(0)));
+  CHECK_STMT(
+      "enum e = a : 1, b : 2",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(2)}}},
+          COMMAS(1)));
+  CHECK_STMT(
+      "enum e = a : 1, b : 1",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}}},
+          COMMAS(1)));
+  CHECK_STMT(
+      "enum e = a, b : 2",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"), std::nullopt},
+           EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(2)}}},
+          COMMAS(1)));
+  CHECK_STMT(
+      "enum e = a : 1, b",
+      enumDeclStmtNode(
+          ENUM,
+          ID("e"),
+          EQ,
+          {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{ID("b"), std::nullopt}},
+          COMMAS(1)));
+
+  SECTION("Errors") {
+    CHECK_STMT("enum", errInvalidStmtEnumDecl(ENUM, END, END, {}, COMMAS(0)));
+    CHECK_STMT("enum e", errInvalidStmtEnumDecl(ENUM, ID("e"), END, {}, COMMAS(0)));
+    CHECK_STMT("enum e =", errInvalidStmtEnumDecl(ENUM, ID("e"), EQ, {}, COMMAS(0)));
+    CHECK_STMT(
+        "enum e = a,",
+        errInvalidStmtEnumDecl(
+            ENUM, ID("e"), EQ, {EnumDeclStmtNode::EntrySpec{ID("a"), std::nullopt}}, COMMAS(1)));
+    CHECK_STMT(
+        "enum e = a :",
+        errInvalidStmtEnumDecl(
+            ENUM,
+            ID("e"),
+            EQ,
+            {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, END}}},
+            COMMAS(0)));
+    CHECK_STMT(
+        "enum e = a : 1, b :",
+        errInvalidStmtEnumDecl(
+            ENUM,
+            ID("e"),
+            EQ,
+            {EnumDeclStmtNode::EntrySpec{ID("a"), EnumDeclStmtNode::ValueSpec{COLON, INT_TOK(1)}},
+             EnumDeclStmtNode::EntrySpec{ID("b"), EnumDeclStmtNode::ValueSpec{COLON, END}}},
+            COMMAS(1)));
+  }
+
+  SECTION("Spans") {
+    CHECK_STMT_SPAN(" enum Color = Red, Blue ", input::Span(1, 22));
+    CHECK_STMT_SPAN(" enum Permission = Read : 0b01, Write : 0b10 ", input::Span(1, 36));
+  }
+}
+
+} // namespace parse

--- a/tests/parse/stmt_struct_decl_test.cpp
+++ b/tests/parse/stmt_struct_decl_test.cpp
@@ -113,6 +113,6 @@ TEST_CASE("Parsing struct declaration statements", "[parse]") {
     CHECK_STMT_SPAN(" struct user = int a ", input::Span(1, 19));
     CHECK_STMT_SPAN(" struct user = int a, bool b ", input::Span(1, 27));
   }
-} // namespace parse
+}
 
 } // namespace parse


### PR DESCRIPTION
Added enums to the language. At runtime they are represented by ints.

Basic enum:
```
enum Day = monday, tuesday, wednesday, thursday, friday, saturday, sunday

fun isWeekend(Day d)
  d == Day.saturday || d == Day.sunday

print("Is saturday weekend? " + Day.saturday.isWeekend())
// Output: Is saturday weekend? true
```

Explicit integers can be assigned:
```
enum Constants =
  meaningOfLife : 42,
  elite         : 1337,
  lessThen0     : -1

print("Meaning of life: " + Constants.meaningOfLife.int())
// Output: Meaning of life: 42
```

Can be used as bit flags:
```
enum PermissionFlags =
  None          : 0,
  Read          : 0b01,
  Write         : 0b10

struct User =
  string            name,
  PermissionFlags   permissions

fun canRead(User u)
  (u.permissions & PermissionFlags.Read) == PermissionFlags.Read

fun canWrite(User u)
  (u.permissions & PermissionFlags.Write) == PermissionFlags.Write

print(
  u = User("John Doe", PermissionFlags.Read);
  "Read? " + u.canRead() + " Write? " + u.canWrite() + '\n')
// Output: Is saturday weekend? true

print(
  u = User("John Doe", PermissionFlags.Read | PermissionFlags.Write);
  "Read? " + u.canRead() + " Write? " + u.canWrite() + '\n')
// Output: Read? true Write? true
```

