### PR TITLE
Function to action implicit conversion

### DIFF
--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -114,8 +114,12 @@ public:
   auto defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void;
   auto defineUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> void;
   auto defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t> entries) -> void;
-  auto defineDelegate(sym::TypeId id, bool isAction, sym::TypeSet input, sym::TypeId output)
-      -> void;
+  auto defineDelegate(
+      sym::TypeId id,
+      bool isAction,
+      sym::TypeSet input,
+      sym::TypeId output,
+      const std::vector<sym::TypeId>& aliases) -> void;
   auto defineFuture(sym::TypeId id, sym::TypeId result) -> void;
   auto defineFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
 

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -43,8 +43,8 @@ public:
       const TypeSet& input,
       OverloadOptions options) const -> std::optional<FuncId>;
 
-  auto registerImplicitConv(
-      const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId;
+  auto registerImplicitConv(const Program& prog, FuncKind kind, TypeId input, TypeId output)
+      -> FuncId;
 
   auto
   registerFunc(const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output)

--- a/src/frontend/internal/delegate_table.hpp
+++ b/src/frontend/internal/delegate_table.hpp
@@ -15,8 +15,6 @@ class DelegateTable final {
     auto operator()(const signature& id) const -> std::size_t;
   };
 
-  using delegateSet = std::unordered_map<signature, prog::sym::TypeId, Hasher>;
-
 public:
   DelegateTable()                             = default;
   DelegateTable(const DelegateTable& rhs)     = delete;
@@ -26,30 +24,17 @@ public:
   auto operator=(const DelegateTable& rhs) -> DelegateTable& = delete;
   auto operator=(DelegateTable&& rhs) noexcept -> DelegateTable& = delete;
 
-  auto getFunction(Context* ctx, const prog::sym::TypeSet& types) -> prog::sym::TypeId;
-
-  auto getAction(Context* ctx, const prog::sym::TypeSet& types) -> prog::sym::TypeId;
-
-  auto getFunction(Context* ctx, const prog::sym::TypeSet& input, prog::sym::TypeId output)
+  auto getDelegate(Context* ctx, bool isAction, const prog::sym::TypeSet& types)
       -> prog::sym::TypeId;
 
-  auto getAction(Context* ctx, const prog::sym::TypeSet& input, prog::sym::TypeId output)
+  auto getDelegate(
+      Context* ctx, bool isAction, const prog::sym::TypeSet& input, prog::sym::TypeId output)
       -> prog::sym::TypeId;
 
 private:
-  delegateSet m_functions;
-  delegateSet m_actions;
-
-  static auto
-  getDelegate(Context* ctx, delegateSet* set, bool isAction, const prog::sym::TypeSet& types)
-      -> prog::sym::TypeId;
-
-  static auto getDelegate(
-      Context* ctx,
-      delegateSet* set,
-      bool isAction,
-      const prog::sym::TypeSet& input,
-      prog::sym::TypeId output) -> prog::sym::TypeId;
+  // For each delegate we keep both a function and an action version.
+  std::unordered_map<signature, std::pair<prog::sym::TypeId, prog::sym::TypeId>, Hasher>
+      m_delegates;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -54,8 +54,7 @@ auto TypeInferExpr::visit(const parse::AnonFuncExprNode& n) -> void {
                : TypeInferExpr::Flags::Aggressive);
 
   if (retType.isConcrete()) {
-    m_type = isAction ? m_ctx->getDelegates()->getAction(m_ctx, *funcInput, retType)
-                      : m_ctx->getDelegates()->getFunction(m_ctx, *funcInput, retType);
+    m_type = m_ctx->getDelegates()->getDelegate(m_ctx, isAction, *funcInput, retType);
   }
 }
 

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -268,10 +268,10 @@ auto instType(
   }
 
   if (typeName == "function") {
-    return ctx->getDelegates()->getFunction(ctx, *typeSet);
+    return ctx->getDelegates()->getDelegate(ctx, false, *typeSet);
   }
   if (typeName == "action") {
-    return ctx->getDelegates()->getAction(ctx, *typeSet);
+    return ctx->getDelegates()->getDelegate(ctx, true, *typeSet);
   }
   if (typeName == "future" && typeSet->getCount() == 1) {
     return ctx->getFutures()->getFuture(ctx, *typeSet->begin());
@@ -343,9 +343,8 @@ auto getDelegate(Context* ctx, prog::sym::FuncId func) -> prog::sym::TypeId {
   if (funcDecl.getOutput().isInfer()) {
     return prog::sym::TypeId::inferType();
   }
-  return funcDecl.isAction()
-      ? ctx->getDelegates()->getAction(ctx, funcDecl.getInput(), funcDecl.getOutput())
-      : ctx->getDelegates()->getFunction(ctx, funcDecl.getInput(), funcDecl.getOutput());
+  return ctx->getDelegates()->getDelegate(
+      ctx, funcDecl.isAction(), funcDecl.getInput(), funcDecl.getOutput());
 }
 
 auto getLitFunc(Context* ctx, prog::sym::FuncId func) -> prog::expr::NodePtr {
@@ -379,9 +378,8 @@ auto getFuncClosure(
   }
 
   auto delegateInputTypes = prog::sym::TypeSet{std::move(delegateInput)};
-  const auto delegateType = funcDecl.isAction()
-      ? ctx->getDelegates()->getAction(ctx, delegateInputTypes, funcDecl.getOutput())
-      : ctx->getDelegates()->getFunction(ctx, delegateInputTypes, funcDecl.getOutput());
+  const auto delegateType = ctx->getDelegates()->getDelegate(
+      ctx, funcDecl.isAction(), delegateInputTypes, funcDecl.getOutput());
 
   return prog::expr::closureNode(*ctx->getProg(), delegateType, func, std::move(boundArgs));
 }

--- a/src/prog/sym/func_decl_table.cpp
+++ b/src/prog/sym/func_decl_table.cpp
@@ -1,5 +1,6 @@
 #include "prog/sym/func_decl_table.hpp"
 #include "internal/overload.hpp"
+#include "prog/program.hpp"
 #include <cassert>
 #include <stdexcept>
 
@@ -55,8 +56,10 @@ auto FuncDeclTable::lookup(
 }
 
 auto FuncDeclTable::registerImplicitConv(
-    const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId {
-  return registerFunc(prog, kind, false, true, std::move(name), std::move(input), output);
+    const Program& prog, FuncKind kind, TypeId input, TypeId output) -> FuncId {
+
+  auto name = prog.getTypeDecl(output).getName();
+  return registerFunc(prog, kind, false, true, std::move(name), TypeSet{input}, output);
 }
 
 auto FuncDeclTable::registerFunc(


### PR DESCRIPTION
Add an implicit conversion from `function` (pure) to `action` (impure) delegate types. 

```c
import "std/print.nov"

fun ret42()
  42

act sumActions(action{int} x, action{int} y)
  x() + y()

print(sumActions(ret42, ret42))
```