### PR TITLE
Feature/self calls

### DIFF
--- a/apps/progdiag/get_expr_color.hpp
+++ b/apps/progdiag/get_expr_color.hpp
@@ -24,6 +24,10 @@ public:
     m_fg = rang::fg::yellow;
   }
 
+  auto visit(const prog::expr::CallSelfExprNode & /*unused*/) -> void override {
+    m_fg = rang::fg::yellow;
+  }
+
   auto visit(const prog::expr::ClosureNode & /*unused*/) -> void override { m_fg = rang::fg::cyan; }
 
   auto visit(const prog::expr::ConstExprNode & /*unused*/) -> void override {

--- a/include/backend/builder.hpp
+++ b/include/backend/builder.hpp
@@ -29,8 +29,8 @@ public:
   auto addLoadLitIp(std::string label) -> void;
 
   auto addStackAlloc(uint8_t amount) -> void;
-  auto addStackStore(uint8_t constId) -> void;
-  auto addStackLoad(uint8_t constId) -> void;
+  auto addStackStore(uint8_t offset) -> void;
+  auto addStackLoad(uint8_t offset) -> void;
 
   auto addAddInt() -> void;
   auto addAddFloat() -> void;

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -212,4 +212,13 @@ errUnsupportedOperator(const Source& src, const std::string& name, input::Span s
 
 [[nodiscard]] auto errForkedNonUserFunc(const Source& src, input::Span span) -> Diag;
 
+[[nodiscard]] auto errForkedSelfCall(const Source& src, input::Span span) -> Diag;
+
+[[nodiscard]] auto errSelfCallInNonFunc(const Source& src, input::Span span) -> Diag;
+
+[[nodiscard]] auto errSelfCallWithoutInferredRetType(const Source& src, input::Span span) -> Diag;
+
+[[nodiscard]] auto errIncorrectNumArgsInSelfCall(
+    const Source& src, int expectedNumArgs, int actualNumArgs, input::Span span) -> Diag;
+
 } // namespace frontend

--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -5,7 +5,21 @@
 
 namespace lex {
 
-enum class Keyword { Import, Fun, Action, Lambda, Fork, Struct, Union, Enum, If, Else, Is, As };
+enum class Keyword {
+  Import,
+  Fun,
+  Action,
+  Self,
+  Lambda,
+  Fork,
+  Struct,
+  Union,
+  Enum,
+  If,
+  Else,
+  Is,
+  As
+};
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream&;
 

--- a/include/parse/node_expr_id.hpp
+++ b/include/parse/node_expr_id.hpp
@@ -18,6 +18,7 @@ public:
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
+  [[nodiscard]] auto isSelf() const -> bool;
   [[nodiscard]] auto getId() const -> const lex::Token&;
   [[nodiscard]] auto getTypeParams() const -> const std::optional<TypeParamList>&;
 

--- a/include/prog/expr/node_call_self.hpp
+++ b/include/prog/expr/node_call_self.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include "prog/expr/node.hpp"
+#include "prog/program.hpp"
+
+namespace prog::expr {
+
+class CallSelfExprNode final : public Node {
+  friend auto callSelfExprNode(sym::TypeId resultType, std::vector<NodePtr> args) -> NodePtr;
+
+public:
+  CallSelfExprNode() = delete;
+
+  auto operator==(const Node& rhs) const noexcept -> bool override;
+  auto operator!=(const Node& rhs) const noexcept -> bool override;
+
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
+  [[nodiscard]] auto getChildCount() const -> unsigned int override;
+  [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
+  [[nodiscard]] auto toString() const -> std::string override;
+
+  auto accept(NodeVisitor* visitor) const -> void override;
+
+private:
+  sym::TypeId m_resultType;
+  std::vector<NodePtr> m_args;
+
+  CallSelfExprNode(sym::TypeId resultType, std::vector<NodePtr> args);
+};
+
+// Factories.
+auto callSelfExprNode(sym::TypeId resultType, std::vector<NodePtr> args) -> NodePtr;
+
+} // namespace prog::expr

--- a/include/prog/expr/node_visitor.hpp
+++ b/include/prog/expr/node_visitor.hpp
@@ -6,6 +6,7 @@ class AssignExprNode;
 class SwitchExprNode;
 class CallExprNode;
 class CallDynExprNode;
+class CallSelfExprNode;
 class ClosureNode;
 class ConstExprNode;
 class FieldExprNode;
@@ -27,6 +28,7 @@ public:
   virtual auto visit(const SwitchExprNode& n) -> void     = 0;
   virtual auto visit(const CallExprNode& n) -> void       = 0;
   virtual auto visit(const CallDynExprNode& n) -> void    = 0;
+  virtual auto visit(const CallSelfExprNode& n) -> void   = 0;
   virtual auto visit(const ClosureNode& n) -> void        = 0;
   virtual auto visit(const ConstExprNode& n) -> void      = 0;
   virtual auto visit(const FieldExprNode& n) -> void      = 0;

--- a/include/prog/expr/node_visitor_optional.hpp
+++ b/include/prog/expr/node_visitor_optional.hpp
@@ -9,6 +9,7 @@ public:
   auto visit(const SwitchExprNode & /*unused*/) -> void override {}
   auto visit(const CallExprNode & /*unused*/) -> void override {}
   auto visit(const CallDynExprNode & /*unused*/) -> void override {}
+  auto visit(const CallSelfExprNode & /*unused*/) -> void override {}
   auto visit(const ClosureNode & /*unused*/) -> void override {}
   auto visit(const ConstExprNode & /*unused*/) -> void override {}
   auto visit(const FieldExprNode & /*unused*/) -> void override {}

--- a/include/prog/expr/nodes.hpp
+++ b/include/prog/expr/nodes.hpp
@@ -1,6 +1,7 @@
 #include "prog/expr/node_assign.hpp"
 #include "prog/expr/node_call.hpp"
 #include "prog/expr/node_call_dyn.hpp"
+#include "prog/expr/node_call_self.hpp"
 #include "prog/expr/node_closure.hpp"
 #include "prog/expr/node_const.hpp"
 #include "prog/expr/node_fail.hpp"

--- a/include/prog/sym/const_decl_table.hpp
+++ b/include/prog/sym/const_decl_table.hpp
@@ -25,12 +25,18 @@ public:
   [[nodiscard]] auto getLocalCount() const -> unsigned int;
 
   [[nodiscard]] auto begin() const -> iterator;
+  [[nodiscard]] auto begin(ConstKind kind) const -> iterator;
   [[nodiscard]] auto end() const -> iterator;
+  [[nodiscard]] auto end(ConstKind kind) const -> iterator;
 
   [[nodiscard]] auto getAll() const -> std::vector<ConstId>;
   [[nodiscard]] auto getInputs() const -> std::vector<ConstId>;
+  [[nodiscard]] auto getBoundInputs() const -> std::vector<ConstId>;
+  [[nodiscard]] auto getNonBoundInputs() const -> std::vector<ConstId>;
 
   [[nodiscard]] auto lookup(const std::string& name) const -> std::optional<ConstId>;
+
+  [[nodiscard]] auto getOffset(ConstId id) const -> unsigned int;
 
   auto registerBound(TypeId type) -> ConstId;
   auto registerInput(std::string name, TypeId type) -> ConstId;
@@ -41,6 +47,9 @@ private:
   std::unordered_map<std::string, ConstId> m_lookup;
 
   auto registerConst(ConstKind kind, std::string name, TypeId type) -> ConstId;
+
+  [[nodiscard]] auto getConstIds(ConstKind beginKind, ConstKind endKind) const
+      -> std::vector<ConstId>;
 };
 
 } // namespace prog::sym

--- a/include/prog/sym/const_kind.hpp
+++ b/include/prog/sym/const_kind.hpp
@@ -3,7 +3,7 @@
 
 namespace prog::sym {
 
-enum class ConstKind { Bound, Input, Local };
+enum class ConstKind { Input = 0, Bound = 1, Local = 2 };
 
 auto operator<<(std::ostream& out, const ConstKind& rhs) -> std::ostream&;
 

--- a/include/vm/op_code.hpp
+++ b/include/vm/op_code.hpp
@@ -78,7 +78,7 @@ enum class OpCode : uint8_t {
   LoadStructField = 101, // [uint8] (struct)  -> (any)    Get value of field x in structure.
 
   Jump   = 220, // [ip] ()    -> () Jump to an instruction pointer.
-  JumpIf = 221, // [ip] (int) -> () Jump to an instruction if integer is 1.
+  JumpIf = 221, // [ip] (int) -> () Jump to an instruction if integer is not 0.
 
   Call          = 230, // [uint8, ip] (any ...)             -> (any)    Call with x args.
   CallTail      = 231, // [uint8, ip] (any ...)             -> (any)    Tail-call with x args.

--- a/novstd/list.nov
+++ b/novstd/list.nov
@@ -109,18 +109,18 @@ fun rangeList{T}(T start, T end)
   List{T}().pushRange(start, end)
 
 fun fold{T, TResult}(List{T} l, delegate{TResult, T, TResult} del)
-  l.foldImpl(del, TResult())
-
-fun foldImpl{T, TResult}(List{T} l, delegate{TResult, T, TResult} del, TResult val)
-  if l as LNode{T} n -> n.next.foldImpl(del, del(val, n.val))
-  if l is LEnd       -> val
+  (
+    lambda (List{T} rem, TResult result)
+      if rem as LNode{T} n -> self(n.next, del(result, n.val))
+      if rem is LEnd       -> result
+  )(l, TResult())
 
 fun foldRight{T, TResult}(List{T} l, delegate{TResult, T, TResult} del)
-  l.foldRightImpl(del, TResult())
-
-fun foldRightImpl{T, TResult}(List{T} l, delegate{TResult, T, TResult} del, TResult val)
-  if l as LNode{T} n -> del(n.next.foldRightImpl(del, val), n.val)
-  if l is LEnd       -> val
+  (
+    lambda (List{T} rem, TResult result)
+      if rem as LNode{T} n -> del(self(n.next, result), n.val)
+      if rem is LEnd       -> result
+  )(l, TResult())
 
 fun filter{T}(List{T} l, delegate{T, bool} pred)
   l.foldRight(lambda (List{T} newList, T val) pred(val) ? val :: newList : newList)

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -6,35 +6,39 @@ import "math.nov"
 fun parseInt(string str)
   parseIntOffset(str, 0, str.length())
 
-fun parseIntOffset(string str, int start, int end)
+fun parseIntOffset(string str, int start, int end) -> Option{int}
+  impl =
+  (
+    lambda (int idx, int result)
+      if idx >= end         -> result
+      if str[idx].isDigit() -> self(++idx, result * 10 + str[idx] - '0')
+      else                  -> None()
+  );
   if start == end       -> None()
-  if str[start] == '-'  -> parseIntImpl(str, ++start, end, 0).map(negate{int})
-  if str[start] == '+'  -> parseIntImpl(str, ++start, end, 0)
-  else                  -> parseIntImpl(str, start, end, 0)
-
-fun parseIntImpl(string str, int idx, int end, int result) -> Option{int}
-  if idx >= end         -> result
-  if str[idx].isDigit() -> parseIntImpl(str, ++idx, end, result * 10 + str[idx] - '0')
-  else                  -> None()
+  if str[start] == '-'  -> impl(++start, 0).map(negate{int})
+  if str[start] == '+'  -> impl(++start, 0)
+  else                  -> impl(start, 0)
 
 fun parseFloat(string str)
   parseFloatOffset(str, 0, str.length())
 
-fun parseFloatOffset(string str, int start, int end)
+fun parseFloatOffset(string str, int start, int end) -> Option{float}
+  impl =
+  (
+    lambda (int idx, float raw, float div, bool dec)
+      if idx >= end                         -> raw / div
+      if str[idx] == '.' && !dec            -> self(++idx, raw, div, true)
+      if str[idx].isDigit()                 -> newRaw = raw * 10.0 + int(str[idx]) - int('0');
+                                               newDiv = dec ? div * 10.0 : div;
+                                               self(++idx, newRaw, newDiv, dec)
+      if str[idx] == 'e' || str[idx] == 'E' -> parseIntOffset(str, ++idx, end).
+                                                  map(lambda (int exp) raw / (div / pow(10.0, exp)))
+      else                                  -> None()
+  );
   if start == end       -> None()
-  if str[start] == '-'  -> parseFloatImpl(str, ++start, end, 0.0, 1.0, false).map(negate{float})
-  if str[start] == '+'  -> parseFloatImpl(str, ++start, end, 0.0, 1.0, false)
-  else                  -> parseFloatImpl(str, start,   end, 0.0, 1.0, false)
-
-fun parseFloatImpl(string str, int idx, int end, float raw, float div, bool dec) -> Option{float}
-  if idx >= end                         -> raw / div
-  if str[idx] == '.' && !dec            -> parseFloatImpl(str, ++idx, end, raw, div, true)
-  if str[idx].isDigit()                 -> newRaw = raw * 10.0 + int(str[idx]) - int('0');
-                                           newDiv = dec ? div * 10.0 : div;
-                                           parseFloatImpl(str, ++idx, end, newRaw, newDiv, dec)
-  if str[idx] == 'e' || str[idx] == 'E' -> parseIntOffset(str, ++idx, end).
-                                            map(lambda (int exp) raw / (div / pow(10.0, exp)))
-  else                                  -> None()
+  if str[start] == '-'  -> impl(++start, 0.0, 1.0, false).map(negate{float})
+  if str[start] == '+'  -> impl(++start, 0.0, 1.0, false)
+  else                  -> impl(start,   0.0, 1.0, false)
 
 fun parseBool(string str) -> Option{bool}
   if str == "true" || str == "TRUE" || str == "True"    -> true

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -50,52 +50,52 @@ fun indexOf(string str, int idx, delegate{char, bool} pred)
   else                    -> indexOf(str, ++idx, pred)
 
 fun startsWith(string str, string subStr)
-  startsWithImpl(str, 0, subStr)
-
-fun startsWithImpl(string str, int idx, string subStr)
-  if idx >= subStr.length()   -> true
-  if idx >= str.length()      -> false
-  if str[idx] != subStr[idx]  -> false
-  else                        -> startsWithImpl(str, ++idx, subStr)
+  (
+    lambda (int idx)
+      if idx >= subStr.length()   -> true
+      if idx >= str.length()      -> false
+      if str[idx] != subStr[idx]  -> false
+      else                        -> self(++idx)
+  )(0)
 
 fun endsWith(string str, string subStr)
-  endsWithImpl(str, 0, subStr)
-
-fun endsWithImpl(string str, int revIdx, string subStr)
-  if revIdx >= subStr.length()                                          -> true
-  if revIdx >= str.length()                                             -> false
-  if str[--str.length() - revIdx] != subStr[--subStr.length() - revIdx] -> false
-  else -> endsWithImpl(str, ++revIdx, subStr)
+  (
+    lambda (int revIdx)
+      if revIdx >= subStr.length()                                          -> true
+      if revIdx >= str.length()                                             -> false
+      if str[--str.length() - revIdx] != subStr[--subStr.length() - revIdx] -> false
+      else                                                                  -> self(++revIdx)
+  )(0)
 
 fun any(string str, delegate{char, bool} pred)
-  anyImpl(str, 0, pred)
-
-fun anyImpl(string str, int idx, delegate{char, bool} pred)
-  if idx >= str.length()  -> false
-  else                    -> pred(str[idx]) || anyImpl(str, ++idx, pred)
+  (
+    lambda (int idx)
+      if idx >= str.length()  -> false
+      else                    -> pred(str[idx]) || self(++idx)
+  )(0)
 
 fun all(string str, delegate{char, bool} pred)
-  allImpl(str, 0, pred)
-
-fun allImpl(string str, int idx, delegate{char, bool} pred)
-  if idx >= str.length()  -> true
-  else                    -> pred(str[idx]) && allImpl(str, ++idx, pred)
+  (
+    lambda (int idx)
+      if idx >= str.length()  -> true
+      else                    -> pred(str[idx]) && self(++idx)
+  )(0)
 
 fun none(string str, delegate{char, bool} pred)
-  noneImpl(str, 0, pred)
-
-fun noneImpl(string str, int idx, delegate{char, bool} pred)
-  if idx >= str.length()  -> true
-  else                    -> !pred(str[idx]) && noneImpl(str, ++idx, pred)
+  (
+    lambda (int idx)
+      if idx >= str.length()  -> true
+      else                    -> !pred(str[idx]) && self(++idx)
+  )(0)
 
 fun replace(string str, string old, string new)
-  replaceImpl(str, 0, old, new)
-
-fun replaceImpl(string str, int startIdx, string old, string new)
-  idx = str.indexOf(startIdx, old, 0);
-  if idx < 0  ->  str
-  else        ->  newStr = str[0, idx] + new + str[idx + old.length(), str.length()];
-                  replaceImpl(newStr, idx + new.length(), old, new)
+  (
+    lambda (string str, int startIdx)
+      idx = str.indexOf(startIdx, old, 0);
+      if idx < 0  ->  str
+      else        ->  newStr = str[0, idx] + new + str[idx + old.length(), str.length()];
+                      self(newStr, idx + new.length())
+  )(str, 0)
 
 fun insert(string str, int idx, string val)
   if idx == 0             -> val + str
@@ -103,30 +103,30 @@ fun insert(string str, int idx, string val)
   else                    -> str[0, idx] + val + str[idx, str.length()]
 
 fun fold{T}(string str, delegate{T, char, T} del)
-  foldImpl(str, 0, del, T())
-
-fun foldImpl{T}(string str, int idx, delegate{T, char, T} del, T val)
-  idx >= str.length() ? val : foldImpl(str, ++idx, del, del(val, str[idx]))
+  (
+    lambda (int idx, T result)
+      idx >= str.length() ? result : self(++idx, del(result, str[idx]))
+  )(0, T())
 
 fun transform(string str, delegate{char, char} del)
   str.fold(lambda (string res, char c) res + del(c))
 
 fun split(string str, delegate{char, bool} pred)
-  splitImpl(str, --str.length(), --str.length(), pred, List{string}())
-
-fun splitImpl(string str, int startIdx, int endIdx, delegate{char, bool} pred, List{string} result)
-  if startIdx < 0         -> startIdx == endIdx ? result : str[startIdx, ++endIdx] :: result
-  if pred(str[startIdx])  -> startIdx == endIdx ?
-    splitImpl(str, --startIdx, --endIdx, pred, result) :
-    splitImpl(str, --startIdx, --startIdx, pred, str[++startIdx, ++endIdx] :: result)
-  else                    -> splitImpl(str, --startIdx, endIdx, pred, result)
+  (
+    lambda (int startIdx, int endIdx, List{string} result)
+      if startIdx < 0         -> startIdx == endIdx ? result : str[startIdx, ++endIdx] :: result
+      if pred(str[startIdx])  -> startIdx == endIdx ?
+        self(--startIdx, --endIdx, result) :
+        self(--startIdx, --startIdx, str[++startIdx, ++endIdx] :: result)
+      else                    -> self(--startIdx, endIdx, result)
+  )(--str.length(), --str.length(), List{string}())
 
 fun toChars(string str)
-  toCharsImpl(str, --str.length(), List{char}())
-
-fun toCharsImpl(string str, int idx, List{char} result)
-  if idx < 0  -> result
-  else        -> toCharsImpl(str, --idx, str[idx] :: result)
+  (
+    lambda (int idx, List{char} result)
+      if idx < 0  -> result
+      else        -> self(--idx, str[idx] :: result)
+  )(--str.length(), List{char}())
 
 fun join(List{string} l)
   l.sum()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ target_include_directories(parse PRIVATE parse)
 add_library(prog STATIC
   prog/expr/node_assign.cpp
   prog/expr/node_call_dyn.cpp
+  prog/expr/node_call_self.cpp
   prog/expr/node_call.cpp
   prog/expr/node_closure.cpp
   prog/expr/node_const.cpp

--- a/src/backend/builder.cpp
+++ b/src/backend/builder.cpp
@@ -55,14 +55,14 @@ auto Builder::addStackAlloc(uint8_t amount) -> void {
   writeUInt8(amount);
 }
 
-auto Builder::addStackStore(uint8_t constId) -> void {
+auto Builder::addStackStore(uint8_t offset) -> void {
   writeOpCode(vm::OpCode::StackStore);
-  writeUInt8(constId);
+  writeUInt8(offset);
 }
 
-auto Builder::addStackLoad(uint8_t constId) -> void {
+auto Builder::addStackLoad(uint8_t offset) -> void {
   writeOpCode(vm::OpCode::StackLoad);
-  writeUInt8(constId);
+  writeUInt8(offset);
 }
 
 auto Builder::addAddInt() -> void { writeOpCode(vm::OpCode::AddInt); }

--- a/src/backend/generator.cpp
+++ b/src/backend/generator.cpp
@@ -31,7 +31,7 @@ generateFunc(Builder* builder, const prog::Program& program, const prog::sym::Fu
   reserveConsts(builder, func.getConsts());
 
   // Generate the function body.
-  auto genExpr = internal::GenExpr{program, builder, true};
+  auto genExpr = internal::GenExpr{program, builder, func.getConsts(), func.getId(), true};
   func.getExpr().accept(&genExpr);
 
   // Note: Due to tail calls this return might never be executed.
@@ -50,7 +50,7 @@ generateExecStmt(Builder* builder, const prog::Program& program, const prog::sym
   reserveConsts(builder, exec.getConsts());
 
   // Generate the expression.
-  auto genExpr = internal::GenExpr{program, builder, false};
+  auto genExpr = internal::GenExpr{program, builder, exec.getConsts(), std::nullopt, false};
   exec.getExpr().accept(&genExpr);
 
   builder->addRet();

--- a/src/backend/internal/gen_expr.hpp
+++ b/src/backend/internal/gen_expr.hpp
@@ -2,17 +2,24 @@
 #include "backend/builder.hpp"
 #include "prog/expr/node_visitor.hpp"
 #include "prog/program.hpp"
+#include <optional>
 
 namespace backend::internal {
 
 class GenExpr final : public prog::expr::NodeVisitor {
 public:
-  GenExpr(const prog::Program& program, Builder* builder, bool tail);
+  GenExpr(
+      const prog::Program& program,
+      Builder* builder,
+      const prog::sym::ConstDeclTable& constTable,
+      std::optional<prog::sym::FuncId> curFunc,
+      bool tail);
 
   auto visit(const prog::expr::AssignExprNode& n) -> void override;
   auto visit(const prog::expr::SwitchExprNode& n) -> void override;
   auto visit(const prog::expr::CallExprNode& n) -> void override;
   auto visit(const prog::expr::CallDynExprNode& n) -> void override;
+  auto visit(const prog::expr::CallSelfExprNode& n) -> void override;
   auto visit(const prog::expr::ClosureNode& n) -> void override;
   auto visit(const prog::expr::ConstExprNode& n) -> void override;
   auto visit(const prog::expr::FieldExprNode& n) -> void override;
@@ -31,6 +38,8 @@ public:
 private:
   const prog::Program& m_program;
   Builder* m_builder;
+  const prog::sym::ConstDeclTable& m_constTable;
+  std::optional<prog::sym::FuncId> m_curFunc;
   bool m_tail;
 
   auto genSubExpr(const prog::expr::Node& n, bool tail) -> void;

--- a/src/backend/internal/utilities.cpp
+++ b/src/backend/internal/utilities.cpp
@@ -16,12 +16,12 @@ auto getUserTypeEqLabel(prog::sym::TypeId typeId) -> std::string {
   return oss.str();
 }
 
-auto getConstId(prog::sym::ConstId constId) -> uint8_t {
-  auto constNum = constId.getNum();
-  if (constNum > std::numeric_limits<uint8_t>::max()) {
+auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId id) -> uint8_t {
+  const auto offset = table.getOffset(id);
+  if (offset > std::numeric_limits<uint8_t>::max()) {
     throw std::logic_error{"More then 256 constants in one scope are not supported"};
   }
-  return static_cast<uint8_t>(constNum);
+  return static_cast<uint8_t>(offset);
 }
 
 auto getFieldId(prog::sym::FieldId fieldId) -> uint8_t {

--- a/src/backend/internal/utilities.hpp
+++ b/src/backend/internal/utilities.hpp
@@ -12,7 +12,7 @@ auto getLabel(prog::sym::FuncId funcId) -> std::string;
 
 auto getUserTypeEqLabel(prog::sym::TypeId typeId) -> std::string;
 
-auto getConstId(prog::sym::ConstId constId) -> uint8_t;
+auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId id) -> uint8_t;
 
 auto getFieldId(prog::sym::FieldId fieldId) -> uint8_t;
 

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -513,4 +513,30 @@ auto errForkedNonUserFunc(const Source& src, input::Span span) -> Diag {
   return error(src, oss.str(), span);
 }
 
+auto errForkedSelfCall(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Self calls cannot be forked";
+  return error(src, oss.str(), span);
+}
+
+auto errSelfCallInNonFunc(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Self calls can only be used inside functions or actions";
+  return error(src, oss.str(), span);
+}
+
+auto errSelfCallWithoutInferredRetType(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Failed to bind self call as return type could not be inferred";
+  return error(src, oss.str(), span);
+}
+
+auto errIncorrectNumArgsInSelfCall(
+    const Source& src, int expectedNumArgs, int actualNumArgs, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Self call requires '" << expectedNumArgs << "' arguments but got '" << actualNumArgs
+      << "'";
+  return error(src, oss.str(), span);
+}
+
 } // namespace frontend

--- a/src/frontend/internal/const_binder.cpp
+++ b/src/frontend/internal/const_binder.cpp
@@ -93,4 +93,20 @@ auto ConstBinder::bind(const std::string& name) -> std::optional<prog::sym::Cons
   return boundLocalConst;
 }
 
+auto ConstBinder::getAllConstTypes() -> std::unordered_map<std::string, prog::sym::TypeId> {
+  auto result = std::unordered_map<std::string, prog::sym::TypeId>{};
+
+  ConstBinder* current = this;
+  while (current) {
+    for (const auto visibleConst : *current->m_visibleConsts) {
+      const auto& name = (*current->m_consts)[visibleConst].getName();
+      const auto& type = (*current->m_consts)[visibleConst].getType();
+      result.insert({name, type});
+    }
+    current = current->m_parent;
+  }
+
+  return result;
+}
+
 } // namespace frontend::internal

--- a/src/frontend/internal/const_binder.hpp
+++ b/src/frontend/internal/const_binder.hpp
@@ -33,6 +33,8 @@ public:
 
   [[nodiscard]] auto bind(const std::string& name) -> std::optional<prog::sym::ConstId>;
 
+  [[nodiscard]] auto getAllConstTypes() -> std::unordered_map<std::string, prog::sym::TypeId>;
+
 private:
   prog::sym::ConstDeclTable* m_consts;
   std::vector<prog::sym::ConstId>* m_visibleConsts;

--- a/src/frontend/internal/define_exec_stmts.cpp
+++ b/src/frontend/internal/define_exec_stmts.cpp
@@ -22,6 +22,7 @@ auto DefineExecStmts::visit(const parse::ExecStmtNode& n) -> void {
                          nullptr,
                          &constBinder,
                          prog::sym::TypeId::inferType(),
+                         std::nullopt,
                          GetExpr::Flags::AllowActionCalls};
   n[0].accept(&getExpr);
   if (!getExpr.getValue()) {

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -20,6 +20,7 @@ auto defineFunc(
 
   const auto& funcDecl   = ctx->getProg()->getFuncDecl(id);
   const auto funcRetType = funcDecl.getOutput();
+  auto funcSignature     = std::make_pair(funcDecl.getInput(), funcRetType);
 
   auto consts = prog::sym::ConstDeclTable{};
   if (!declareFuncInput(ctx, typeSubTable, n, &consts)) {
@@ -34,7 +35,7 @@ auto defineFunc(
     getExprFlags = getExprFlags | GetExpr::Flags::AllowActionCalls;
   }
 
-  auto getExpr = GetExpr{ctx, typeSubTable, &constBinder, funcRetType, getExprFlags};
+  auto getExpr = GetExpr{ctx, typeSubTable, &constBinder, funcRetType, funcSignature, getExprFlags};
   n[0].accept(&getExpr);
   auto expr = std::move(getExpr.getValue());
 

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -2,8 +2,11 @@
 #include "internal/const_binder.hpp"
 #include "internal/context.hpp"
 #include "internal/type_substitution_table.hpp"
+#include <utility>
 
 namespace frontend::internal {
+
+using Signature = std::pair<prog::sym::TypeSet, prog::sym::TypeId>;
 
 class GetExpr final : public parse::NodeVisitor {
 public:
@@ -25,6 +28,7 @@ public:
       const TypeSubstitutionTable* typeSubTable,
       ConstBinder* constBinder,
       prog::sym::TypeId typeHint,
+      std::optional<Signature> selfSig,
       Flags flags);
 
   [[nodiscard]] auto getValue() -> prog::expr::NodePtr&;
@@ -61,6 +65,7 @@ private:
   const TypeSubstitutionTable* m_typeSubTable;
   ConstBinder* m_constBinder;
   prog::sym::TypeId m_typeHint;
+  std::optional<Signature> m_selfSig;
   Flags m_flags;
 
   prog::expr::NodePtr m_expr;
@@ -95,6 +100,8 @@ private:
       const lex::Token& fieldToken) -> prog::expr::NodePtr;
 
   [[nodiscard]] auto getConstExpr(const parse::IdExprNode& n) -> prog::expr::NodePtr;
+
+  [[nodiscard]] auto getSelfCallExpr(const parse::CallExprNode& n) -> prog::expr::NodePtr;
 
   [[nodiscard]] auto getDynCallExpr(const parse::CallExprNode& n) -> prog::expr::NodePtr;
 

--- a/src/frontend/internal/get_identifier.hpp
+++ b/src/frontend/internal/get_identifier.hpp
@@ -15,10 +15,12 @@ public:
   explicit GetIdentifier(bool includeInstances) :
       m_includeInstances{includeInstances},
       m_instance{nullptr},
+      m_isSelf{false},
       m_identifier{std::nullopt},
       m_typeParams{std::nullopt} {}
 
   [[nodiscard]] auto getInstance() const noexcept -> const parse::Node* { return m_instance; }
+  [[nodiscard]] auto isSelf() const noexcept -> bool { return m_isSelf; }
   [[nodiscard]] auto getIdentifier() const noexcept -> const std::optional<lex::Token>& {
     return m_identifier;
   }
@@ -27,6 +29,7 @@ public:
   }
 
   auto visit(const parse::IdExprNode& n) -> void override {
+    m_isSelf     = n.isSelf();
     m_identifier = n.getId();
     m_typeParams = n.getTypeParams();
   }
@@ -41,6 +44,7 @@ public:
 private:
   bool m_includeInstances;
   const parse::Node* m_instance;
+  bool m_isSelf;
   std::optional<lex::Token> m_identifier;
   std::optional<parse::TypeParamList> m_typeParams;
 };

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -14,6 +14,9 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::Action:
     out << "action";
     break;
+  case Keyword::Self:
+    out << "self";
+    break;
   case Keyword::Lambda:
     out << "lambda";
     break;
@@ -50,6 +53,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
       {"import", Keyword::Import},
       {"fun", Keyword::Fun},
       {"action", Keyword::Action},
+      {"self", Keyword::Self},
       {"lambda", Keyword::Lambda},
       {"fork", Keyword::Fork},
       {"struct", Keyword::Struct},

--- a/src/parse/node_expr_id.cpp
+++ b/src/parse/node_expr_id.cpp
@@ -1,4 +1,5 @@
 #include "parse/node_expr_id.hpp"
+#include "lex/keyword.hpp"
 #include "utilities.hpp"
 
 namespace parse {
@@ -28,6 +29,8 @@ auto IdExprNode::getSpan() const -> input::Span {
   return m_id.getSpan();
 }
 
+auto IdExprNode::isSelf() const -> bool { return getKw(m_id) == lex::Keyword::Self; }
+
 auto IdExprNode::getId() const -> const lex::Token& { return m_id; }
 
 auto IdExprNode::getTypeParams() const -> const std::optional<TypeParamList>& {
@@ -37,7 +40,7 @@ auto IdExprNode::getTypeParams() const -> const std::optional<TypeParamList>& {
 auto IdExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
 auto IdExprNode::print(std::ostream& out) const -> std::ostream& {
-  out << ::parse::getId(m_id).value_or("error");
+  out << (isSelf() ? "self" : ::parse::getId(m_id).value_or("error"));
   if (m_typeParams) {
     out << *m_typeParams;
   }

--- a/src/prog/expr/node_call_self.cpp
+++ b/src/prog/expr/node_call_self.cpp
@@ -1,0 +1,41 @@
+#include "prog/expr/node_call_self.hpp"
+#include "internal/implicit_conv.hpp"
+#include "utilities.hpp"
+#include <sstream>
+#include <stdexcept>
+
+namespace prog::expr {
+
+CallSelfExprNode::CallSelfExprNode(sym::TypeId resultType, std::vector<NodePtr> args) :
+    m_resultType{resultType}, m_args{std::move(args)} {}
+
+auto CallSelfExprNode::operator==(const Node& rhs) const noexcept -> bool {
+  const auto r = dynamic_cast<const CallSelfExprNode*>(&rhs);
+  return r != nullptr && m_resultType == r->m_resultType && nodesEqual(m_args, r->m_args);
+}
+
+auto CallSelfExprNode::operator!=(const Node& rhs) const noexcept -> bool {
+  return !CallSelfExprNode::operator==(rhs);
+}
+
+auto CallSelfExprNode::operator[](unsigned int i) const -> const Node& {
+  if (i >= m_args.size()) {
+    throw std::out_of_range("No child at given index");
+  }
+  return *m_args[i];
+}
+
+auto CallSelfExprNode::getChildCount() const -> unsigned int { return m_args.size(); }
+
+auto CallSelfExprNode::getType() const noexcept -> sym::TypeId { return m_resultType; }
+
+auto CallSelfExprNode::toString() const -> std::string { return "self-call"; }
+
+auto CallSelfExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
+
+// Factories.
+auto callSelfExprNode(sym::TypeId resultType, std::vector<NodePtr> args) -> NodePtr {
+  return std::unique_ptr<CallSelfExprNode>{new CallSelfExprNode{resultType, std::move(args)}};
+}
+
+} // namespace prog::expr

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(tests
 
   backend/assembly_output.cpp
   backend/call_dyn_expr_test.cpp
+  backend/call_self_expr_test.cpp
   backend/call_expr_test.cpp
   backend/constants_test.cpp
   backend/enum_test.cpp
@@ -35,6 +36,7 @@ add_executable(tests
   frontend/get_binary_expr_test.cpp
   frontend/get_call_dyn_expr_test.cpp
   frontend/get_call_expr_test.cpp
+  frontend/get_call_self_expr_test.cpp
   frontend/get_conditional_expr_test.cpp
   frontend/get_const_expr_test.cpp
   frontend/get_enum_expr_test.cpp

--- a/tests/backend/call_self_expr_test.cpp
+++ b/tests/backend/call_self_expr_test.cpp
@@ -1,0 +1,68 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+
+namespace backend {
+
+TEST_CASE("Generate assembly for self call expressions", "[backend]") {
+
+  SECTION("Function") {
+    CHECK_PROG("fun f(int i) i < 0 ? self(0) : i ", [](backend::Builder* builder) -> void {
+      // Function.
+      builder->label("func");
+      builder->addStackLoad(0); // Load arg 'i'.
+      builder->addLoadLitInt(0);
+      builder->addCheckLeInt();
+      builder->addJumpIf("less");
+
+      builder->addStackLoad(0); // Load arg 'i'.
+      builder->addJump("end");
+
+      builder->label("less");
+      builder->addLoadLitInt(0);
+      builder->addCall("func", 1, CallMode::Tail);
+
+      builder->label("end");
+      builder->addRet();
+
+      // Entry point.
+      builder->setEntrypoint("entry");
+      builder->label("entry");
+      builder->addRet();
+    });
+  }
+
+  SECTION("Closure") {
+    CHECK_PROG(
+        "fun f(int i) lambda (bool b) b ? i : self(!b) ", [](backend::Builder* builder) -> void {
+          // Function.
+          builder->addStackLoad(0); // Load arg 'i'.
+          builder->addLoadLitIp("lambda");
+          builder->addMakeStruct(2); // Make closure containing 'i' and the lambda ip.
+          builder->addRet();
+
+          // Lambda.
+          builder->label("lambda");
+          builder->addStackLoad(0); // Load arg 'b'.
+          builder->addJumpIf("bTrue");
+
+          builder->addStackLoad(0);  // Load arg 'b'.
+          builder->addLogicInvInt(); // !b
+          builder->addStackLoad(1);  // Load closure arg 'i'.
+          builder->addCall("lambda", 2, CallMode::Tail);
+          builder->addJump("lambdaEnd");
+
+          builder->label("bTrue");
+          builder->addStackLoad(1); // Load closure arg 'i'.
+
+          builder->label("lambdaEnd");
+          builder->addRet();
+
+          // Entry point.
+          builder->setEntrypoint("entry");
+          builder->label("entry");
+          builder->addRet();
+        });
+  }
+}
+
+} // namespace backend

--- a/tests/frontend/get_call_self_expr_test.cpp
+++ b/tests/frontend/get_call_self_expr_test.cpp
@@ -1,0 +1,62 @@
+#include "catch2/catch.hpp"
+#include "frontend/diag_defs.hpp"
+#include "helpers.hpp"
+#include "prog/expr/node_call_self.hpp"
+#include "prog/expr/node_lit_bool.hpp"
+#include "prog/expr/node_lit_int.hpp"
+#include "prog/expr/node_switch.hpp"
+
+namespace frontend {
+
+TEST_CASE("Analyzing self call expressions", "[frontend]") {
+
+  SECTION("Get basic self call") {
+    const auto& output = ANALYZE("fun f() false ? self() : 1 ");
+    REQUIRE(output.isSuccess());
+
+    auto conditions = std::vector<prog::expr::NodePtr>{};
+    conditions.push_back(prog::expr::litBoolNode(output.getProg(), false));
+
+    auto branches = std::vector<prog::expr::NodePtr>{};
+    branches.push_back(prog::expr::callSelfExprNode(GET_TYPE_ID(output, "int"), {}));
+    branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
+
+    CHECK(
+        GET_FUNC_DEF(output, "f").getExpr() ==
+        *prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches)));
+  }
+
+  SECTION("Get anonymous function with self call") {
+    const auto& output = ANALYZE("fun f() lambda () false ? self() : 1 ");
+    REQUIRE(output.isSuccess());
+
+    auto conditions = std::vector<prog::expr::NodePtr>{};
+    conditions.push_back(prog::expr::litBoolNode(output.getProg(), false));
+
+    auto branches = std::vector<prog::expr::NodePtr>{};
+    branches.push_back(prog::expr::callSelfExprNode(GET_TYPE_ID(output, "int"), {}));
+    branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
+
+    CHECK(
+        findAnonFuncDef(output, 0).getExpr() ==
+        *prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches)));
+  }
+
+  SECTION("Diagnostics") {
+    CHECK_DIAG("conWrite(self())", errSelfCallInNonFunc(src, input::Span{9, 14}));
+    CHECK_DIAG(
+        "fun f(int i) i < 0 ? fork self(0) : i", errForkedSelfCall(src, input::Span{21, 32}));
+    CHECK_DIAG("fun f() self()", errSelfCallWithoutInferredRetType(src, input::Span{8, 13}));
+    CHECK_DIAG(
+        "fun f(int i) i < 0 ? self() : i",
+        errIncorrectNumArgsInSelfCall(src, 1, 0, input::Span{21, 26}));
+    CHECK_DIAG(
+        "fun f(int i) i < 0 ? self(i, 1) : i",
+        errIncorrectNumArgsInSelfCall(src, 1, 2, input::Span{21, 30}));
+    CHECK_DIAG(
+        "fun f(int i) i < 0 ? self(\"hello\") : i",
+        errNoImplicitConversionFound(src, "string", "int", input::Span{26, 32}));
+  }
+}
+
+} // namespace frontend

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -6,6 +6,8 @@ namespace lex {
 TEST_CASE("Lexing keywords", "[lex]") {
   CHECK_TOKENS("import", keywordToken(Keyword::Import));
   CHECK_TOKENS("fun", keywordToken(Keyword::Fun));
+  CHECK_TOKENS("action", keywordToken(Keyword::Action));
+  CHECK_TOKENS("self", keywordToken(Keyword::Self));
   CHECK_TOKENS("lambda", keywordToken(Keyword::Lambda));
   CHECK_TOKENS("fork", keywordToken(Keyword::Fork));
   CHECK_TOKENS("struct", keywordToken(Keyword::Struct));

--- a/tests/parse/expr_call_test.cpp
+++ b/tests/parse/expr_call_test.cpp
@@ -12,6 +12,7 @@ TEST_CASE("Parsing call expressions", "[parse]") {
 
   CHECK_EXPR("a()", callExprNode({}, ID_EXPR("a"), OPAREN, NODES(), COMMAS(0), CPAREN));
   CHECK_EXPR("1()", callExprNode({}, INT(1), OPAREN, NODES(), COMMAS(0), CPAREN));
+  CHECK_EXPR("self()", callExprNode({}, SELF_ID_EXPR, OPAREN, NODES(), COMMAS(0), CPAREN));
   CHECK_EXPR(
       "1()()",
       callExprNode(

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -81,6 +81,7 @@ namespace parse {
 #define STR(VAL) litExprNode(lex::litStrToken(VAL))
 #define BOOL(VAL) litExprNode(lex::litBoolToken(VAL))
 #define ID_EXPR(ID) idExprNode(lex::identiferToken(ID), std::nullopt)
+#define SELF_ID_EXPR idExprNode(lex::keywordToken(lex::Keyword::Self), std::nullopt)
 #define ID_EXPR_PARAM(ID, TYPE_PARAMS) idExprNode(lex::identiferToken(ID), TYPE_PARAMS)
 #define CONSTDECL(ID, EXPR) constDeclExprNode(lex::identiferToken(ID), EQ, EXPR)
 


### PR DESCRIPTION
Self calls are a way to recurse without using the function name, although it works just fine for normal functions its meant to support recursion on lambdas. 

Recursive lambda's allow you to hide implementation details easier, for example an 'any' implementation on string:
```crystal
fun any(string str, delegate{char, bool} pred)
  anyImpl(str, 0, pred)

fun anyImpl(string str, int idx, delegate{char, bool} pred)
  if idx >= str.length()  -> false
  else                    -> pred(str[idx]) || anyImpl(str, ++idx, pred)
```
Can be rewritten to:
```crystal
fun any(string str, delegate{char, bool} pred)
  (
    lambda (int idx)
      if idx >= str.length()  -> false
      else                    -> pred(str[idx]) || self(++idx)
  )(0)
```


