### PR TITLE
Action delegates

### DIFF
--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -178,6 +178,8 @@ errAmbiguousFunction(const Source& src, const std::string& name, input::Span spa
     const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
     -> Diag;
 
+[[nodiscard]] auto errIllegalDelegateCall(const Source& src, input::Span span) -> Diag;
+
 [[nodiscard]] auto errIncorrectArgsToDelegate(const Source& src, input::Span span) -> Diag;
 
 [[nodiscard]] auto errUndeclaredCallOperator(

--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -5,7 +5,22 @@
 
 namespace lex {
 
-enum class Keyword { Import, Fun, Act, Self, Lambda, Fork, Struct, Union, Enum, If, Else, Is, As };
+enum class Keyword {
+  Import,
+  Fun,
+  Act,
+  Self,
+  Lambda,
+  Pure,
+  Fork,
+  Struct,
+  Union,
+  Enum,
+  If,
+  Else,
+  Is,
+  As
+};
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream&;
 

--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -5,21 +5,7 @@
 
 namespace lex {
 
-enum class Keyword {
-  Import,
-  Fun,
-  Action,
-  Self,
-  Lambda,
-  Fork,
-  Struct,
-  Union,
-  Enum,
-  If,
-  Else,
-  Is,
-  As
-};
+enum class Keyword { Import, Fun, Act, Self, Lambda, Fork, Struct, Union, Enum, If, Else, Is, As };
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream&;
 

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -21,8 +21,9 @@ namespace parse {
     std::optional<FuncDeclStmtNode::RetTypeSpec> retType,
     NodePtr body) -> NodePtr;
 
-[[nodiscard]] auto
-errInvalidAnonFuncExpr(lex::Token kw, const ArgumentListDecl& argList, NodePtr body) -> NodePtr;
+[[nodiscard]] auto errInvalidAnonFuncExpr(
+    std::vector<lex::Token> modifiers, lex::Token kw, const ArgumentListDecl& argList, NodePtr body)
+    -> NodePtr;
 
 [[nodiscard]] auto errInvalidStmtStructDecl(
     lex::Token kw,

--- a/include/parse/node_expr_anon_func.hpp
+++ b/include/parse/node_expr_anon_func.hpp
@@ -2,12 +2,15 @@
 #include "lex/token.hpp"
 #include "parse/argument_list_decl.hpp"
 #include "parse/node.hpp"
+#include <vector>
 
 namespace parse {
 
 class AnonFuncExprNode final : public Node {
 public:
-  friend auto anonFuncExprNode(lex::Token kw, ArgumentListDecl argList, NodePtr body) -> NodePtr;
+  friend auto anonFuncExprNode(
+      std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body)
+      -> NodePtr;
 
   AnonFuncExprNode() = delete;
 
@@ -18,21 +21,26 @@ public:
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
+  [[nodiscard]] auto isPure() const -> bool;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 
 private:
+  const std::vector<lex::Token> m_modifiers;
   const lex::Token m_kw;
   const ArgumentListDecl m_argList;
   const NodePtr m_body;
 
-  AnonFuncExprNode(lex::Token kw, ArgumentListDecl argList, NodePtr body);
+  AnonFuncExprNode(
+      std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body);
 
   auto print(std::ostream& out) const -> std::ostream& override;
 };
 
 // Factories.
-auto anonFuncExprNode(lex::Token kw, ArgumentListDecl argList, NodePtr body) -> NodePtr;
+auto anonFuncExprNode(
+    std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body)
+    -> NodePtr;
 
 } // namespace parse

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -45,7 +45,7 @@ private:
   auto nextExprSwitch() -> NodePtr;
   auto nextExprSwitchIf() -> NodePtr;
   auto nextExprSwitchElse() -> NodePtr;
-  auto nextExprAnonFunc() -> NodePtr;
+  auto nextExprAnonFunc(std::vector<lex::Token> modifiers) -> NodePtr;
 
   auto nextType() -> Type;
   auto nextTypeParamList() -> TypeParamList;

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -89,10 +89,10 @@ public:
 
   [[nodiscard]] auto isFuture(sym::TypeId id) const -> bool;
 
-  [[nodiscard]] auto isCallable(sym::FuncId func, const std::vector<expr::NodePtr>& args) const
-      -> bool;
-  [[nodiscard]] auto isCallable(sym::TypeId delegate, const std::vector<expr::NodePtr>& args) const
-      -> bool;
+  [[nodiscard]] auto satisfiesOptions(sym::TypeId delegate, OvOptions options) const -> bool;
+
+  [[nodiscard]] auto
+  isCallable(sym::TypeId delegate, const sym::TypeSet& input, OvOptions options) const -> bool;
 
   [[nodiscard]] auto getDelegateRetType(sym::TypeId id) const -> std::optional<sym::TypeId>;
 
@@ -114,7 +114,8 @@ public:
   auto defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void;
   auto defineUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> void;
   auto defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t> entries) -> void;
-  auto defineDelegate(sym::TypeId id, sym::TypeSet input, sym::TypeId output) -> void;
+  auto defineDelegate(sym::TypeId id, bool isAction, sym::TypeSet input, sym::TypeId output)
+      -> void;
   auto defineFuture(sym::TypeId id, sym::TypeId result) -> void;
   auto defineFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
 

--- a/include/prog/sym/delegate_def.hpp
+++ b/include/prog/sym/delegate_def.hpp
@@ -17,15 +17,17 @@ public:
   auto operator=(DelegateDef&& rhs) noexcept -> DelegateDef& = delete;
 
   [[nodiscard]] auto getId() const noexcept -> const TypeId&;
+  [[nodiscard]] auto isAction() const noexcept -> bool;
   [[nodiscard]] auto getInput() const -> const TypeSet&;
   [[nodiscard]] auto getOutput() const -> TypeId;
 
 private:
   sym::TypeId m_id;
+  bool m_isAction;
   TypeSet m_input;
   TypeId m_output;
 
-  DelegateDef(sym::TypeId id, TypeSet input, TypeId output);
+  DelegateDef(sym::TypeId id, bool isAction, TypeSet input, TypeId output);
 };
 
 } // namespace prog::sym

--- a/include/prog/sym/type_def_table.hpp
+++ b/include/prog/sym/type_def_table.hpp
@@ -45,7 +45,11 @@ public:
       std::unordered_map<std::string, int32_t> entries) -> void;
 
   auto registerDelegate(
-      const sym::TypeDeclTable& typeTable, sym::TypeId id, TypeSet input, TypeId output) -> void;
+      const sym::TypeDeclTable& typeTable,
+      sym::TypeId id,
+      bool isAction,
+      TypeSet input,
+      TypeId output) -> void;
 
   auto registerFuture(const sym::TypeDeclTable& typeTable, sym::TypeId id, TypeId result) -> void;
 

--- a/novstd/either.nov
+++ b/novstd/either.nov
@@ -10,19 +10,19 @@ fun string{T1, T2}(Either{T1, T2} e)
 
 // Functions
 
-fun map{T1, T2, TResult}(Either{T1, T2} e, delegate{T1, TResult} del)
-  if e as T1 t1 -> Either{TResult, T2}(del(t1))
+fun map{T1, T2, TResult}(Either{T1, T2} e, function{T1, TResult} func)
+  if e as T1 t1 -> Either{TResult, T2}(func(t1))
   if e as T2 t2 -> Either{TResult, T2}(t2)
 
-fun map{T1, T2, TResult}(Either{T1, T2} e, delegate{T2, TResult} del)
+fun map{T1, T2, TResult}(Either{T1, T2} e, function{T2, TResult} func)
   if e as T1 t1 -> Either{T1, TResult}(t1)
-  if e as T2 t2 -> Either{T1, TResult}(del(t2))
+  if e as T2 t2 -> Either{T1, TResult}(func(t2))
 
-fun map{T1, T2}(Either{T1, T2} e, delegate{T1, Either{T1, T2}} del)
-  e as T1 t1 ? del(t1) : e
+fun map{T1, T2}(Either{T1, T2} e, function{T1, Either{T1, T2}} func)
+  e as T1 t1 ? func(t1) : e
 
-fun map{T1, T2}(Either{T1, T2} e, delegate{T2, Either{T1, T2}} del)
-  e as T2 t2 ? del(t2) : e
+fun map{T1, T2}(Either{T1, T2} e, function{T2, Either{T1, T2}} func)
+  e as T2 t2 ? func(t2) : e
 
 // Tests
 
@@ -35,23 +35,23 @@ assert(Either{int, string}(42).string() == "42")
 assert(Either{int, string}("hello world").string() == "hello world")
 
 assert(
-  Either{int, string}("hello").map(lambda (string str) str == "hello") == true &&
-  Either{int, string}("hello").map(lambda (string str) str + " world") == "hello world" &&
-  Either{int, string}(42).map(lambda (string str) str == "hello") == 42)
+  Either{int, string}("hello").map(pure lambda (string str) str == "hello") == true &&
+  Either{int, string}("hello").map(pure lambda (string str) str + " world") == "hello world" &&
+  Either{int, string}(42).map(pure lambda (string str) str == "hello") == 42)
 
 assert(
-  Either{int, string}("hello").map(lambda (int i) i * i) == "hello" &&
-  Either{int, string}(42).map(lambda (int i) i == 42) == true &&
-  Either{int, string}(42).map(lambda (int i) i * i) == 42 * 42)
+  Either{int, string}("hello").map(pure lambda (int i) i * i) == "hello" &&
+  Either{int, string}(42).map(pure lambda (int i) i == 42) == true &&
+  Either{int, string}(42).map(pure lambda (int i) i * i) == 42 * 42)
 
 assert(
-  func = (lambda (int i) i == 42 ? Either{int, bool}(true) : Either{int, bool}(i));
+  func = (pure lambda (int i) i == 42 ? Either{int, bool}(true) : Either{int, bool}(i));
   Either{int, bool}(42).map(func) == true &&
   Either{int, bool}(41).map(func) == 41 &&
   Either{int, bool}(false).map(func) == false)
 
 assert(
-  func = (lambda (int i) i == 42 ? Either{bool, int}(true) : Either{bool, int}(i));
+  func = (pure lambda (int i) i == 42 ? Either{bool, int}(true) : Either{bool, int}(i));
   Either{bool, int}(42).map(func) == true &&
   Either{bool, int}(41).map(func) == 41 &&
   Either{bool, int}(false).map(func) == false)

--- a/novstd/env.nov
+++ b/novstd/env.nov
@@ -35,7 +35,7 @@ fun isLongOpt(string s)
 fun takeNonOpts(List{string} l)
   l.take(lambda (string str) str[0] != '-' || str[1].isDigit())
 
-fun findEnvOptVal{T}(List{string} args, string n, delegate{string, Option{T}} p) -> Either{T, Error}
+fun findEnvOptVal{T}(List{string} args, string n, function{string, Option{T}} p) -> Either{T, Error}
   if findEnvOpt(args, n) as EnvOpt o  ->
     if o.args.front().map(p) as T t -> t
     if o.args.isEmpty()             -> Error(2, "Option has no arguments")
@@ -54,11 +54,11 @@ act getEnvOpt(string name)
   findEnvOpt(getEnvArgs(), name)
 
 act getEnvArgs()
-  getEnvArgsImpl(--getEnvArgCount(), List{string}())
-
-act getEnvArgsImpl(int idx, List{string} result)
-  if idx < 0  -> result
-  else        -> getEnvArgsImpl(--idx, getEnvArg(idx) :: result)
+  (
+    lambda (int idx, List{string} result)
+      if idx < 0  -> result
+      else        -> self(--idx, getEnvArg(idx) :: result)
+  )(--getEnvArgCount(), List{string}())
 
 // Tests
 

--- a/novstd/env.nov
+++ b/novstd/env.nov
@@ -44,19 +44,19 @@ fun findEnvOptVal{T}(List{string} args, string n, delegate{string, Option{T}} p)
 
 // Actions
 
-action getIntEnvOpt(string name)
+act getIntEnvOpt(string name)
   findEnvOptVal(getEnvArgs(), name, parseInt)
 
-action getFloatEnvOpt(string name)
+act getFloatEnvOpt(string name)
   findEnvOptVal(getEnvArgs(), name, parseFloat)
 
-action getEnvOpt(string name)
+act getEnvOpt(string name)
   findEnvOpt(getEnvArgs(), name)
 
-action getEnvArgs()
+act getEnvArgs()
   getEnvArgsImpl(--getEnvArgCount(), List{string}())
 
-action getEnvArgsImpl(int idx, List{string} result)
+act getEnvArgsImpl(int idx, List{string} result)
   if idx < 0  -> result
   else        -> getEnvArgsImpl(--idx, getEnvArg(idx) :: result)
 

--- a/novstd/error.nov
+++ b/novstd/error.nov
@@ -17,7 +17,7 @@ fun Error(int errCode)
 fun ??{T}(Either{T, Error} e, T def)
   e as T val ? val : def
 
-fun ??{T}(Either{T, Error} e, delegate{T} defFactory)
+fun ??{T}(Either{T, Error} e, function{T} defFactory)
   e as T val ? val : defFactory()
 
 // Conversions

--- a/novstd/func.nov
+++ b/novstd/func.nov
@@ -1,60 +1,60 @@
 // Operators
 
-fun []{TC, TR}(delegate{TC, TR} del, TC arg)
-  curry(del, arg)
+fun []{TC, TR}(function{TC, TR} func, TC arg)
+  curry(func, arg)
 
-fun []{T1, TC, TR}(delegate{T1, TC, TR} del, TC arg)
-  curry(del, arg)
+fun []{T1, TC, TR}(function{T1, TC, TR} func, TC arg)
+  curry(func, arg)
 
-fun []{T1, T2, TC, TR}(delegate{T1, T2, TC, TR} del, TC arg)
-  curry(del, arg)
+fun []{T1, T2, TC, TR}(function{T1, T2, TC, TR} func, TC arg)
+  curry(func, arg)
 
-fun []{T1, T2, T3, TC, TR}(delegate{T1, T2, T3, TC, TR} del, TC arg)
-  curry(del, arg)
+fun []{T1, T2, T3, TC, TR}(function{T1, T2, T3, TC, TR} func, TC arg)
+  curry(func, arg)
 
-fun &(delegate{bool} predA, delegate{bool} predB)
+fun &(function{bool} predA, function{bool} predB)
   and(predA, predB)
 
-fun &{T1}(delegate{T1, bool} predA, delegate{T1, bool} predB)
+fun &{T1}(function{T1, bool} predA, function{T1, bool} predB)
   and(predA, predB)
 
-fun &{T1, T2}(delegate{T1, T2, bool} predA, delegate{T1, T2, bool} predB)
+fun &{T1, T2}(function{T1, T2, bool} predA, function{T1, T2, bool} predB)
   and(predA, predB)
 
-fun &{T1, T2, T3}(delegate{T1, T2, T3, bool} predA, delegate{T1, T2, T3, bool} predB)
+fun &{T1, T2, T3}(function{T1, T2, T3, bool} predA, function{T1, T2, T3, bool} predB)
   and(predA, predB)
 
-fun &{T1, T2, T3, T4}(delegate{T1, T2, T3, T4, bool} predA, delegate{T1, T2, T3, T4, bool} predB)
+fun &{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} predA, function{T1, T2, T3, T4, bool} predB)
   and(predA, predB)
 
-fun |(delegate{bool} predA, delegate{bool} predB)
+fun |(function{bool} predA, function{bool} predB)
   or(predA, predB)
 
-fun |{T1}(delegate{T1, bool} predA, delegate{T1, bool} predB)
+fun |{T1}(function{T1, bool} predA, function{T1, bool} predB)
   or(predA, predB)
 
-fun |{T1, T2}(delegate{T1, T2, bool} predA, delegate{T1, T2, bool} predB)
+fun |{T1, T2}(function{T1, T2, bool} predA, function{T1, T2, bool} predB)
   or(predA, predB)
 
-fun |{T1, T2, T3}(delegate{T1, T2, T3, bool} predA, delegate{T1, T2, T3, bool} predB)
+fun |{T1, T2, T3}(function{T1, T2, T3, bool} predA, function{T1, T2, T3, bool} predB)
   or(predA, predB)
 
-fun |{T1, T2, T3, T4}(delegate{T1, T2, T3, T4, bool} predA, delegate{T1, T2, T3, T4, bool} predB)
+fun |{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} predA, function{T1, T2, T3, T4, bool} predB)
   or(predA, predB)
 
-fun !(delegate{bool} pred)
+fun !(function{bool} pred)
   invert(pred)
 
-fun !{T1}(delegate{T1, bool} pred)
+fun !{T1}(function{T1, bool} pred)
   invert(pred)
 
-fun !{T1, T2}(delegate{T1, T2, bool} pred)
+fun !{T1, T2}(function{T1, T2, bool} pred)
   invert(pred)
 
-fun !{T1, T2, T3}(delegate{T1, T2, T3, bool} pred)
+fun !{T1, T2, T3}(function{T1, T2, T3, bool} pred)
   invert(pred)
 
-fun !{T1, T2, T3, T4}(delegate{T1, T2, T3, T4, bool} pred)
+fun !{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} pred)
   invert(pred)
 
 // Functions
@@ -62,61 +62,61 @@ fun !{T1, T2, T3, T4}(delegate{T1, T2, T3, T4, bool} pred)
 fun equals{T}(T a, T b)
   a == b
 
-fun curry{TC, TR}(delegate{TC, TR} del, TC arg)
-  lambda () del(arg)
+fun curry{TC, TR}(function{TC, TR} func, TC arg)
+  lambda () func(arg)
 
-fun curry{T1, TC, TR}(delegate{T1, TC, TR} del, TC arg)
-  lambda (T1 a1) del(a1, arg)
+fun curry{T1, TC, TR}(function{T1, TC, TR} func, TC arg)
+  lambda (T1 a1) func(a1, arg)
 
-fun curry{T1, T2, TC, TR}(delegate{T1, T2, TC, TR} del, TC arg)
-  lambda (T1 a1, T2 a2) del(a1, a2, arg)
+fun curry{T1, T2, TC, TR}(function{T1, T2, TC, TR} func, TC arg)
+  lambda (T1 a1, T2 a2) func(a1, a2, arg)
 
-fun curry{T1, T2, T3, TC, TR}(delegate{T1, T2, T3, TC, TR} del, TC arg)
-  lambda (T1 a1, T2 a2, T3 a3) del(a1, a2, a3, arg)
+fun curry{T1, T2, T3, TC, TR}(function{T1, T2, T3, TC, TR} func, TC arg)
+  lambda (T1 a1, T2 a2, T3 a3) func(a1, a2, a3, arg)
 
-fun and(delegate{bool} predA, delegate{bool} predB)
+fun and(function{bool} predA, function{bool} predB)
   lambda () predA() && predB()
 
-fun and{T1}(delegate{T1, bool} predA, delegate{T1, bool} predB)
+fun and{T1}(function{T1, bool} predA, function{T1, bool} predB)
   lambda (T1 a1) predA(a1) && predB(a1)
 
-fun and{T1, T2}(delegate{T1, T2, bool} predA, delegate{T1, T2, bool} predB)
+fun and{T1, T2}(function{T1, T2, bool} predA, function{T1, T2, bool} predB)
   lambda (T1 a1, T2 a2) predA(a1, a2) && predB(a1, a2)
 
-fun and{T1, T2, T3}(delegate{T1, T2, T3, bool} predA, delegate{T1, T2, T3, bool} predB)
+fun and{T1, T2, T3}(function{T1, T2, T3, bool} predA, function{T1, T2, T3, bool} predB)
   lambda (T1 a1, T2 a2, T3 a3) predA(a1, a2, a3) && predB(a1, a2, a3)
 
-fun and{T1, T2, T3, T4}(delegate{T1, T2, T3, T4, bool} predA, delegate{T1, T2, T3, T4, bool} predB)
+fun and{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} predA, function{T1, T2, T3, T4, bool} predB)
   lambda (T1 a1, T2 a2, T3 a3, T4 a4) predA(a1, a2, a3, a4) && predB(a1, a2, a3, a4)
 
-fun or(delegate{bool} predA, delegate{bool} predB)
+fun or(function{bool} predA, function{bool} predB)
   lambda () predA() || predB()
 
-fun or{T1}(delegate{T1, bool} predA, delegate{T1, bool} predB)
+fun or{T1}(function{T1, bool} predA, function{T1, bool} predB)
   lambda (T1 a1) predA(a1) || predB(a1)
 
-fun or{T1, T2}(delegate{T1, T2, bool} predA, delegate{T1, T2, bool} predB)
+fun or{T1, T2}(function{T1, T2, bool} predA, function{T1, T2, bool} predB)
   lambda (T1 a1, T2 a2) predA(a1, a2) || predB(a1, a2)
 
-fun or{T1, T2, T3}(delegate{T1, T2, T3, bool} predA, delegate{T1, T2, T3, bool} predB)
+fun or{T1, T2, T3}(function{T1, T2, T3, bool} predA, function{T1, T2, T3, bool} predB)
   lambda (T1 a1, T2 a2, T3 a3) predA(a1, a2, a3) || predB(a1, a2, a3)
 
-fun or{T1, T2, T3, T4}(delegate{T1, T2, T3, T4, bool} predA, delegate{T1, T2, T3, T4, bool} predB)
+fun or{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} predA, function{T1, T2, T3, T4, bool} predB)
   lambda (T1 a1, T2 a2, T3 a3, T4 a4) predA(a1, a2, a3, a4) || predB(a1, a2, a3, a4)
 
-fun invert(delegate{bool} pred)
+fun invert(function{bool} pred)
   lambda () !pred()
 
-fun invert{T1}(delegate{T1, bool} pred)
+fun invert{T1}(function{T1, bool} pred)
   lambda (T1 a1) !pred(a1)
 
-fun invert{T1, T2}(delegate{T1, T2, bool} pred)
+fun invert{T1, T2}(function{T1, T2, bool} pred)
   lambda (T1 a1, T2 a2) !pred(a1, a2)
 
-fun invert{T1, T2, T3}(delegate{T1, T2, T3, bool} pred)
+fun invert{T1, T2, T3}(function{T1, T2, T3, bool} pred)
   lambda (T1 a1, T2 a2, T3 a3) !pred(a1, a2, a3)
 
-fun invert{T1, T2, T3, T4}(delegate{T1, T2, T3, T4, bool} pred)
+fun invert{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} pred)
   lambda (T1 a1, T2 a2, T3 a3, T4 a4) !pred(a1, a2, a3, a4)
 
 // Tests
@@ -128,105 +128,135 @@ assert(
   eq42(42) && !eq42(43))
 
 assert(
-  funcRet = (lambda (int x) x);
+  funcRet = (pure lambda (int x) x);
   ret42 = funcRet[42];
   ret42() == funcRet(42))
 
 assert(
-  funcPlus = (lambda (int a, int b) a + b);
+  funcPlus = (pure lambda (int a, int b) a + b);
   plus42 = funcPlus[42];
   plus42(1337) == funcPlus(1337, 42))
 
 assert(
-  funcSum = (lambda (int a, int b, int c) a + b + c);
+  funcSum = (pure lambda (int a, int b, int c) a + b + c);
   sumPlus42 = funcSum[42];
   sumPlus42(1, 2) == funcSum(1, 2, 42))
 
 assert(
-  funcSum = (lambda (int a, int b, int c, int d) a + b + c + d);
+  funcSum = (pure lambda (int a, int b, int c, int d) a + b + c + d);
   sumPlus42 = funcSum[42];
   sumPlus42(1, 2, 3) == funcSum(1, 2, 3, 42))
 
 assert(
-  funcTrue = (lambda () true);
-  funcFalse = (lambda () false);
+  funcTrue = (pure lambda () true);
+  funcFalse = (pure lambda () false);
   (funcTrue & funcTrue)() && !(funcTrue & funcFalse)())
 
 assert(
-  isEven = (lambda (int x) x % 2 == 0);
-  isPos = (lambda (int x) x > 0);
+  isEven = (pure lambda (int x) x % 2 == 0);
+  isPos = (pure lambda (int x) x > 0);
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2) && !isEvenAndPos(3) && !isEvenAndPos(-2))
 
 assert(
-  isEven = (lambda (int x, int y) x % 2 == 0 && y % 2 == 0);
-  isPos = (lambda (int x, int y) x > 0 && y > 0);
+  isEven = (pure lambda (int x, int y) x % 2 == 0 && y % 2 == 0);
+  isPos = (pure lambda (int x, int y) x > 0 && y > 0);
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2, 4) && !isEvenAndPos(2, 3) && !isEvenAndPos(2, -2))
 
 assert(
-  isEven = (lambda (int x, int y, int z) x % 2 == 0 && y % 2 == 0 && z % 2 == 0);
-  isPos = (lambda (int x, int y, int z) x > 0 && y > 0 && z > 0);
+  isEven = (pure lambda (int x, int y, int z) x % 2 == 0 && y % 2 == 0 && z % 2 == 0);
+  isPos = (pure lambda (int x, int y, int z) x > 0 && y > 0 && z > 0);
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2, 2, 4) && !isEvenAndPos(2, 2, 3) && !isEvenAndPos(2, 2, -2))
 
 assert(
-  isEven = (lambda (int x, int y, int z, int w) x % 2 == 0 && y % 2 == 0 && z % 2 == 0 && w % 2 == 0);
-  isPos = (lambda (int x, int y, int z, int w) x > 0 && y > 0 && z > 0 && w > 0);
+  isEven = (
+    pure lambda (int x, int y, int z, int w)
+      x % 2 == 0 && y % 2 == 0 && z % 2 == 0 && w % 2 == 0
+  );
+  isPos = (
+    pure lambda (int x, int y, int z, int w)
+      x > 0 && y > 0 && z > 0 && w > 0
+  );
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2, 2, 2, 4) && !isEvenAndPos(2, 2, 2, 3) && !isEvenAndPos(2, 2, 2, -2))
 
 assert(
-  funcTrue = (lambda () true);
-  funcFalse = (lambda () false);
+  funcTrue = (pure lambda () true);
+  funcFalse = (pure lambda () false);
   (funcTrue | funcFalse)() && (funcFalse | funcTrue)() && !(funcFalse | funcFalse)())
 
 assert(
-  isEven = (lambda (int x) x % 2 == 0);
-  isPos = (lambda (int x) x > 0);
+  isEven = (pure lambda (int x) x % 2 == 0);
+  isPos = (pure lambda (int x) x > 0);
   isEvenOrPos = isEven | isPos;
   isEvenOrPos(2) && isEvenOrPos(1) && isEvenOrPos(-2) && !isEvenOrPos(-1))
 
 assert(
-  isEven = (lambda (int x, int y) x % 2 == 0 && y % 2 == 0);
-  isPos = (lambda (int x, int y) x > 0 && y > 0);
+  isEven = (
+    pure lambda (int x, int y)
+      x % 2 == 0 && y % 2 == 0
+  );
+  isPos = (
+    pure lambda (int x, int y)
+      x > 0 && y > 0
+  );
   isEvenOrPos = isEven | isPos;
   isEvenOrPos(2, 1) && isEvenOrPos(-2, 2) && !isEvenOrPos(-1, -2))
 
 assert(
-  isEven = (lambda (int x, int y, int z) x % 2 == 0 && y % 2 == 0 && z % 2 == 0);
-  isPos = (lambda (int x, int y, int z) x > 0 && y > 0 && z > 0);
+  isEven = (
+    pure lambda (int x, int y, int z)
+      x % 2 == 0 && y % 2 == 0 && z % 2 == 0
+  );
+  isPos = (
+    pure lambda (int x, int y, int z)
+      x > 0 && y > 0 && z > 0
+  );
   isEvenOrPos = isEven | isPos;
   isEvenOrPos(2, 2, 1) && isEvenOrPos(-2, -2, 2) && !isEvenOrPos(-1, -1, -2))
 
 assert(
-  isEven = (lambda (int x, int y, int z, int w) x % 2 == 0 && y % 2 == 0 && z % 2 == 0 && w % 2 == 0);
-  isPos = (lambda (int x, int y, int z, int w) x > 0 && y > 0 && z > 0 && w > 0);
+  isEven = (
+    pure lambda (int x, int y, int z, int w)
+      x % 2 == 0 && y % 2 == 0 && z % 2 == 0 && w % 2 == 0
+  );
+  isPos = (
+    pure lambda (int x, int y, int z, int w)
+      x > 0 && y > 0 && z > 0 && w > 0
+  );
   isEvenOrPos = isEven | isPos;
   isEvenOrPos(2, 2, 2, 1) && isEvenOrPos(-2, -2, -2, 2) && !isEvenOrPos(-1, -1, -1, -2))
 
 assert(
-  funcFalse = (lambda () false);
+  funcFalse = (pure lambda () false);
   funcTrue = !funcFalse;
   funcTrue())
 
 assert(
-  is42 = (lambda (int x) x == 42);
+  is42 = (pure lambda (int x) x == 42);
   isNot42 = !is42;
   isNot42(1337) && !isNot42(42))
 
 assert(
-  eq = (lambda (int x, int y) x == y);
+  eq = (pure lambda (int x, int y) x == y);
   notEq = !eq;
   notEq(42, 1337) && !notEq(42, 42))
 
 assert(
-  eq = (lambda (int x, int y, int z) x == y && y == z);
+  eq = (
+    pure lambda (int x, int y, int z)
+      x == y && y == z
+  );
   notEq = !eq;
   notEq(42, 42, 1337) && !notEq(42, 42, 42))
 
 assert(
-  eq = (lambda (int x, int y, int z, int w) x == y && y == z && z == w);
+  eq = (
+    pure lambda (int x, int y, int z, int w)
+      x == y && y == z && z == w
+  );
   notEq = !eq;
   notEq(42, 42, 42, 1337) && !notEq(42, 42, 42, 42))
 

--- a/novstd/list.nov
+++ b/novstd/list.nov
@@ -80,7 +80,7 @@ fun pop{T}(List{T} l, int amount)
   if l as LNode{T} n  -> amount > 0 ? pop(n.next, --amount) : l
   if l is LEnd        -> l
 
-fun pop{T}(List{T} l, delegate{T, bool} pred)
+fun pop{T}(List{T} l, function{T, bool} pred)
   if l as LNode{T} n  -> pred(n.val) ? pop(n.next, pred) : l
   if l is LEnd        -> l
 
@@ -94,7 +94,7 @@ fun take{T}(List{T} l, int amount)
   if l as LNode{T} n  -> amount > 0 ? List{T}(n.val, take(n.next, --amount)) : List{T}()
   if l is LEnd        -> l
 
-fun take{T}(List{T} l, delegate{T, bool} pred)
+fun take{T}(List{T} l, function{T, bool} pred)
   if l as LNode{T} n  -> pred(n.val) ? List{T}(n.val, take(n.next, pred)) : List{T}()
   if l is LEnd        -> l
 
@@ -108,31 +108,31 @@ fun insertOrdered{T}(List{T} l, T val)
 fun rangeList{T}(T start, T end)
   List{T}().pushRange(start, end)
 
-fun fold{T, TResult}(List{T} l, delegate{TResult, T, TResult} del)
+fun fold{T, TResult}(List{T} l, function{TResult, T, TResult} func)
   (
     lambda (List{T} rem, TResult result)
-      if rem as LNode{T} n -> self(n.next, del(result, n.val))
+      if rem as LNode{T} n -> self(n.next, func(result, n.val))
       if rem is LEnd       -> result
   )(l, TResult())
 
-fun foldRight{T, TResult}(List{T} l, delegate{TResult, T, TResult} del)
+fun foldRight{T, TResult}(List{T} l, function{TResult, T, TResult} func)
   (
     lambda (List{T} rem, TResult result)
-      if rem as LNode{T} n -> del(self(n.next, result), n.val)
+      if rem as LNode{T} n -> func(self(n.next, result), n.val)
       if rem is LEnd       -> result
   )(l, TResult())
 
-fun filter{T}(List{T} l, delegate{T, bool} pred)
+fun filter{T}(List{T} l, function{T, bool} pred)
   l.foldRight(lambda (List{T} newList, T val) pred(val) ? val :: newList : newList)
 
-fun filterReverse{T}(List{T} l, delegate{T, bool} pred)
+fun filterReverse{T}(List{T} l, function{T, bool} pred)
   l.fold(lambda (List{T} newList, T val) pred(val) ? val :: newList : newList)
 
-fun map{T, TResult}(List{T} l, delegate{T, TResult} del)
-  l.foldRight(lambda (List{TResult} newList, T val) del(val) :: newList)
+fun map{T, TResult}(List{T} l, function{T, TResult} func)
+  l.foldRight(lambda (List{TResult} newList, T val) func(val) :: newList)
 
-fun mapReverse{T, TResult}(List{T} l, delegate{T, TResult} del)
-  l.fold(lambda (List{TResult} newList, T val) del(val) :: newList)
+fun mapReverse{T, TResult}(List{T} l, function{T, TResult} func)
+  l.fold(lambda (List{TResult} newList, T val) func(val) :: newList)
 
 fun length{T}(List{T} l)
   l.fold(lambda (int c, T val) c + 1)
@@ -146,18 +146,18 @@ fun reverse{T}(List{T} l)
 fun sort{T}(List{T} l)
   l.fold(insertOrdered{T})
 
-fun count{T}(List{T} l, delegate{T, bool} pred)
+fun count{T}(List{T} l, function{T, bool} pred)
   l.fold(lambda (int c, T val) pred(val) ? ++c : c)
 
-fun any{T}(List{T} l, delegate{T, bool} pred)
+fun any{T}(List{T} l, function{T, bool} pred)
   if l as LNode{T} n  -> pred(n.val) || n.next.any(pred)
   if l is LEnd        -> false
 
-fun all{T}(List{T} l, delegate{T, bool} pred)
+fun all{T}(List{T} l, function{T, bool} pred)
   if l as LNode{T} n  -> pred(n.val) && n.next.any(pred)
   if l is LEnd        -> true
 
-fun none{T}(List{T} l, delegate{T, bool} pred)
+fun none{T}(List{T} l, function{T, bool} pred)
   if l as LNode{T} n  -> !pred(n.val) && n.next.none(pred)
   if l is LEnd        -> true
 
@@ -242,10 +242,10 @@ assert(
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: List{int}();
-  l.pop(lambda (int i) i == 0) == l &&
-  l.pop(lambda (int i) i > 0) == List{int}() &&
-  l.pop(lambda (int i) i == 1) == 2 :: 3 :: 4 :: List{int}() &&
-  l.pop(lambda (int i) i < 3) == 3 :: 4 :: List{int}())
+  l.pop(pure lambda (int i) i == 0) == l &&
+  l.pop(pure lambda (int i) i > 0) == List{int}() &&
+  l.pop(pure lambda (int i) i == 1) == 2 :: 3 :: 4 :: List{int}() &&
+  l.pop(pure lambda (int i) i < 3) == 3 :: 4 :: List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
@@ -258,9 +258,9 @@ assert(
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.take(lambda (int i) i == 0) == List{int}() &&
-  l.take(lambda (int i) i > 0) == l &&
-  l.take(lambda (int i) i < 3) == 1 :: 2 :: List{int}())
+  l.take(pure lambda (int i) i == 0) == List{int}() &&
+  l.take(pure lambda (int i) i > 0) == l &&
+  l.take(pure lambda (int i) i < 3) == 1 :: 2 :: List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: List{int}();
@@ -295,23 +295,23 @@ assert(rangeList('a', 'c') == 'a' :: 'b' :: 'c' :: List{char}())
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: List{int}();
-  l.filter(lambda (int v) v > 2) == 3 :: 4 :: List{int}() &&
-  l.filter(lambda (int v) v < 0) == List{int}())
+  l.filter(pure lambda (int v) v > 2) == 3 :: 4 :: List{int}() &&
+  l.filter(pure lambda (int v) v < 0) == List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: 5 :: List{int}();
-  l.filterReverse(lambda (int v) v > 2) == 5 :: 4 :: 3 :: List{int}() &&
-  l.filterReverse(lambda (int v) v < 0) == List{int}())
+  l.filterReverse(pure lambda (int v) v > 2) == 5 :: 4 :: 3 :: List{int}() &&
+  l.filterReverse(pure lambda (int v) v < 0) == List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.map(lambda (int v) v * 2) == 2 :: 4 :: 6 :: List{int}() &&
-  l.map(lambda (int v) v.string()) == "1" :: "2" :: "3" :: List{string}())
+  l.map(pure lambda (int v) v * 2) == 2 :: 4 :: 6 :: List{int}() &&
+  l.map(pure lambda (int v) v.string()) == "1" :: "2" :: "3" :: List{string}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.mapReverse(lambda (int v) v * 2) == 6 :: 4 :: 2 :: List{int}() &&
-  l.mapReverse(lambda (int v) v.string()) == "3" :: "2" :: "1" :: List{string}())
+  l.mapReverse(pure lambda (int v) v * 2) == 6 :: 4 :: 2 :: List{int}() &&
+  l.mapReverse(pure lambda (int v) v.string()) == "3" :: "2" :: "1" :: List{string}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
@@ -341,18 +341,18 @@ assert(List{int}().sort() == List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.count(lambda (int v) v > 2) == 1 &&
-  l.count(lambda (int v) v == 0) == 0 &&
-  l.count(lambda (int v) v > 0) == 3)
+  l.count(pure lambda (int v) v > 2) == 1 &&
+  l.count(pure lambda (int v) v == 0) == 0 &&
+  l.count(pure lambda (int v) v > 0) == 3)
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.any(lambda (int v) v > 2) && !l.any(lambda (int v) v < 0))
+  l.any(pure lambda (int v) v > 2) && !l.any(pure lambda (int v) v < 0))
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.all(lambda (int v) v > 0) && !l.all(lambda (int v) v > 1))
+  l.all(pure lambda (int v) v > 0) && !l.all(pure lambda (int v) v > 1))
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.none(lambda (int v) v < 0) && !l.none(lambda (int v) v > 1))
+  l.none(pure lambda (int v) v < 0) && !l.none(pure lambda (int v) v > 1))

--- a/novstd/option.nov
+++ b/novstd/option.nov
@@ -14,7 +14,7 @@ fun Option{T}()
 fun ??{T}(Option{T} opt, T def)
   opt as T val ? val : def
 
-fun ??{T}(Option{T} opt, delegate{T} defFactory)
+fun ??{T}(Option{T} opt, function{T} defFactory)
   opt as T val ? val : defFactory()
 
 // Conversions
@@ -24,11 +24,11 @@ fun string{T}(Option{T} opt)
 
 // Functions
 
-fun map{T, TResult}(Option{T} opt, delegate{T, TResult} del)
-  opt as T val ? del(val) : None()
+fun map{T, TResult}(Option{T} opt, function{T, TResult} func)
+  opt as T val ? func(val) : None()
 
-fun map{T, TResult}(Option{T} opt, delegate{T, Option{TResult}} del)
-  opt as T val ? del(val) : None()
+fun map{T, TResult}(Option{T} opt, function{T, Option{TResult}} func)
+  opt as T val ? func(val) : None()
 
 // Tests
 
@@ -40,17 +40,17 @@ assert(Option{int}() == Option{int}())
 assert(Option{int}() ?? 42 == 42)
 assert(Option(1337) ?? 42 == 1337)
 
-assert(Option{int}() ?? (lambda () 42) == 42)
-assert(Option(1337) ?? (lambda () 42) == 1337)
+assert(Option{int}() ?? (pure lambda () 42) == 42)
+assert(Option(1337) ?? (pure lambda () 42) == 1337)
 
 assert(Option(42).string() == "42")
 assert(Option{int}().string() == "none")
 
-assert(Option(42).map(lambda (int val) val * 2) == 84)
-assert(Option{int}().map(lambda (int val) val * 2) is None)
+assert(Option(42).map(pure lambda (int val) val * 2) == 84)
+assert(Option{int}().map(pure lambda (int val) val * 2) is None)
 
 assert(
-  func = (lambda (int val) val > 0 ? Option(val) : None());
+  func = (pure lambda (int val) val > 0 ? Option(val) : None());
   Option(42).map(func) == 42 &&
   Option(-42).map(func) is None &&
   Option{int}().map(func) is None)

--- a/novstd/print.nov
+++ b/novstd/print.nov
@@ -1,4 +1,4 @@
 // Actions
 
-action print{T}(T x)
+act print{T}(T x)
   conWriteLine(x.string())

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -41,10 +41,10 @@ fun indexOfLast(string str, int idx, string subStr, int subStrIdx)
                                           subStr,
                                           --subStr.length())
 
-fun indexOf(string str, delegate{char, bool} pred)
+fun indexOf(string str, function{char, bool} pred)
   indexOf(str, 0, pred)
 
-fun indexOf(string str, int idx, delegate{char, bool} pred)
+fun indexOf(string str, int idx, function{char, bool} pred)
   if idx >= str.length()  -> -1
   if pred(str[idx])       -> idx
   else                    -> indexOf(str, ++idx, pred)
@@ -67,21 +67,21 @@ fun endsWith(string str, string subStr)
       else                                                                  -> self(++revIdx)
   )(0)
 
-fun any(string str, delegate{char, bool} pred)
+fun any(string str, function{char, bool} pred)
   (
     lambda (int idx)
       if idx >= str.length()  -> false
       else                    -> pred(str[idx]) || self(++idx)
   )(0)
 
-fun all(string str, delegate{char, bool} pred)
+fun all(string str, function{char, bool} pred)
   (
     lambda (int idx)
       if idx >= str.length()  -> true
       else                    -> pred(str[idx]) && self(++idx)
   )(0)
 
-fun none(string str, delegate{char, bool} pred)
+fun none(string str, function{char, bool} pred)
   (
     lambda (int idx)
       if idx >= str.length()  -> true
@@ -102,16 +102,16 @@ fun insert(string str, int idx, string val)
   if idx >= str.length()  -> str + val
   else                    -> str[0, idx] + val + str[idx, str.length()]
 
-fun fold{T}(string str, delegate{T, char, T} del)
+fun fold{T}(string str, function{T, char, T} func)
   (
     lambda (int idx, T result)
-      idx >= str.length() ? result : self(++idx, del(result, str[idx]))
+      idx >= str.length() ? result : self(++idx, func(result, str[idx]))
   )(0, T())
 
-fun transform(string str, delegate{char, char} del)
-  str.fold(lambda (string res, char c) res + del(c))
+fun transform(string str, function{char, char} func)
+  str.fold(lambda (string res, char c) res + func(c))
 
-fun split(string str, delegate{char, bool} pred)
+fun split(string str, function{char, bool} pred)
   (
     lambda (int startIdx, int endIdx, List{string} result)
       if startIdx < 0         -> startIdx == endIdx ? result : str[startIdx, ++endIdx] :: result
@@ -176,7 +176,7 @@ assert(
 
 assert(
   "hello world".indexOf(equals{char}[' ']) == 5 &&
-  "hello world".indexOf(lambda (char c) c == 'd') == 10 &&
+  "hello world".indexOf(pure lambda (char c) c == 'd') == 10 &&
   "hello world".indexOf(equals{char}['h']) == 0 &&
   "hello world".indexOf(equals{char}['1']) == -1 &&
   "".indexOf(equals{char}[' ']) == -1)
@@ -234,8 +234,8 @@ assert(
   "helloworld".insert(5, "_") == "hello_world")
 
 assert(
-  "hello".transform(lambda (char c) 'W') == "WWWWW" &&
-  "".transform(lambda (char c) 'W') == "")
+  "hello".transform(pure lambda (char c) 'W') == "WWWWW" &&
+  "".transform(pure lambda (char c) 'W') == "")
 
 assert(
   "hello world".split(equals{char}[' ']) == "hello" :: "world" :: List{string}() &&

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -173,7 +173,7 @@ auto errNonOverloadableOperator(const Source& src, const std::string& name, inpu
 
 auto errNonPureOperatorOverload(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Operator overloads have to be pure ('fun' instead of 'action')";
+  oss << "Operator overloads have to be pure ('fun' instead of 'act')";
   return error(src, oss.str(), span);
 }
 
@@ -503,7 +503,7 @@ auto errNonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> D
 
 auto errNonPureConversion(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Type conversion has to be pure ('fun' instead of 'action')";
+  oss << "Type conversion has to be pure ('fun' instead of 'act')";
   return error(src, oss.str(), span);
 }
 

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -418,9 +418,15 @@ auto errAmbiguousTemplateFunction(
   return error(src, oss.str(), span);
 }
 
+auto errIllegalDelegateCall(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Cannot invoke the delegate, action's cannot be called from pure functions";
+  return error(src, oss.str(), span);
+}
+
 auto errIncorrectArgsToDelegate(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Incorrect arguments provided to function delegate";
+  oss << "Incorrect arguments provided to delegate";
   return error(src, oss.str(), span);
 }
 

--- a/src/frontend/internal/delegate_table.hpp
+++ b/src/frontend/internal/delegate_table.hpp
@@ -15,6 +15,8 @@ class DelegateTable final {
     auto operator()(const signature& id) const -> std::size_t;
   };
 
+  using delegateSet = std::unordered_map<signature, prog::sym::TypeId, Hasher>;
+
 public:
   DelegateTable()                             = default;
   DelegateTable(const DelegateTable& rhs)     = delete;
@@ -24,13 +26,30 @@ public:
   auto operator=(const DelegateTable& rhs) -> DelegateTable& = delete;
   auto operator=(DelegateTable&& rhs) noexcept -> DelegateTable& = delete;
 
-  auto getDelegate(Context* ctx, const prog::sym::TypeSet& types) -> prog::sym::TypeId;
+  auto getFunction(Context* ctx, const prog::sym::TypeSet& types) -> prog::sym::TypeId;
 
-  auto getDelegate(Context* ctx, const prog::sym::TypeSet& input, prog::sym::TypeId output)
+  auto getAction(Context* ctx, const prog::sym::TypeSet& types) -> prog::sym::TypeId;
+
+  auto getFunction(Context* ctx, const prog::sym::TypeSet& input, prog::sym::TypeId output)
+      -> prog::sym::TypeId;
+
+  auto getAction(Context* ctx, const prog::sym::TypeSet& input, prog::sym::TypeId output)
       -> prog::sym::TypeId;
 
 private:
-  std::unordered_map<signature, prog::sym::TypeId, Hasher> m_delegates;
+  delegateSet m_functions;
+  delegateSet m_actions;
+
+  static auto
+  getDelegate(Context* ctx, delegateSet* set, bool isAction, const prog::sym::TypeSet& types)
+      -> prog::sym::TypeId;
+
+  static auto getDelegate(
+      Context* ctx,
+      delegateSet* set,
+      bool isAction,
+      const prog::sym::TypeSet& input,
+      prog::sym::TypeId output) -> prog::sym::TypeId;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -113,15 +113,13 @@ private:
   [[nodiscard]] auto getFunctionsInclConversions(
       const lex::Token& nameToken,
       const std::optional<parse::TypeParamList>& typeParams,
-      const prog::sym::TypeSet& argTypes,
-      bool exclActions) -> std::vector<prog::sym::FuncId>;
+      const prog::sym::TypeSet& argTypes) -> std::vector<prog::sym::FuncId>;
 
   [[nodiscard]] auto getFunctions(
       const std::string& funcName,
       const std::optional<parse::TypeParamList>& typeParams,
       const prog::sym::TypeSet& argTypes,
-      input::Span span,
-      bool exclActions) -> std::vector<prog::sym::FuncId>;
+      input::Span span) -> std::vector<prog::sym::FuncId>;
 
   template <Flags F>
   [[nodiscard]] inline auto hasFlag() const noexcept {
@@ -129,14 +127,17 @@ private:
         static_cast<unsigned int>(F);
   }
 
-  [[nodiscard]] inline auto getOvOptions(int maxImplicitConvs, bool excludeActions = false) const
+  [[nodiscard]] inline auto getOvOptions(int maxImplicitConvs, bool excludeNonUser = false) const
       noexcept {
     auto ovFlags = prog::OvFlags::None;
     if (!hasFlag<Flags::AllowPureFuncCalls>()) {
       ovFlags = ovFlags | prog::OvFlags::ExclPureFuncs;
     }
-    if (!hasFlag<Flags::AllowActionCalls>() || excludeActions) {
+    if (!hasFlag<Flags::AllowActionCalls>()) {
       ovFlags = ovFlags | prog::OvFlags::ExclActions;
+    }
+    if (excludeNonUser) {
+      ovFlags = ovFlags | prog::OvFlags::ExclNonUser;
     }
     return prog::OvOptions{ovFlags, maxImplicitConvs};
   }

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -56,6 +56,8 @@ template <typename FuncParseNode>
     const std::unordered_map<std::string, prog::sym::TypeId>* additionalConstTypes,
     TypeInferExpr::Flags flags) -> prog::sym::TypeId;
 
+[[nodiscard]] auto getDelegate(Context* ctx, prog::sym::FuncId func) -> prog::sym::TypeId;
+
 [[nodiscard]] auto getLitFunc(Context* ctx, prog::sym::FuncId func) -> prog::expr::NodePtr;
 
 [[nodiscard]] auto
@@ -80,6 +82,8 @@ template <typename FuncParseNode>
 [[nodiscard]] auto getTypeSet(
     Context* ctx, const TypeSubstitutionTable* subTable, const std::vector<parse::Type>& parseTypes)
     -> std::optional<prog::sym::TypeSet>;
+
+[[nodiscard]] auto getTypeSet(const std::vector<prog::expr::NodePtr>& exprs) -> prog::sym::TypeSet;
 
 [[nodiscard]] auto getConstName(
     Context* ctx,

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -20,6 +20,9 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::Lambda:
     out << "lambda";
     break;
+  case Keyword::Pure:
+    out << "pure";
+    break;
   case Keyword::Fork:
     out << "fork";
     break;
@@ -55,6 +58,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
       {"act", Keyword::Act},
       {"self", Keyword::Self},
       {"lambda", Keyword::Lambda},
+      {"pure", Keyword::Pure},
       {"fork", Keyword::Fork},
       {"struct", Keyword::Struct},
       {"union", Keyword::Union},

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -11,8 +11,8 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::Fun:
     out << "fun";
     break;
-  case Keyword::Action:
-    out << "action";
+  case Keyword::Act:
+    out << "act";
     break;
   case Keyword::Self:
     out << "self";
@@ -52,7 +52,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
   static const std::unordered_map<std::string, Keyword> keywordTable = {
       {"import", Keyword::Import},
       {"fun", Keyword::Fun},
-      {"action", Keyword::Action},
+      {"act", Keyword::Act},
       {"self", Keyword::Self},
       {"lambda", Keyword::Lambda},
       {"fork", Keyword::Fork},

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -129,16 +129,22 @@ auto errInvalidStmtFuncDecl(
   return errorNode(oss.str(), std::move(tokens), std::move(nodes));
 }
 
-auto errInvalidAnonFuncExpr(lex::Token kw, const ArgumentListDecl& argList, NodePtr body)
+auto errInvalidAnonFuncExpr(
+    std::vector<lex::Token> modifiers, lex::Token kw, const ArgumentListDecl& argList, NodePtr body)
     -> NodePtr {
   std::ostringstream oss;
-  if (!argList.validate()) {
+  if (getKw(kw) != lex::Keyword::Lambda) {
+    oss << "Expected keyword 'lambda' but got: '" << kw << '\'';
+  } else if (!argList.validate()) {
     getError(oss, argList);
   } else {
     oss << "Invalid anonymous function";
   }
 
   auto tokens = std::vector<lex::Token>{};
+  for (auto& mod : modifiers) {
+    tokens.push_back(std::move(mod));
+  }
   tokens.push_back(std::move(kw));
   addTokens(argList, &tokens);
 

--- a/src/parse/node_expr_anon_func.cpp
+++ b/src/parse/node_expr_anon_func.cpp
@@ -3,12 +3,17 @@
 
 namespace parse {
 
-AnonFuncExprNode::AnonFuncExprNode(lex::Token kw, ArgumentListDecl argList, NodePtr body) :
-    m_kw{std::move(kw)}, m_argList{std::move(argList)}, m_body{std::move(body)} {}
+AnonFuncExprNode::AnonFuncExprNode(
+    std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body) :
+    m_modifiers{std::move(modifiers)},
+    m_kw{std::move(kw)},
+    m_argList{std::move(argList)},
+    m_body{std::move(body)} {}
 
 auto AnonFuncExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const AnonFuncExprNode*>(&rhs);
-  return r != nullptr && m_argList == r->m_argList && *m_body == *r->m_body;
+  return r != nullptr && m_modifiers == r->m_modifiers && m_argList == r->m_argList &&
+      *m_body == *r->m_body;
 }
 
 auto AnonFuncExprNode::operator!=(const Node& rhs) const noexcept -> bool {
@@ -25,7 +30,16 @@ auto AnonFuncExprNode::operator[](unsigned int i) const -> const Node& {
 auto AnonFuncExprNode::getChildCount() const -> unsigned int { return 1; }
 
 auto AnonFuncExprNode::getSpan() const -> input::Span {
+  if (!m_modifiers.empty()) {
+    return input::Span::combine(m_modifiers.begin()->getSpan(), m_body->getSpan());
+  }
   return input::Span::combine(m_kw.getSpan(), m_body->getSpan());
+}
+
+auto AnonFuncExprNode::isPure() const -> bool {
+  return std::any_of(m_modifiers.begin(), m_modifiers.end(), [](const lex::Token& t) {
+    return getKw(t) == lex::Keyword::Pure;
+  });
 }
 
 auto AnonFuncExprNode::getArgList() const -> const ArgumentListDecl& { return m_argList; }
@@ -33,18 +47,25 @@ auto AnonFuncExprNode::getArgList() const -> const ArgumentListDecl& { return m_
 auto AnonFuncExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
 auto AnonFuncExprNode::print(std::ostream& out) const -> std::ostream& {
-  out << "anonfun-";
-  out << m_argList;
-  return out;
+  for (const auto& mod : m_modifiers) {
+    auto modKw = getKw(mod);
+    if (modKw) {
+      out << *modKw << '-';
+    }
+  }
+  return out << "anonfun-" << m_argList;
+  ;
 }
 
 // Factories.
-auto anonFuncExprNode(lex::Token kw, ArgumentListDecl argList, NodePtr body) -> NodePtr {
+auto anonFuncExprNode(
+    std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body)
+    -> NodePtr {
   if (body == nullptr) {
     throw std::invalid_argument{"Body cannot be null"};
   }
-  return std::unique_ptr<AnonFuncExprNode>{
-      new AnonFuncExprNode{std::move(kw), std::move(argList), std::move(body)}};
+  return std::unique_ptr<AnonFuncExprNode>{new AnonFuncExprNode{
+      std::move(modifiers), std::move(kw), std::move(argList), std::move(body)}};
 }
 
 } // namespace parse

--- a/src/parse/node_expr_call.cpp
+++ b/src/parse/node_expr_call.cpp
@@ -19,7 +19,8 @@ CallExprNode::CallExprNode(
 
 auto CallExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const CallExprNode*>(&rhs);
-  return r != nullptr && *m_lhs == *r->m_lhs && nodesEqual(m_args, r->m_args);
+  return r != nullptr && m_modifiers == r->m_modifiers && *m_lhs == *r->m_lhs &&
+      nodesEqual(m_args, r->m_args);
 }
 
 auto CallExprNode::operator!=(const Node& rhs) const noexcept -> bool {

--- a/src/parse/node_stmt_func_decl.cpp
+++ b/src/parse/node_stmt_func_decl.cpp
@@ -57,7 +57,7 @@ auto FuncDeclStmtNode::getSpan() const -> input::Span {
   return input::Span::combine(m_kw.getSpan(), m_body->getSpan());
 }
 
-auto FuncDeclStmtNode::isAction() const -> bool { return getKw(m_kw) == lex::Keyword::Action; }
+auto FuncDeclStmtNode::isAction() const -> bool { return getKw(m_kw) == lex::Keyword::Act; }
 
 auto FuncDeclStmtNode::getId() const -> const lex::Token& { return m_id; }
 

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -22,7 +22,7 @@ auto ParserImpl::nextStmt() -> NodePtr {
     case lex::Keyword::Import:
       return nextImport();
     case lex::Keyword::Fun:
-    case lex::Keyword::Action:
+    case lex::Keyword::Act:
       return nextStmtFuncDecl();
     case lex::Keyword::Struct:
       return nextStmtStructDecl();
@@ -77,7 +77,7 @@ auto ParserImpl::nextStmtFuncDecl() -> NodePtr {
   }
   auto body = nextExpr(0);
 
-  auto kwValid       = kw == lex::Keyword::Fun || kw == lex::Keyword::Action;
+  auto kwValid       = kw == lex::Keyword::Fun || kw == lex::Keyword::Act;
   auto typeSubsValid = !typeSubs || typeSubs->validate();
   auto idValid =
       id.getKind() == lex::TokenKind::Identifier || id.getCat() == lex::TokenCat::Operator;

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -310,8 +310,12 @@ auto ParserImpl::nextExprPrimary() -> NodePtr {
     switch (*getKw(nextTok)) {
     case lex::Keyword::If:
       return nextExprSwitch();
+    case lex::Keyword::Pure: {
+      auto modifiers = std::vector<lex::Token>{consumeToken()};
+      return nextExprAnonFunc(std::move(modifiers));
+    }
     case lex::Keyword::Lambda:
-      return nextExprAnonFunc();
+      return nextExprAnonFunc({});
     case lex::Keyword::Fork: {
       auto modifiers = std::vector<lex::Token>{consumeToken()};
       return nextExprCall(nextExpr(0, callPrecedence), std::move(modifiers));
@@ -476,15 +480,15 @@ auto ParserImpl::nextExprSwitchElse() -> NodePtr {
   return errInvalidSwitchElse(kw, arrow, std::move(expr));
 }
 
-auto ParserImpl::nextExprAnonFunc() -> NodePtr {
+auto ParserImpl::nextExprAnonFunc(std::vector<lex::Token> modifiers) -> NodePtr {
   auto kw      = consumeToken();
   auto argList = nextArgDeclList();
   auto body    = nextExpr(0);
 
   if (getKw(kw) == lex::Keyword::Lambda && argList.validate()) {
-    return anonFuncExprNode(kw, std::move(argList), std::move(body));
+    return anonFuncExprNode(std::move(modifiers), kw, std::move(argList), std::move(body));
   }
-  return errInvalidAnonFuncExpr(kw, argList, std::move(body));
+  return errInvalidAnonFuncExpr(std::move(modifiers), kw, argList, std::move(body));
 }
 
 auto ParserImpl::nextType() -> Type {

--- a/src/prog/internal/implicit_conv.cpp
+++ b/src/prog/internal/implicit_conv.cpp
@@ -60,31 +60,31 @@ auto findImplicitConvTypes(const Program& prog, sym::TypeId from) -> std::vector
 }
 
 auto isImplicitConvertible(
-    const Program& prog, const sym::TypeSet& toTypes, const sym::TypeSet& fromTypes) -> bool {
+    const Program& prog,
+    const sym::TypeSet& toTypes,
+    const sym::TypeSet& fromTypes,
+    int maxConversions) -> bool {
+
   if (toTypes.getCount() != fromTypes.getCount()) {
     return false;
   }
+  auto convAmount   = 0;
   auto fromTypesItr = fromTypes.begin();
   auto toTypesItr   = toTypes.begin();
   for (; fromTypesItr != fromTypes.end(); ++fromTypesItr, ++toTypesItr) {
-    if (*fromTypesItr != *toTypesItr && !findImplicitConv(prog, *fromTypesItr, *toTypesItr)) {
+    // Check if types match.
+    if (*fromTypesItr == *toTypesItr) {
+      continue;
+    }
+
+    // Check if this is not requiring too many conversions.
+    if (maxConversions > 0 && convAmount >= maxConversions) {
       return false;
     }
-  }
-  return true;
-}
+    convAmount++;
 
-auto isImplicitConvertible(
-    const Program& prog, const sym::TypeSet& toTypes, const std::vector<expr::NodePtr>& fromArgs)
-    -> bool {
-  if (toTypes.getCount() != fromArgs.size()) {
-    return false;
-  }
-  auto fromArgsItr = fromArgs.begin();
-  auto toTypesItr  = toTypes.begin();
-  for (; fromArgsItr != fromArgs.end(); ++fromArgsItr, ++toTypesItr) {
-    const auto argType = (*fromArgsItr)->getType();
-    if (argType != *toTypesItr && !findImplicitConv(prog, argType, *toTypesItr)) {
+    // Check if an conversion is possible.
+    if (!findImplicitConv(prog, *fromTypesItr, *toTypesItr)) {
       return false;
     }
   }

--- a/src/prog/internal/implicit_conv.hpp
+++ b/src/prog/internal/implicit_conv.hpp
@@ -12,12 +12,10 @@ namespace prog::internal {
 
 // Are the fromTypes convertible to the toTypes.
 [[nodiscard]] auto isImplicitConvertible(
-    const Program& prog, const sym::TypeSet& toTypes, const sym::TypeSet& fromTypes) -> bool;
-
-// Are the fromArgs convertible to the toTypes.
-[[nodiscard]] auto isImplicitConvertible(
-    const Program& prog, const sym::TypeSet& toTypes, const std::vector<expr::NodePtr>& fromArgs)
-    -> bool;
+    const Program& prog,
+    const sym::TypeSet& toTypes,
+    const sym::TypeSet& fromTypes,
+    int maxConversions = -1) -> bool;
 
 // Apply conversions to the fromArgs so are matches the toTypes.
 auto applyImplicitConversions(

--- a/src/prog/internal/overload.cpp
+++ b/src/prog/internal/overload.cpp
@@ -20,6 +20,19 @@ auto findOverload(
       continue; // Argument count has to match.
     }
 
+    // Check if this overload satisfies the given options.
+    using Flags = sym::OverloadFlags;
+    if (options.hasFlag<Flags::ExclActions>() && declTable[overload].isAction()) {
+      continue;
+    }
+    if (options.hasFlag<Flags::ExclPureFuncs>() && !declTable[overload].isAction()) {
+      continue;
+    }
+    if (options.hasFlag<Flags::ExclNonUser>() &&
+        declTable[overload].getKind() != sym::FuncKind::User) {
+      continue;
+    }
+
     auto convAmount = 0;
     auto valid      = true;
     auto inputItr   = input.begin();

--- a/src/prog/sym/delegate_def.cpp
+++ b/src/prog/sym/delegate_def.cpp
@@ -2,10 +2,12 @@
 
 namespace prog::sym {
 
-DelegateDef::DelegateDef(sym::TypeId id, TypeSet input, TypeId output) :
-    m_id{id}, m_input{std::move(input)}, m_output{output} {}
+DelegateDef::DelegateDef(sym::TypeId id, bool isAction, TypeSet input, TypeId output) :
+    m_id{id}, m_isAction{isAction}, m_input{std::move(input)}, m_output{output} {}
 
 auto DelegateDef::getId() const noexcept -> const TypeId& { return m_id; }
+
+auto DelegateDef::isAction() const noexcept -> bool { return m_isAction; }
 
 auto DelegateDef::getInput() const -> const TypeSet& { return m_input; }
 

--- a/src/prog/sym/type_def_table.cpp
+++ b/src/prog/sym/type_def_table.cpp
@@ -64,7 +64,11 @@ auto TypeDefTable::registerEnum(
 }
 
 auto TypeDefTable::registerDelegate(
-    const sym::TypeDeclTable& typeTable, sym::TypeId id, TypeSet input, TypeId output) -> void {
+    const sym::TypeDeclTable& typeTable,
+    sym::TypeId id,
+    bool isAction,
+    TypeSet input,
+    TypeId output) -> void {
 
   if (typeTable[id].getKind() != sym::TypeKind::Delegate) {
     throw std::invalid_argument{"Type has not been declared as being a delegate"};
@@ -73,7 +77,7 @@ auto TypeDefTable::registerDelegate(
   if (itr != m_types.end()) {
     throw std::logic_error{"Type already has a definition registered"};
   }
-  m_types.insert({id, DelegateDef{id, std::move(input), output}});
+  m_types.insert({id, DelegateDef{id, isAction, std::move(input), output}});
 }
 
 auto TypeDefTable::registerFuture(

--- a/tests/backend/tail_calls_test.cpp
+++ b/tests/backend/tail_calls_test.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Generate assembly for tail calls", "[backend]") {
   SECTION("Dynamic tail call") {
     CHECK_PROG(
         "fun f1() -> int 42 "
-        "fun f2(delegate{int} func) -> int func() "
+        "fun f2(function{int} func) -> int func() "
         "conWrite(string(f2(f1)))",
         [](backend::Builder* builder) -> void {
           builder->label("f2");

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -183,9 +183,9 @@ TEST_CASE("Analyzing anonymous functions", "[frontend]") {
         "fun f() false ? i = 1 : (lambda () i)() ",
         errUninitializedConst(src, "i", input::Span{35, 35}));
     CHECK_DIAG(
-        "action a1() -> int 42 "
-        "action a2() lambda () a1()",
-        errUndeclaredPureFunc(src, "a1", {}, input::Span{44, 47}));
+        "act a1() -> int 42 "
+        "act a2() lambda () a1()",
+        errUndeclaredPureFunc(src, "a1", {}, input::Span{38, 41}));
   }
 }
 

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -113,23 +113,23 @@ TEST_CASE("Analyzing user-function declarations", "[frontend]") {
   SECTION("Actions") {
 
     SECTION("Declare basic action") {
-      const auto& output = ANALYZE("action act(int a, bool b) -> bool false");
+      const auto& output = ANALYZE("act a(int a, bool b) -> bool false");
       REQUIRE(output.isSuccess());
       CHECK(
-          GET_FUNC_DECL(output, "act", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "bool"))
+          GET_FUNC_DECL(output, "a", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "bool"))
               .getOutput() == GET_TYPE_ID(output, "bool"));
     }
 
     SECTION("Declare action template") {
-      const auto& output = ANALYZE("fun act{T}(T a) -> T a "
-                                   "fun f2() -> int act{int}(1) "
-                                   "fun f3() -> float act{float}(1.0)");
+      const auto& output = ANALYZE("act a{T}(T a) -> T a "
+                                   "act f2() -> int a{int}(1) "
+                                   "act f3() -> float a{float}(1.0)");
       REQUIRE(output.isSuccess());
       CHECK(
-          GET_FUNC_DECL(output, "act__int", GET_TYPE_ID(output, "int")).getOutput() ==
+          GET_FUNC_DECL(output, "a__int", GET_TYPE_ID(output, "int")).getOutput() ==
           GET_TYPE_ID(output, "int"));
       CHECK(
-          GET_FUNC_DECL(output, "act__float", GET_TYPE_ID(output, "float")).getOutput() ==
+          GET_FUNC_DECL(output, "a__float", GET_TYPE_ID(output, "float")).getOutput() ==
           GET_TYPE_ID(output, "float"));
     }
   }
@@ -178,19 +178,19 @@ TEST_CASE("Analyzing user-function declarations", "[frontend]") {
     CHECK_DIAG(
         "fun conWrite(string input) input",
         errDuplicateFuncDeclaration(src, "conWrite", input::Span{0, 31}));
-    CHECK_DIAG("action +(int i) i + 1", errNonPureOperatorOverload(src, input::Span{7, 7}));
-    CHECK_DIAG("action +{T}(T t) t + 1", errNonPureOperatorOverload(src, input::Span{7, 7}));
+    CHECK_DIAG("act +(int i) i + 1", errNonPureOperatorOverload(src, input::Span{4, 4}));
+    CHECK_DIAG("act +{T}(T t) t + 1", errNonPureOperatorOverload(src, input::Span{4, 4}));
     CHECK_DIAG(
         "struct S = int i, bool b "
-        "action S() S(0, false)",
-        errNonPureConversion(src, input::Span{32, 32}));
+        "act S() S(0, false)",
+        errNonPureConversion(src, input::Span{29, 29}));
     CHECK_DIAG(
         "struct S{T} = int i, T t "
-        "action S{T}() S{T}(0, T()) "
-        "action act() S{int}()",
-        errNonPureConversion(src, input::Span{25, 50}),
-        errInvalidFuncInstantiation(src, input::Span{65, 65}),
-        errNoTypeOrConversionFoundToInstantiate(src, "S", 1, input::Span{65, 72}));
+        "act S{T}() S{T}(0, T()) "
+        "act a() S{int}()",
+        errNonPureConversion(src, input::Span{25, 47}),
+        errInvalidFuncInstantiation(src, input::Span{57, 57}),
+        errNoTypeOrConversionFoundToInstantiate(src, "S", 1, input::Span{57, 64}));
   }
 }
 

--- a/tests/frontend/declare_user_types_test.cpp
+++ b/tests/frontend/declare_user_types_test.cpp
@@ -79,7 +79,8 @@ TEST_CASE("Analyzing user-type declarations", "[frontend]") {
     CHECK_DIAG("struct int = bool i", errTypeAlreadyDeclared(src, "int", input::Span{7, 9}));
     CHECK_DIAG("union int = int, bool", errTypeAlreadyDeclared(src, "int", input::Span{6, 8}));
     CHECK_DIAG(
-        "struct delegate = bool i", errTypeNameIsReserved(src, "delegate", input::Span{7, 14}));
+        "struct function = bool i", errTypeNameIsReserved(src, "function", input::Span{7, 14}));
+    CHECK_DIAG("struct action = bool i", errTypeNameIsReserved(src, "action", input::Span{7, 12}));
     CHECK_DIAG(
         "struct conWrite = bool i",
         errTypeNameConflictsWithFunc(src, "conWrite", input::Span{7, 14}));
@@ -107,7 +108,8 @@ TEST_CASE("Analyzing user-type declarations", "[frontend]") {
         "struct s{T} = T t",
         errTypeTemplateAlreadyDeclared(src, "s", input::Span{28, 28}));
     CHECK_DIAG("enum int = a", errTypeAlreadyDeclared(src, "int", input::Span{5, 7}));
-    CHECK_DIAG("enum delegate = a", errTypeNameIsReserved(src, "delegate", input::Span{5, 12}));
+    CHECK_DIAG("enum function = a", errTypeNameIsReserved(src, "function", input::Span{5, 12}));
+    CHECK_DIAG("enum action = a", errTypeNameIsReserved(src, "action", input::Span{5, 10}));
     CHECK_DIAG(
         "enum conWrite = a", errTypeNameConflictsWithFunc(src, "conWrite", input::Span{5, 12}));
   }

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Analyzing execute statements", "[frontend]") {
   }
 
   SECTION("Define exec statement to custom action") {
-    const auto& output = ANALYZE("action main() "
+    const auto& output = ANALYZE("act main() "
                                  " conWrite(\"hello \"); "
                                  " conWrite(\"world\") "
                                  "main()");

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -51,8 +51,11 @@ TEST_CASE("Analyzing user-function definitions", "[frontend]") {
         "fun f(int int) -> int true",
         errConstNameConflictsWithType(src, "int", input::Span{10, 12}));
     CHECK_DIAG(
-        "fun f(int delegate) -> int true",
-        errConstNameConflictsWithType(src, "delegate", input::Span{10, 17}));
+        "fun f(int function) -> int true",
+        errConstNameConflictsWithType(src, "function", input::Span{10, 17}));
+    CHECK_DIAG(
+        "fun f(int action) -> int true",
+        errConstNameConflictsWithType(src, "action", input::Span{10, 15}));
     CHECK_DIAG(
         "fun f(int a, int a) -> int true",
         errConstNameConflictsWithConst(src, "a", input::Span{17, 17}));
@@ -93,9 +96,9 @@ TEST_CASE("Analyzing user-function definitions", "[frontend]") {
         errInvalidFuncInstantiation(src, input::Span{50, 50}),
         errNoFuncFoundToInstantiate(src, "f", 1, input::Span{50, 58}));
     CHECK_DIAG(
-        "fun f() -> delegate{int} lambda () false",
+        "fun f() -> function{int} lambda () false",
         errNonMatchingFuncReturnType(
-            src, "f", "delegate{int}", "delegate{bool}", input::Span{25, 39}));
+            src, "f", "function{int}", "function{bool}", input::Span{25, 39}));
     CHECK_DIAG(
         "fun f() -> string conWrite(\"hello world\")",
         errUndeclaredPureFunc(src, "conWrite", {"string"}, input::Span{18, 40}));

--- a/tests/frontend/define_user_types_test.cpp
+++ b/tests/frontend/define_user_types_test.cpp
@@ -106,8 +106,10 @@ TEST_CASE("Analyzing user-type definitions", "[frontend]") {
     CHECK_DIAG(
         "struct s = int int", errFieldNameConflictsWithType(src, "int", input::Span{15, 17}));
     CHECK_DIAG(
-        "struct s = int delegate",
-        errFieldNameConflictsWithType(src, "delegate", input::Span{15, 22}));
+        "struct s = int function",
+        errFieldNameConflictsWithType(src, "function", input::Span{15, 22}));
+    CHECK_DIAG(
+        "struct s = int action", errFieldNameConflictsWithType(src, "action", input::Span{15, 20}));
     CHECK_DIAG("struct s = s i", errCyclicStruct(src, "i", "s", input::Span{0, 13}));
     CHECK_DIAG(
         "struct s1 = s2 a "

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -160,15 +160,15 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
         errUndeclaredConst(src, "conWrite", input::Span{23, 30}),
         errUndeclaredPureFunc(src, "op", {"string"}, input::Span{33, 49}));
     CHECK_DIAG(
-        "action main() conWrite(\"hello world\") "
-        "action a() -> string op = main; op()",
-        errUndeclaredConst(src, "main", input::Span{64, 67}),
-        errUndeclaredFuncOrAction(src, "op", {}, input::Span{70, 73}));
+        "act main() conWrite(\"hello world\") "
+        "act a() -> string op = main; op()",
+        errUndeclaredConst(src, "main", input::Span{58, 61}),
+        errUndeclaredFuncOrAction(src, "op", {}, input::Span{64, 67}));
     CHECK_DIAG(
-        "action main{T}() conWrite(\"hello world\") "
-        "action a() -> string op = main{int}; op()",
-        errNoFuncFoundToInstantiate(src, "main", 1, input::Span{67, 75}),
-        errUndeclaredFuncOrAction(src, "op", {}, input::Span{78, 81}));
+        "act main{T}() conWrite(\"hello world\") "
+        "act a() -> string op = main{int}; op()",
+        errNoFuncFoundToInstantiate(src, "main", 1, input::Span{61, 69}),
+        errUndeclaredFuncOrAction(src, "op", {}, input::Span{72, 75}));
   }
 }
 

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -14,10 +14,10 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
   SECTION("Get delegate call without args") {
     const auto& output = ANALYZE("fun f1() -> int 1 "
-                                 "fun f2(delegate{int} op) -> int op() "
+                                 "fun f2(function{int} op) -> int op() "
                                  "fun f() -> int f2(f1)");
     REQUIRE(output.isSuccess());
-    const auto& f2Def = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__delegate_int"));
+    const auto& f2Def = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__function_int"));
     const auto& fDef  = GET_FUNC_DEF(output, "f");
 
     CHECK(
@@ -29,7 +29,7 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
     auto fArgs = std::vector<prog::expr::NodePtr>{};
     fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__delegate_int"), GET_FUNC_ID(output, "f1")));
+        output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
     CHECK(
         fDef.getExpr() ==
         *prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs)));
@@ -37,11 +37,11 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
   SECTION("Get delegate call with args") {
     const auto& output = ANALYZE("fun f1(bool b, float v) -> int b ? 1 : 0 "
-                                 "fun f2(delegate{bool, float, int} op) -> int op(false, 1) "
+                                 "fun f2(function{bool, float, int} op) -> int op(false, 1) "
                                  "fun f() -> int f2(f1)");
     REQUIRE(output.isSuccess());
     const auto& f2Def =
-        GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__delegate_bool_float_int"));
+        GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__function_bool_float_int"));
     const auto& fDef = GET_FUNC_DEF(output, "f");
 
     auto f2Args = std::vector<prog::expr::NodePtr>{};
@@ -57,7 +57,7 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
     auto fArgs = std::vector<prog::expr::NodePtr>{};
     fArgs.push_back(prog::expr::litFuncNode(
         output.getProg(),
-        GET_TYPE_ID(output, "__delegate_bool_float_int"),
+        GET_TYPE_ID(output, "__function_bool_float_int"),
         GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "bool"), GET_TYPE_ID(output, "float"))));
     CHECK(
         fDef.getExpr() ==
@@ -66,10 +66,10 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
   SECTION("Get delegate call with templated function") {
     const auto& output = ANALYZE("fun f1{T}() -> T T() "
-                                 "fun f2(delegate{int} op) -> int op() "
+                                 "fun f2(function{int} op) -> int op() "
                                  "fun f() -> int f2(f1{int})");
     REQUIRE(output.isSuccess());
-    const auto& f2Def = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__delegate_int"));
+    const auto& f2Def = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__function_int"));
     const auto& fDef  = GET_FUNC_DEF(output, "f");
 
     CHECK(
@@ -81,14 +81,14 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
     auto fArgs = std::vector<prog::expr::NodePtr>{};
     fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__delegate_int"), GET_FUNC_ID(output, "f1__int")));
+        output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1__int")));
     CHECK(
         fDef.getExpr() ==
         *prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs)));
   }
 
   SECTION("Get delegate call on struct") {
-    const auto& output = ANALYZE("struct S = delegate{int} del "
+    const auto& output = ANALYZE("struct S = function{int} del "
                                  "fun f(S s) -> int s.del()");
     REQUIRE(output.isSuccess());
     const auto& sDef = std::get<prog::sym::StructDef>(GET_TYPE_DEF(output, "S"));
@@ -107,10 +107,10 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
   SECTION("Get forked delegate call") {
     const auto& output = ANALYZE("fun f1() -> int 1 "
-                                 "fun f2(delegate{int} op) -> future{int} fork op() "
+                                 "fun f2(function{int} op) -> future{int} fork op() "
                                  "fun f() -> future{int} f2(f1)");
     REQUIRE(output.isSuccess());
-    const auto& f2Def = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__delegate_int"));
+    const auto& f2Def = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__function_int"));
     const auto& fDef  = GET_FUNC_DEF(output, "f");
 
     CHECK(
@@ -124,7 +124,7 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
     auto fArgs = std::vector<prog::expr::NodePtr>{};
     fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__delegate_int"), GET_FUNC_ID(output, "f1")));
+        output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
     CHECK(
         fDef.getExpr() ==
         *prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs)));
@@ -132,7 +132,7 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
 
   SECTION("Diagnostics") {
     CHECK_DIAG(
-        "fun f(delegate{int, float, bool} op) -> bool op(false, 1.0)",
+        "fun f(function{int, float, bool} op) -> bool op(false, 1.0)",
         errIncorrectArgsToDelegate(src, input::Span{45, 58}));
     CHECK_DIAG(
         "fun f1(int v) -> int v "
@@ -153,22 +153,15 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
         errNoTypeParamsProvidedToTemplateFunction(src, "f1", input::Span{42, 43}),
         errUndeclaredPureFunc(src, "op", {}, input::Span{46, 49}));
     CHECK_DIAG(
-        "fun f() -> delegate{string, string} conWrite",
+        "fun f() -> function{string, string} conWrite",
         errUndeclaredConst(src, "conWrite", input::Span{36, 43}));
     CHECK_DIAG(
         "fun f() -> string op = conWrite; op(\"hello world\")",
         errUndeclaredConst(src, "conWrite", input::Span{23, 30}),
         errUndeclaredPureFunc(src, "op", {"string"}, input::Span{33, 49}));
+    CHECK_DIAG("fun f(action{int} a) a()", errIllegalDelegateCall(src, input::Span{21, 23}));
     CHECK_DIAG(
-        "act main() conWrite(\"hello world\") "
-        "act a() -> string op = main; op()",
-        errUndeclaredConst(src, "main", input::Span{58, 61}),
-        errUndeclaredFuncOrAction(src, "op", {}, input::Span{64, 67}));
-    CHECK_DIAG(
-        "act main{T}() conWrite(\"hello world\") "
-        "act a() -> string op = main{int}; op()",
-        errNoFuncFoundToInstantiate(src, "main", 1, input::Span{61, 69}),
-        errUndeclaredFuncOrAction(src, "op", {}, input::Span{72, 75}));
+        "fun f(action{int} a) lambda () a()", errIllegalDelegateCall(src, input::Span{31, 33}));
   }
 }
 

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -168,8 +168,8 @@ TEST_CASE("Analyzing call expressions", "[frontend]") {
   }
 
   SECTION("Get call to action") {
-    const auto& output = ANALYZE("action a1() -> int 1 "
-                                 "action a2() -> int a1()");
+    const auto& output = ANALYZE("act a1() -> int 1 "
+                                 "act a2() -> int a1()");
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DEF(output, "a2").getExpr() ==
@@ -214,17 +214,17 @@ TEST_CASE("Analyzing call expressions", "[frontend]") {
         "fun f() -> int 42()",
         errUndeclaredCallOperator(src, {"int"}, input::Span{50, 53}));
     CHECK_DIAG(
-        "action a() -> int 1 "
+        "act a() -> int 1 "
         "fun f2() -> int a()",
-        errUndeclaredPureFunc(src, "a", {}, input::Span{36, 38}));
+        errUndeclaredPureFunc(src, "a", {}, input::Span{33, 35}));
     CHECK_DIAG(
-        "action a{T}() -> T T() "
+        "act a{T}() -> T T() "
         "fun f2() -> int a{int}()",
-        errNoFuncFoundToInstantiate(src, "a", 1, input::Span{39, 46}));
+        errNoFuncFoundToInstantiate(src, "a", 1, input::Span{36, 43}));
     CHECK_DIAG(
-        "action a(int i) -> int i * 2 "
+        "act a(int i) -> int i * 2 "
         "fun f2(int i) -> int i.a()",
-        errUndeclaredPureFunc(src, "a", {"int"}, input::Span{50, 54}));
+        errUndeclaredPureFunc(src, "a", {"int"}, input::Span{47, 51}));
   }
 }
 

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -331,7 +331,7 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
   }
 
   SECTION("Infinite recursing action") {
-    const auto& output = ANALYZE("action main() "
+    const auto& output = ANALYZE("act main() "
                                  " conWrite(\"hello world\"); "
                                  " main()");
     REQUIRE(output.isSuccess());

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -40,14 +40,28 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
     const auto& output = ANALYZE("fun f1(int i) i "
                                  "fun f() f1");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__delegate_int_int"));
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__function_int_int"));
+  }
+
+  SECTION("Action literal") {
+    const auto& output = ANALYZE("act a1(int i) i "
+                                 "act a() a1");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "a").getOutput() == GET_TYPE_ID(output, "__action_int_int"));
   }
 
   SECTION("Templated function literal") {
     const auto& output = ANALYZE("fun f1{T}(T t) t "
                                  "fun f() f1{int}");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__delegate_int_int"));
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__function_int_int"));
+  }
+
+  SECTION("Templated action literal") {
+    const auto& output = ANALYZE("act a1{T}(T t) t "
+                                 "act a() a1{int}");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "a").getOutput() == GET_TYPE_ID(output, "__action_int_int"));
   }
 
   SECTION("Function argument") {
@@ -254,15 +268,15 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
   }
 
   SECTION("Dynamic call") {
-    const auto& output = ANALYZE("fun f(delegate{int, int} op) op(1)");
+    const auto& output = ANALYZE("fun f(function{int, int} op) op(1)");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "__delegate_int_int")).getOutput() ==
+        GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "__function_int_int")).getOutput() ==
         GET_TYPE_ID(output, "int"));
   }
 
   SECTION("Dynamic call on struct field") {
-    const auto& output = ANALYZE("struct S = delegate{int} del "
+    const auto& output = ANALYZE("struct S = function{int} del "
                                  "fun f(S s) s.del()");
     REQUIRE(output.isSuccess());
     CHECK(
@@ -271,17 +285,17 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
   }
 
   SECTION("Forked dynamic call") {
-    const auto& output = ANALYZE("fun f(delegate{int, int} op) fork op(1)");
+    const auto& output = ANALYZE("fun f(function{int, int} op) fork op(1)");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "__delegate_int_int")).getOutput() ==
+        GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "__function_int_int")).getOutput() ==
         GET_TYPE_ID(output, "__future_int"));
   }
 
   SECTION("Anonymous function") {
     const auto& output = ANALYZE("fun f() lambda (int i) i == i");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__delegate_int_bool"));
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__function_int_bool"));
   }
 
   SECTION("Anonymous function call") {
@@ -295,7 +309,7 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float")).getOutput() ==
-        GET_TYPE_ID(output, "__delegate_int_float"));
+        GET_TYPE_ID(output, "__function_int_float"));
   }
 
   SECTION("Anonymous function with nested closure") {
@@ -303,7 +317,7 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float")).getOutput() ==
-        GET_TYPE_ID(output, "__delegate_int___delegate_float"));
+        GET_TYPE_ID(output, "__function_int___function_float"));
   }
 
   SECTION("Anonymous function call with closure") {
@@ -319,7 +333,19 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float")).getOutput() ==
-        GET_TYPE_ID(output, "__delegate_float"));
+        GET_TYPE_ID(output, "__function_float"));
+  }
+
+  SECTION("Anonymous action") {
+    const auto& output = ANALYZE("act a() lambda (int i) i == i");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "a").getOutput() == GET_TYPE_ID(output, "__action_int_bool"));
+  }
+
+  SECTION("Anonymous action call") {
+    const auto& output = ANALYZE("act a() (lambda (int i) i == i)(42)");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "a").getOutput() == GET_TYPE_ID(output, "bool"));
   }
 
   SECTION("Templated overloaded call") {

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -229,7 +229,7 @@ TEST_CASE("Analyzing user-function templates", "[frontend]") {
 
   SECTION("Func templates are ignored when arguments don't match") {
     const auto& output = ANALYZE("fun ft{T}(int i, T v) -> bool false "
-                                 "fun ft{T1, T2}(delegate{T1} d, T2 v) -> bool false "
+                                 "fun ft{T1, T2}(function{T1} d, T2 v) -> bool false "
                                  "fun f() -> bool ft(lambda () 42, 42)");
     REQUIRE(output.isSuccess());
 

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -6,7 +6,7 @@ namespace lex {
 TEST_CASE("Lexing keywords", "[lex]") {
   CHECK_TOKENS("import", keywordToken(Keyword::Import));
   CHECK_TOKENS("fun", keywordToken(Keyword::Fun));
-  CHECK_TOKENS("action", keywordToken(Keyword::Action));
+  CHECK_TOKENS("act", keywordToken(Keyword::Act));
   CHECK_TOKENS("self", keywordToken(Keyword::Self));
   CHECK_TOKENS("lambda", keywordToken(Keyword::Lambda));
   CHECK_TOKENS("fork", keywordToken(Keyword::Fork));

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -9,6 +9,7 @@ TEST_CASE("Lexing keywords", "[lex]") {
   CHECK_TOKENS("act", keywordToken(Keyword::Act));
   CHECK_TOKENS("self", keywordToken(Keyword::Self));
   CHECK_TOKENS("lambda", keywordToken(Keyword::Lambda));
+  CHECK_TOKENS("pure", keywordToken(Keyword::Pure));
   CHECK_TOKENS("fork", keywordToken(Keyword::Fork));
   CHECK_TOKENS("struct", keywordToken(Keyword::Struct));
   CHECK_TOKENS("union", keywordToken(Keyword::Union));

--- a/tests/parse/expr_anon_func_test.cpp
+++ b/tests/parse/expr_anon_func_test.cpp
@@ -9,10 +9,14 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
 
   CHECK_EXPR(
       "lambda () 1",
-      anonFuncExprNode(LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), INT(1)));
+      anonFuncExprNode({}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), INT(1)));
+  CHECK_EXPR(
+      "pure lambda () 1",
+      anonFuncExprNode({PURE}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), INT(1)));
   CHECK_EXPR(
       "lambda (int x) 1",
       anonFuncExprNode(
+          {},
           LAMBDA,
           ArgumentListDecl(
               OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), CPAREN),
@@ -20,6 +24,7 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
   CHECK_EXPR(
       "lambda (int x, int y) 1",
       anonFuncExprNode(
+          {},
           LAMBDA,
           ArgumentListDecl(
               OPAREN,
@@ -31,6 +36,7 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
   CHECK_EXPR(
       "lambda (int x, int y, bool z) x * y",
       anonFuncExprNode(
+          {},
           LAMBDA,
           ArgumentListDecl(
               OPAREN,
@@ -45,18 +51,22 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
     CHECK_EXPR(
         "lambda ()",
         anonFuncExprNode(
-            LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), errInvalidPrimaryExpr(END)));
+            {},
+            LAMBDA,
+            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
         "lambda",
         errInvalidAnonFuncExpr(
-            LAMBDA, ArgumentListDecl(END, {}, COMMAS(0), END), errInvalidPrimaryExpr(END)));
+            {}, LAMBDA, ArgumentListDecl(END, {}, COMMAS(0), END), errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
         "lambda (",
         errInvalidAnonFuncExpr(
-            LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), END), errInvalidPrimaryExpr(END)));
+            {}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), END), errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
         "lambda (int x",
         errInvalidAnonFuncExpr(
+            {},
             LAMBDA,
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), END),
@@ -64,12 +74,14 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
     CHECK_EXPR(
         "lambda (int",
         errInvalidAnonFuncExpr(
+            {},
             LAMBDA,
             ArgumentListDecl(OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), END)}, COMMAS(0), END),
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
         "lambda (int x int y)",
         errInvalidAnonFuncExpr(
+            {},
             LAMBDA,
             ArgumentListDecl(
                 OPAREN,
@@ -81,6 +93,7 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
     CHECK_EXPR(
         "lambda (int x,,)",
         errInvalidAnonFuncExpr(
+            {},
             LAMBDA,
             ArgumentListDecl(
                 OPAREN,
@@ -89,11 +102,23 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
                 COMMAS(1),
                 END),
             errInvalidPrimaryExpr(END)));
+    CHECK_EXPR(
+        "pure function () 1",
+        errInvalidAnonFuncExpr(
+            {PURE},
+            ID("function"),
+            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            INT(1)));
+    CHECK_EXPR(
+        "pure action () 1",
+        errInvalidAnonFuncExpr(
+            {PURE}, ID("action"), ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN), INT(1)));
   }
 
   SECTION("Spans") {
     CHECK_EXPR_SPAN(" lambda () 1 + 2", input::Span(1, 15));
     CHECK_EXPR_SPAN("lambda (int i) i", input::Span(0, 15));
+    CHECK_EXPR_SPAN("pure lambda (int i) i", input::Span(0, 20));
   }
 }
 

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -50,7 +50,7 @@ namespace parse {
 #define DISCARD lex::basicToken(lex::TokenKind::Discard)
 #define IMPORT lex::keywordToken(lex::Keyword::Import)
 #define FUN lex::keywordToken(lex::Keyword::Fun)
-#define ACTION lex::keywordToken(lex::Keyword::Action)
+#define ACT lex::keywordToken(lex::Keyword::Act)
 #define LAMBDA lex::keywordToken(lex::Keyword::Lambda)
 #define FORK lex::keywordToken(lex::Keyword::Fork)
 #define STRUCT lex::keywordToken(lex::Keyword::Struct)

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -52,6 +52,7 @@ namespace parse {
 #define FUN lex::keywordToken(lex::Keyword::Fun)
 #define ACT lex::keywordToken(lex::Keyword::Act)
 #define LAMBDA lex::keywordToken(lex::Keyword::Lambda)
+#define PURE lex::keywordToken(lex::Keyword::Pure)
 #define FORK lex::keywordToken(lex::Keyword::Fork)
 #define STRUCT lex::keywordToken(lex::Keyword::Struct)
 #define UNION lex::keywordToken(lex::Keyword::Union)

--- a/tests/parse/stmt_func_decl_test.cpp
+++ b/tests/parse/stmt_func_decl_test.cpp
@@ -132,18 +132,18 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
 
   SECTION("Actions") {
     CHECK_STMT(
-        "action a() 1",
+        "act a() 1",
         funcDeclStmtNode(
-            ACTION,
+            ACT,
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN),
             std::nullopt,
             INT(1)));
     CHECK_STMT(
-        "action a(int x) -> int 1",
+        "act a(int x) -> int 1",
         funcDeclStmtNode(
-            ACTION,
+            ACT,
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -151,9 +151,9 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
-        "action a{T, U}(T{U} x) x",
+        "act a{T, U}(T{U} x) x",
         funcDeclStmtNode(
-            ACTION,
+            ACT,
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(1), CCURLY},
             ArgumentListDecl(


### PR DESCRIPTION
Adds a delegate type for actions.

Changes:
* `delegate` type is renamed to `function`.
* `action` keyword is renamed `act`.
* New non-pure delegate called `action`.
* Lamba's in a non-pure context create `action`'s default.
* To create a 'function' lambda in a non-pure context there is a new `pure lambda` syntax.

```c
import "std/print.nov"
import "std/parse.nov"
import "std/env.nov"

fun sum(int x, int y)
  x + y

fun apply(int x, int y, function{int, int, int} op)
  op(x, y)

print(apply(42, 1337, sum))
print(apply(42, 1337, pure lambda (int x, int y) x * y))

act readInt()
  parseInt(conReadLine()) ?? -1

act sumActions(action{int} x, action{int} y)
  x() + y()

print(sumActions(readInt, readInt))
print(sumActions(
  lambda () getIntEnvOpt("a") ?? -1, 
  lambda () getIntEnvOpt("b") ?? -1))
```