### PR TITLE
As expression

### DIFF
--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -5,7 +5,7 @@
 
 namespace lex {
 
-enum class Keyword { Fun, Lambda, Struct, Union, Enum, If, Else, Is };
+enum class Keyword { Fun, Lambda, Struct, Union, Enum, If, Else, Is, As };
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream&;
 

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -63,7 +63,8 @@ errInvalidAnonFuncExpr(lex::Token kw, const ArgumentListDecl& argList, NodePtr b
 [[nodiscard]] auto errInvalidIdExpr(lex::Token id, std::optional<TypeParamList> typeParams)
     -> NodePtr;
 
-[[nodiscard]] auto errInvalidIsExpr(NodePtr lhs, lex::Token kw, const Type& type, lex::Token id)
+[[nodiscard]] auto
+errInvalidIsExpr(NodePtr lhs, lex::Token kw, const Type& type, std::optional<lex::Token> id)
     -> NodePtr;
 
 [[nodiscard]] auto errInvalidCallExpr(

--- a/include/parse/node_expr_is.hpp
+++ b/include/parse/node_expr_is.hpp
@@ -2,11 +2,13 @@
 #include "lex/token.hpp"
 #include "parse/node.hpp"
 #include "parse/type.hpp"
+#include <optional>
 
 namespace parse {
 
 class IsExprNode final : public Node {
-  friend auto isExprNode(NodePtr lhs, lex::Token kw, Type type, lex::Token id) -> NodePtr;
+  friend auto isExprNode(NodePtr lhs, lex::Token kw, Type type, std::optional<lex::Token> id)
+      -> NodePtr;
 
 public:
   IsExprNode() = delete;
@@ -20,7 +22,7 @@ public:
 
   [[nodiscard]] auto getType() const -> const Type&;
   [[nodiscard]] auto hasId() const -> bool;
-  [[nodiscard]] auto getId() const -> const lex::Token&;
+  [[nodiscard]] auto getId() const -> const std::optional<lex::Token>&;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 
@@ -28,14 +30,14 @@ private:
   const NodePtr m_lhs;
   const lex::Token m_kw;
   const Type m_type;
-  const lex::Token m_id;
+  const std::optional<lex::Token> m_id;
 
-  IsExprNode(NodePtr lhs, lex::Token kw, Type type, lex::Token id);
+  IsExprNode(NodePtr lhs, lex::Token kw, Type type, std::optional<lex::Token> id);
 
   auto print(std::ostream& out) const -> std::ostream& override;
 };
 
 // Factories.
-auto isExprNode(NodePtr lhs, lex::Token kw, Type type, lex::Token id) -> NodePtr;
+auto isExprNode(NodePtr lhs, lex::Token kw, Type type, std::optional<lex::Token> id) -> NodePtr;
 
 } // namespace parse

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -417,7 +417,7 @@ auto GetExpr::visit(const parse::IsExprNode& n) -> void {
   }
 
   // Declare the const.
-  const auto constId = declareConst(n.getId(), *type);
+  const auto constId = declareConst(*n.getId(), *type);
   if (constId) {
     m_expr = prog::expr::unionGetExprNode(
         *m_context->getProg(), std::move(lhsExpr), *m_constBinder->getConsts(), *constId);

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -238,10 +238,12 @@ auto TypeInferExpr::visit(const parse::IndexExprNode& n) -> void {
 }
 
 auto TypeInferExpr::visit(const parse::IsExprNode& n) -> void {
-  // Register the type of the constant this declares.
-  const auto constType = getOrInstType(m_context, m_typeSubTable, n.getType());
-  if (constType) {
-    setConstType(n.getId(), *constType);
+  if (n.hasId()) {
+    // Register the type of the constant this declares.
+    const auto constType = getOrInstType(m_context, m_typeSubTable, n.getType());
+    if (constType) {
+      setConstType(*n.getId(), *constType);
+    }
   }
 
   // Expression itself always evaluates to a bool.

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -29,6 +29,9 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::Is:
     out << "is";
     break;
+  case Keyword::As:
+    out << "as";
+    break;
   }
   return out;
 }
@@ -43,6 +46,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
       {"if", Keyword::If},
       {"else", Keyword::Else},
       {"is", Keyword::Is},
+      {"as", Keyword::As},
   };
 
   const auto keywordSearch = keywordTable.find(str);

--- a/src/parse/node_expr_is.cpp
+++ b/src/parse/node_expr_is.cpp
@@ -3,12 +3,13 @@
 
 namespace parse {
 
-IsExprNode::IsExprNode(NodePtr lhs, lex::Token kw, Type type, lex::Token id) :
+IsExprNode::IsExprNode(NodePtr lhs, lex::Token kw, Type type, std::optional<lex::Token> id) :
     m_lhs{std::move(lhs)}, m_kw{std::move(kw)}, m_type{std::move(type)}, m_id{std::move(id)} {}
 
 auto IsExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const IsExprNode*>(&rhs);
-  return r != nullptr && *m_lhs == *r->m_lhs && m_type == r->m_type && m_id == r->m_id;
+  return r != nullptr && *m_lhs == *r->m_lhs && m_kw == r->m_kw && m_type == r->m_type &&
+      m_id == r->m_id;
 }
 
 auto IsExprNode::operator!=(const Node& rhs) const noexcept -> bool {
@@ -25,27 +26,32 @@ auto IsExprNode::operator[](unsigned int i) const -> const Node& {
 auto IsExprNode::getChildCount() const -> unsigned int { return 1; }
 
 auto IsExprNode::getSpan() const -> input::Span {
-  return input::Span::combine(m_lhs->getSpan(), m_id.getSpan());
+  if (m_id) {
+    return input::Span::combine(m_lhs->getSpan(), m_id->getSpan());
+  }
+  return input::Span::combine(m_lhs->getSpan(), m_type.getSpan());
 }
 
 auto IsExprNode::getType() const -> const Type& { return m_type; }
 
-auto IsExprNode::hasId() const -> bool { return m_id.getKind() == lex::TokenKind::Identifier; }
+auto IsExprNode::hasId() const -> bool {
+  return m_id && m_id->getKind() == lex::TokenKind::Identifier;
+}
 
-auto IsExprNode::getId() const -> const lex::Token& { return m_id; }
+auto IsExprNode::getId() const -> const std::optional<lex::Token>& { return m_id; }
 
 auto IsExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
 auto IsExprNode::print(std::ostream& out) const -> std::ostream& {
-  out << "is-" << m_type;
-  if (m_id.getKind() == lex::TokenKind::Identifier) {
-    out << '-' << parse::getId(m_id).value_or("error");
+  out << m_kw << '-' << m_type;
+  if (hasId()) {
+    out << '-' << parse::getId(*m_id).value_or("error");
   }
   return out;
 }
 
 // Factories.
-auto isExprNode(NodePtr lhs, lex::Token kw, Type type, lex::Token id) -> NodePtr {
+auto isExprNode(NodePtr lhs, lex::Token kw, Type type, std::optional<lex::Token> id) -> NodePtr {
   if (lhs == nullptr) {
     throw std::invalid_argument{"Lhs cannot be null"};
   }

--- a/src/parse/op_precedence.cpp
+++ b/src/parse/op_precedence.cpp
@@ -56,8 +56,12 @@ auto getRhsOpPrecedence(const lex::Token& token) -> int {
   case lex::TokenKind::OpSemi:
     return groupingPrecedence;
   case lex::TokenKind::Keyword:
-    if (getKw(token) == lex::Keyword::Is) {
+    switch (*getKw(token)) {
+    case lex::Keyword::Is:
+    case lex::Keyword::As:
       return typeTestPrecedence;
+    default:
+      break;
     }
     [[fallthrough]];
   default:

--- a/tests/frontend/get_binary_expr_test.cpp
+++ b/tests/frontend/get_binary_expr_test.cpp
@@ -120,11 +120,11 @@ TEST_CASE("Analyzing binary expressions", "[frontend]") {
         *prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches)));
   }
 
-  SECTION("Chain 'is' checks with binary 'and' in switch") {
+  SECTION("Chain 'as' checks with binary 'and' in switch") {
     const auto& output = ANALYZE("struct Null "
                                  "union Option = int, Null "
                                  "fun f(Option a, Option b) "
-                                 "  if a is int aVal && b is int bVal -> bVal "
+                                 "  if a as int aVal && b as int bVal -> bVal "
                                  "  else                              -> 0");
     REQUIRE(output.isSuccess());
     const auto& funcDef =

--- a/tests/frontend/get_switch_expr_test.cpp
+++ b/tests/frontend/get_switch_expr_test.cpp
@@ -115,8 +115,8 @@ TEST_CASE("Analyzing switch expressions", "[frontend]") {
   SECTION("Exhaustive union check switch expression") {
     const auto& output = ANALYZE("union U = int, float "
                                  "fun f(U u) -> int "
-                                 "  if u is int i   -> i "
-                                 "  if u is float _ -> 0");
+                                 "  if u as int i -> i "
+                                 "  if u is float -> 0");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "U"));
     const auto& consts  = funcDef.getConsts();
@@ -166,8 +166,8 @@ TEST_CASE("Analyzing switch expressions", "[frontend]") {
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) -> int "
-        "  if u is float _ -> 1 ",
-        errNonExhaustiveSwitchWithoutElse(src, input::Span{41, 60}));
+        "  if u is float -> 1 ",
+        errNonExhaustiveSwitchWithoutElse(src, input::Span{41, 58}));
   }
 }
 

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Analyzing user-function templates", "[frontend]") {
     const auto& output = ANALYZE("struct Null "
                                  "union Option{T} = T, Null "
                                  "fun ft{T}(Option{T} a, Option{T} b) "
-                                 "  if a is T aVal && b is T bVal -> aVal + bVal "
+                                 "  if a as T aVal && b as T bVal -> aVal + bVal "
                                  "  else -> T()"
                                  "fun f() ft(Option{int}(1), Option{int}(2))");
     REQUIRE(output.isSuccess());

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -12,6 +12,7 @@ TEST_CASE("Lexing keywords", "[lex]") {
   CHECK_TOKENS("if", keywordToken(Keyword::If));
   CHECK_TOKENS("else", keywordToken(Keyword::Else));
   CHECK_TOKENS("is", keywordToken(Keyword::Is));
+  CHECK_TOKENS("as", keywordToken(Keyword::As));
 }
 
 } // namespace lex

--- a/tests/parse/expr_is_test.cpp
+++ b/tests/parse/expr_is_test.cpp
@@ -8,35 +8,39 @@
 
 namespace parse {
 
-TEST_CASE("Parsing is expressions", "[parse]") {
+TEST_CASE("Parsing is / as expressions", "[parse]") {
 
-  CHECK_EXPR("x is int i", isExprNode(ID_EXPR("x"), IS, TYPE("int"), ID("i")));
-  CHECK_EXPR("x is int _", isExprNode(ID_EXPR("x"), IS, TYPE("int"), DISCARD));
+  CHECK_EXPR("x as int i", isExprNode(ID_EXPR("x"), AS, TYPE("int"), ID("i")));
+  CHECK_EXPR("x as int _", isExprNode(ID_EXPR("x"), AS, TYPE("int"), DISCARD));
+  CHECK_EXPR("x is int", isExprNode(ID_EXPR("x"), IS, TYPE("int"), std::nullopt));
   CHECK_EXPR(
-      "-x is int i", isExprNode(unaryExprNode(MINUS, ID_EXPR("x")), IS, TYPE("int"), ID("i")));
+      "-x as int i", isExprNode(unaryExprNode(MINUS, ID_EXPR("x")), AS, TYPE("int"), ID("i")));
   CHECK_EXPR(
-      "(x + y) is int i",
+      "(x + y) as int i",
       isExprNode(
           parenExprNode(OPAREN, binaryExprNode(ID_EXPR("x"), PLUS, ID_EXPR("y")), CPAREN),
-          IS,
+          AS,
           TYPE("int"),
           ID("i")));
   CHECK_EXPR(
-      "x is List{T{Y}} i",
-      isExprNode(ID_EXPR("x"), IS, TYPE("List", TYPE("T", TYPE("Y"))), ID("i")));
+      "x as List{T{Y}} i",
+      isExprNode(ID_EXPR("x"), AS, TYPE("List", TYPE("T", TYPE("Y"))), ID("i")));
+  CHECK_EXPR(
+      "x is List{T{Y}}",
+      isExprNode(ID_EXPR("x"), IS, TYPE("List", TYPE("T", TYPE("Y"))), std::nullopt));
 
   SECTION("Errors") {
-    CHECK_EXPR("x is", errInvalidIsExpr(ID_EXPR("x"), IS, Type(END), END));
-    CHECK_EXPR("x is int", errInvalidIsExpr(ID_EXPR("x"), IS, TYPE("int"), END));
-    CHECK_EXPR("x is is i", errInvalidIsExpr(ID_EXPR("x"), IS, Type(IS), ID("i")));
-    CHECK_EXPR("x is int is", errInvalidIsExpr(ID_EXPR("x"), IS, TYPE("int"), IS));
+    CHECK_EXPR("x as", errInvalidIsExpr(ID_EXPR("x"), AS, Type(END), END));
+    CHECK_EXPR("x as int", errInvalidIsExpr(ID_EXPR("x"), AS, TYPE("int"), END));
+    CHECK_EXPR("x as is i", errInvalidIsExpr(ID_EXPR("x"), AS, Type(IS), ID("i")));
+    CHECK_EXPR("x as int is", errInvalidIsExpr(ID_EXPR("x"), AS, TYPE("int"), IS));
     CHECK_EXPR(
-        "x is int{} i",
+        "x as int{} i",
         errInvalidIsExpr(
-            ID_EXPR("x"), IS, Type(ID("int"), TypeParamList(OCURLY, {}, {}, CCURLY)), ID("i")));
+            ID_EXPR("x"), AS, Type(ID("int"), TypeParamList(OCURLY, {}, {}, CCURLY)), ID("i")));
   }
 
-  SECTION("Spans") { CHECK_EXPR_SPAN("x is int i", input::Span(0, 9)); }
+  SECTION("Spans") { CHECK_EXPR_SPAN("x as int i", input::Span(0, 9)); }
 }
 
 } // namespace parse

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -56,6 +56,7 @@ namespace parse {
 #define IF lex::keywordToken(lex::Keyword::If)
 #define ELSE lex::keywordToken(lex::Keyword::Else)
 #define IS lex::keywordToken(lex::Keyword::Is)
+#define AS lex::keywordToken(lex::Keyword::As)
 #define END lex::endToken()
 #define INT_TOK(VAL) lex::litIntToken(VAL)
 


### PR DESCRIPTION
Changes the keyword of the current `is` expression to `as` and introduces a new `is` expression that does not take an identifier.

Example:
```
struct None
union Option{T} = T, None

fun getOrDefault{T}(Option{T} opt, T default)
  if opt as T val -> val
  if opt is None  -> default
```

This behaves the same as `is` + `_` used to.