### PR TITLE
Add action to poll for status of futures

### DIFF
--- a/include/backend/builder.hpp
+++ b/include/backend/builder.hpp
@@ -94,7 +94,8 @@ public:
   auto addPCall(vm::PCallCode code) -> void;
   auto addRet() -> void;
 
-  auto addWaitFuture() -> void;
+  auto addFutureBlock() -> void;
+  auto addFuturePoll() -> void;
   auto addDup() -> void;
   auto addPop() -> void;
   auto addFail() -> void;

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -81,7 +81,8 @@ enum class FuncKind {
   MakeStruct,
   MakeUnion,
 
-  WaitFuture,
+  FutureBlock,
+  FuturePoll,
 
   CheckEqUserType,
   CheckNEqUserType,

--- a/include/vm/op_code.hpp
+++ b/include/vm/op_code.hpp
@@ -83,9 +83,10 @@ enum class OpCode : uint8_t {
   PCall         = 237,
   Ret           = 238,
 
-  WaitFuture = 240,
-  Dup        = 241,
-  Pop        = 242,
+  FutureBlock = 240,
+  FuturePoll  = 241,
+  Dup         = 242,
+  Pop         = 243,
 
   Fail = 255,
 };

--- a/src/backend/builder.cpp
+++ b/src/backend/builder.cpp
@@ -236,7 +236,9 @@ auto Builder::addPCall(vm::PCallCode code) -> void {
 
 auto Builder::addRet() -> void { writeOpCode(vm::OpCode::Ret); }
 
-auto Builder::addWaitFuture() -> void { writeOpCode(vm::OpCode::WaitFuture); }
+auto Builder::addFutureBlock() -> void { writeOpCode(vm::OpCode::FutureBlock); }
+
+auto Builder::addFuturePoll() -> void { writeOpCode(vm::OpCode::FuturePoll); }
 
 auto Builder::addDup() -> void { writeOpCode(vm::OpCode::Dup); }
 

--- a/src/backend/dasm/disassembler.cpp
+++ b/src/backend/dasm/disassembler.cpp
@@ -87,7 +87,8 @@ auto disassembleInstructions(const vm::Assembly& assembly) -> std::vector<Instru
     case vm::OpCode::ConvIntChar:
     case vm::OpCode::Ret:
     case vm::OpCode::Fail:
-    case vm::OpCode::WaitFuture:
+    case vm::OpCode::FutureBlock:
+    case vm::OpCode::FuturePoll:
     case vm::OpCode::Dup:
     case vm::OpCode::Pop:
       result.push_back(Instruction(opCode, offset, {}));

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -332,8 +332,12 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   }
 
-  case prog::sym::FuncKind::WaitFuture: {
-    m_builder->addWaitFuture();
+  case prog::sym::FuncKind::FutureBlock: {
+    m_builder->addFutureBlock();
+    break;
+  }
+  case prog::sym::FuncKind::FuturePoll: {
+    m_builder->addFuturePoll();
     break;
   }
 

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -452,8 +452,11 @@ auto Program::defineDelegate(sym::TypeId id, sym::TypeSet input, sym::TypeId out
 }
 
 auto Program::defineFuture(sym::TypeId id, sym::TypeId result) -> void {
-  // Register 'wait' function.
-  m_funcDecls.registerFunc(*this, sym::FuncKind::WaitFuture, "wait", sym::TypeSet{id}, result);
+  // Register 'result' function.
+  m_funcDecls.registerFunc(*this, sym::FuncKind::FutureBlock, "result", sym::TypeSet{id}, result);
+
+  // Register 'isReady' action.
+  m_funcDecls.registerAction(*this, sym::FuncKind::FuturePoll, "isReady", sym::TypeSet{id}, m_bool);
 
   // Register future definition.
   m_typeDefs.registerFuture(m_typeDecls, id, result);

--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -583,7 +583,7 @@ auto execute(
       PUSH(retVal);
     } break;
 
-    case OpCode::WaitFuture: {
+    case OpCode::FutureBlock: {
       // The the future but leave it on the stack, reason is gc could run while we are blocked.
       auto* future = getFutureRef(PEEK());
 
@@ -605,6 +605,10 @@ auto execute(
         execHandle.setState(futureState);
         goto End;
       }
+    } break;
+    case OpCode::FuturePoll: {
+      auto* future = getFutureRef(POP());
+      PUSH_INT(future->poll() == ExecState::Success ? 1 : 0);
     } break;
     case OpCode::Dup:
       PUSH(PEEK());

--- a/src/vm/internal/ref_future.hpp
+++ b/src/vm/internal/ref_future.hpp
@@ -20,9 +20,14 @@ public:
   auto operator=(const FutureRef& rhs) -> FutureRef& = delete;
   auto operator=(FutureRef&& rhs) -> FutureRef& = delete;
 
-  [[nodiscard]] inline auto wait() noexcept {
+  [[nodiscard]] inline auto wait() noexcept -> ExecState {
     auto lk = std::unique_lock<std::mutex>{m_mutex};
     m_condVar.wait(lk, [this] { return m_state != ExecState::Running; });
+    return m_state;
+  }
+
+  [[nodiscard]] inline auto poll() noexcept -> ExecState {
+    auto lk = std::lock_guard<std::mutex>{m_mutex};
     return m_state;
   }
 

--- a/src/vm/op_code.cpp
+++ b/src/vm/op_code.cpp
@@ -222,8 +222,11 @@ auto operator<<(std::ostream& out, const OpCode& rhs) noexcept -> std::ostream& 
     out << "ret";
     break;
 
-  case OpCode::WaitFuture:
-    out << "wait-future";
+  case OpCode::FutureBlock:
+    out << "future-block";
+    break;
+  case OpCode::FuturePoll:
+    out << "future-poll";
     break;
   case OpCode::Dup:
     out << "dup";

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -191,7 +191,7 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
   }
 
   SECTION("Future result") {
-    const auto& output = ANALYZE("fun f2(future{int} f) f.wait()");
+    const auto& output = ANALYZE("fun f2(future{int} f) f.result()");
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f2", GET_TYPE_ID(output, "__future_int")).getOutput() ==


### PR DESCRIPTION
Example usage:
```
import "std/print.nov"

action expensiveAdd(int a, int b)
  sleep(1000);
  a + b

action waitForResult(future{int} a, future{int} b)
  if isReady(a) && isReady(b) -> a.result() + b.result()
  else                        -> print("Still calculating..."); sleep(100); waitForResult(a, b)

action main()
  addA    = fork expensiveAdd(42, 1337);
  addB    = fork expensiveAdd(42, 1337);
  result  = waitForResult(addA, addB);
  print("Finished calculating: " + string(result))

main()
```