### PR TITLE
Pure lambdas by default

### DIFF
--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -11,7 +11,7 @@ enum class Keyword {
   Act,
   Self,
   Lambda,
-  Pure,
+  Impure,
   Fork,
   Struct,
   Union,

--- a/include/parse/node_expr_anon_func.hpp
+++ b/include/parse/node_expr_anon_func.hpp
@@ -21,7 +21,7 @@ public:
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
-  [[nodiscard]] auto isPure() const -> bool;
+  [[nodiscard]] auto isImpure() const -> bool;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
 
   auto accept(NodeVisitor* visitor) const -> void override;

--- a/novstd/either.nov
+++ b/novstd/either.nov
@@ -35,23 +35,23 @@ assert(Either{int, string}(42).string() == "42")
 assert(Either{int, string}("hello world").string() == "hello world")
 
 assert(
-  Either{int, string}("hello").map(pure lambda (string str) str == "hello") == true &&
-  Either{int, string}("hello").map(pure lambda (string str) str + " world") == "hello world" &&
-  Either{int, string}(42).map(pure lambda (string str) str == "hello") == 42)
+  Either{int, string}("hello").map(lambda (string str) str == "hello") == true &&
+  Either{int, string}("hello").map(lambda (string str) str + " world") == "hello world" &&
+  Either{int, string}(42).map(lambda (string str) str == "hello") == 42)
 
 assert(
-  Either{int, string}("hello").map(pure lambda (int i) i * i) == "hello" &&
-  Either{int, string}(42).map(pure lambda (int i) i == 42) == true &&
-  Either{int, string}(42).map(pure lambda (int i) i * i) == 42 * 42)
+  Either{int, string}("hello").map(lambda (int i) i * i) == "hello" &&
+  Either{int, string}(42).map(lambda (int i) i == 42) == true &&
+  Either{int, string}(42).map(lambda (int i) i * i) == 42 * 42)
 
 assert(
-  func = (pure lambda (int i) i == 42 ? Either{int, bool}(true) : Either{int, bool}(i));
+  func = (lambda (int i) i == 42 ? Either{int, bool}(true) : Either{int, bool}(i));
   Either{int, bool}(42).map(func) == true &&
   Either{int, bool}(41).map(func) == 41 &&
   Either{int, bool}(false).map(func) == false)
 
 assert(
-  func = (pure lambda (int i) i == 42 ? Either{bool, int}(true) : Either{bool, int}(i));
+  func = (lambda (int i) i == 42 ? Either{bool, int}(true) : Either{bool, int}(i));
   Either{bool, int}(42).map(func) == true &&
   Either{bool, int}(41).map(func) == 41 &&
   Either{bool, int}(false).map(func) == false)

--- a/novstd/env.nov
+++ b/novstd/env.nov
@@ -55,7 +55,7 @@ act getEnvOpt(string name)
 
 act getEnvArgs()
   (
-    lambda (int idx, List{string} result)
+    impure lambda (int idx, List{string} result)
       if idx < 0  -> result
       else        -> self(--idx, getEnvArg(idx) :: result)
   )(--getEnvArgCount(), List{string}())

--- a/novstd/func.nov
+++ b/novstd/func.nov
@@ -128,78 +128,78 @@ assert(
   eq42(42) && !eq42(43))
 
 assert(
-  funcRet = (pure lambda (int x) x);
+  funcRet = (lambda (int x) x);
   ret42 = funcRet[42];
   ret42() == funcRet(42))
 
 assert(
-  funcPlus = (pure lambda (int a, int b) a + b);
+  funcPlus = (lambda (int a, int b) a + b);
   plus42 = funcPlus[42];
   plus42(1337) == funcPlus(1337, 42))
 
 assert(
-  funcSum = (pure lambda (int a, int b, int c) a + b + c);
+  funcSum = (lambda (int a, int b, int c) a + b + c);
   sumPlus42 = funcSum[42];
   sumPlus42(1, 2) == funcSum(1, 2, 42))
 
 assert(
-  funcSum = (pure lambda (int a, int b, int c, int d) a + b + c + d);
+  funcSum = (lambda (int a, int b, int c, int d) a + b + c + d);
   sumPlus42 = funcSum[42];
   sumPlus42(1, 2, 3) == funcSum(1, 2, 3, 42))
 
 assert(
-  funcTrue = (pure lambda () true);
-  funcFalse = (pure lambda () false);
+  funcTrue = (lambda () true);
+  funcFalse = (lambda () false);
   (funcTrue & funcTrue)() && !(funcTrue & funcFalse)())
 
 assert(
-  isEven = (pure lambda (int x) x % 2 == 0);
-  isPos = (pure lambda (int x) x > 0);
+  isEven = (lambda (int x) x % 2 == 0);
+  isPos = (lambda (int x) x > 0);
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2) && !isEvenAndPos(3) && !isEvenAndPos(-2))
 
 assert(
-  isEven = (pure lambda (int x, int y) x % 2 == 0 && y % 2 == 0);
-  isPos = (pure lambda (int x, int y) x > 0 && y > 0);
+  isEven = (lambda (int x, int y) x % 2 == 0 && y % 2 == 0);
+  isPos = (lambda (int x, int y) x > 0 && y > 0);
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2, 4) && !isEvenAndPos(2, 3) && !isEvenAndPos(2, -2))
 
 assert(
-  isEven = (pure lambda (int x, int y, int z) x % 2 == 0 && y % 2 == 0 && z % 2 == 0);
-  isPos = (pure lambda (int x, int y, int z) x > 0 && y > 0 && z > 0);
+  isEven = (lambda (int x, int y, int z) x % 2 == 0 && y % 2 == 0 && z % 2 == 0);
+  isPos = (lambda (int x, int y, int z) x > 0 && y > 0 && z > 0);
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2, 2, 4) && !isEvenAndPos(2, 2, 3) && !isEvenAndPos(2, 2, -2))
 
 assert(
   isEven = (
-    pure lambda (int x, int y, int z, int w)
+    lambda (int x, int y, int z, int w)
       x % 2 == 0 && y % 2 == 0 && z % 2 == 0 && w % 2 == 0
   );
   isPos = (
-    pure lambda (int x, int y, int z, int w)
+    lambda (int x, int y, int z, int w)
       x > 0 && y > 0 && z > 0 && w > 0
   );
   isEvenAndPos = isEven & isPos;
   isEvenAndPos(2, 2, 2, 4) && !isEvenAndPos(2, 2, 2, 3) && !isEvenAndPos(2, 2, 2, -2))
 
 assert(
-  funcTrue = (pure lambda () true);
-  funcFalse = (pure lambda () false);
+  funcTrue = (lambda () true);
+  funcFalse = (lambda () false);
   (funcTrue | funcFalse)() && (funcFalse | funcTrue)() && !(funcFalse | funcFalse)())
 
 assert(
-  isEven = (pure lambda (int x) x % 2 == 0);
-  isPos = (pure lambda (int x) x > 0);
+  isEven = (lambda (int x) x % 2 == 0);
+  isPos = (lambda (int x) x > 0);
   isEvenOrPos = isEven | isPos;
   isEvenOrPos(2) && isEvenOrPos(1) && isEvenOrPos(-2) && !isEvenOrPos(-1))
 
 assert(
   isEven = (
-    pure lambda (int x, int y)
+    lambda (int x, int y)
       x % 2 == 0 && y % 2 == 0
   );
   isPos = (
-    pure lambda (int x, int y)
+    lambda (int x, int y)
       x > 0 && y > 0
   );
   isEvenOrPos = isEven | isPos;
@@ -207,11 +207,11 @@ assert(
 
 assert(
   isEven = (
-    pure lambda (int x, int y, int z)
+    lambda (int x, int y, int z)
       x % 2 == 0 && y % 2 == 0 && z % 2 == 0
   );
   isPos = (
-    pure lambda (int x, int y, int z)
+    lambda (int x, int y, int z)
       x > 0 && y > 0 && z > 0
   );
   isEvenOrPos = isEven | isPos;
@@ -219,34 +219,34 @@ assert(
 
 assert(
   isEven = (
-    pure lambda (int x, int y, int z, int w)
+    lambda (int x, int y, int z, int w)
       x % 2 == 0 && y % 2 == 0 && z % 2 == 0 && w % 2 == 0
   );
   isPos = (
-    pure lambda (int x, int y, int z, int w)
+    lambda (int x, int y, int z, int w)
       x > 0 && y > 0 && z > 0 && w > 0
   );
   isEvenOrPos = isEven | isPos;
   isEvenOrPos(2, 2, 2, 1) && isEvenOrPos(-2, -2, -2, 2) && !isEvenOrPos(-1, -1, -1, -2))
 
 assert(
-  funcFalse = (pure lambda () false);
+  funcFalse = (lambda () false);
   funcTrue = !funcFalse;
   funcTrue())
 
 assert(
-  is42 = (pure lambda (int x) x == 42);
+  is42 = (lambda (int x) x == 42);
   isNot42 = !is42;
   isNot42(1337) && !isNot42(42))
 
 assert(
-  eq = (pure lambda (int x, int y) x == y);
+  eq = (lambda (int x, int y) x == y);
   notEq = !eq;
   notEq(42, 1337) && !notEq(42, 42))
 
 assert(
   eq = (
-    pure lambda (int x, int y, int z)
+    lambda (int x, int y, int z)
       x == y && y == z
   );
   notEq = !eq;
@@ -254,7 +254,7 @@ assert(
 
 assert(
   eq = (
-    pure lambda (int x, int y, int z, int w)
+    lambda (int x, int y, int z, int w)
       x == y && y == z && z == w
   );
   notEq = !eq;

--- a/novstd/list.nov
+++ b/novstd/list.nov
@@ -242,10 +242,10 @@ assert(
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: List{int}();
-  l.pop(pure lambda (int i) i == 0) == l &&
-  l.pop(pure lambda (int i) i > 0) == List{int}() &&
-  l.pop(pure lambda (int i) i == 1) == 2 :: 3 :: 4 :: List{int}() &&
-  l.pop(pure lambda (int i) i < 3) == 3 :: 4 :: List{int}())
+  l.pop(lambda (int i) i == 0) == l &&
+  l.pop(lambda (int i) i > 0) == List{int}() &&
+  l.pop(lambda (int i) i == 1) == 2 :: 3 :: 4 :: List{int}() &&
+  l.pop(lambda (int i) i < 3) == 3 :: 4 :: List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
@@ -258,9 +258,9 @@ assert(
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.take(pure lambda (int i) i == 0) == List{int}() &&
-  l.take(pure lambda (int i) i > 0) == l &&
-  l.take(pure lambda (int i) i < 3) == 1 :: 2 :: List{int}())
+  l.take(lambda (int i) i == 0) == List{int}() &&
+  l.take(lambda (int i) i > 0) == l &&
+  l.take(lambda (int i) i < 3) == 1 :: 2 :: List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: List{int}();
@@ -295,23 +295,23 @@ assert(rangeList('a', 'c') == 'a' :: 'b' :: 'c' :: List{char}())
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: List{int}();
-  l.filter(pure lambda (int v) v > 2) == 3 :: 4 :: List{int}() &&
-  l.filter(pure lambda (int v) v < 0) == List{int}())
+  l.filter(lambda (int v) v > 2) == 3 :: 4 :: List{int}() &&
+  l.filter(lambda (int v) v < 0) == List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: 4 :: 5 :: List{int}();
-  l.filterReverse(pure lambda (int v) v > 2) == 5 :: 4 :: 3 :: List{int}() &&
-  l.filterReverse(pure lambda (int v) v < 0) == List{int}())
+  l.filterReverse(lambda (int v) v > 2) == 5 :: 4 :: 3 :: List{int}() &&
+  l.filterReverse(lambda (int v) v < 0) == List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.map(pure lambda (int v) v * 2) == 2 :: 4 :: 6 :: List{int}() &&
-  l.map(pure lambda (int v) v.string()) == "1" :: "2" :: "3" :: List{string}())
+  l.map(lambda (int v) v * 2) == 2 :: 4 :: 6 :: List{int}() &&
+  l.map(lambda (int v) v.string()) == "1" :: "2" :: "3" :: List{string}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.mapReverse(pure lambda (int v) v * 2) == 6 :: 4 :: 2 :: List{int}() &&
-  l.mapReverse(pure lambda (int v) v.string()) == "3" :: "2" :: "1" :: List{string}())
+  l.mapReverse(lambda (int v) v * 2) == 6 :: 4 :: 2 :: List{int}() &&
+  l.mapReverse(lambda (int v) v.string()) == "3" :: "2" :: "1" :: List{string}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
@@ -341,18 +341,18 @@ assert(List{int}().sort() == List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.count(pure lambda (int v) v > 2) == 1 &&
-  l.count(pure lambda (int v) v == 0) == 0 &&
-  l.count(pure lambda (int v) v > 0) == 3)
+  l.count(lambda (int v) v > 2) == 1 &&
+  l.count(lambda (int v) v == 0) == 0 &&
+  l.count(lambda (int v) v > 0) == 3)
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.any(pure lambda (int v) v > 2) && !l.any(pure lambda (int v) v < 0))
+  l.any(lambda (int v) v > 2) && !l.any(lambda (int v) v < 0))
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.all(pure lambda (int v) v > 0) && !l.all(pure lambda (int v) v > 1))
+  l.all(lambda (int v) v > 0) && !l.all(lambda (int v) v > 1))
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
-  l.none(pure lambda (int v) v < 0) && !l.none(pure lambda (int v) v > 1))
+  l.none(lambda (int v) v < 0) && !l.none(lambda (int v) v > 1))

--- a/novstd/option.nov
+++ b/novstd/option.nov
@@ -40,17 +40,17 @@ assert(Option{int}() == Option{int}())
 assert(Option{int}() ?? 42 == 42)
 assert(Option(1337) ?? 42 == 1337)
 
-assert(Option{int}() ?? (pure lambda () 42) == 42)
-assert(Option(1337) ?? (pure lambda () 42) == 1337)
+assert(Option{int}() ?? (lambda () 42) == 42)
+assert(Option(1337) ?? (lambda () 42) == 1337)
 
 assert(Option(42).string() == "42")
 assert(Option{int}().string() == "none")
 
-assert(Option(42).map(pure lambda (int val) val * 2) == 84)
-assert(Option{int}().map(pure lambda (int val) val * 2) is None)
+assert(Option(42).map(lambda (int val) val * 2) == 84)
+assert(Option{int}().map(lambda (int val) val * 2) is None)
 
 assert(
-  func = (pure lambda (int val) val > 0 ? Option(val) : None());
+  func = (lambda (int val) val > 0 ? Option(val) : None());
   Option(42).map(func) == 42 &&
   Option(-42).map(func) is None &&
   Option{int}().map(func) is None)

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -176,7 +176,7 @@ assert(
 
 assert(
   "hello world".indexOf(equals{char}[' ']) == 5 &&
-  "hello world".indexOf(pure lambda (char c) c == 'd') == 10 &&
+  "hello world".indexOf(lambda (char c) c == 'd') == 10 &&
   "hello world".indexOf(equals{char}['h']) == 0 &&
   "hello world".indexOf(equals{char}['1']) == -1 &&
   "".indexOf(equals{char}[' ']) == -1)
@@ -234,8 +234,8 @@ assert(
   "helloworld".insert(5, "_") == "hello_world")
 
 assert(
-  "hello".transform(pure lambda (char c) 'W') == "WWWWW" &&
-  "".transform(pure lambda (char c) 'W') == "")
+  "hello".transform(lambda (char c) 'W') == "WWWWW" &&
+  "".transform(lambda (char c) 'W') == "")
 
 assert(
   "hello world".split(equals{char}[' ']) == "hello" :: "world" :: List{string}() &&

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -64,8 +64,8 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
     inputTypes.push_back(consts[constId].getType());
   }
 
-  // Lambda's inside actions are themselves actions too unless marked as pure.
-  auto isAction = hasFlag<Flags::AllowActionCalls>() && !n.isPure();
+  // Impure lambda's produce actions and are allowed to call other actions.
+  auto isAction = n.isImpure();
 
   // Infer the return type of the anonymous function.
   auto parentConstTypes = m_constBinder->getAllConstTypes();

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -41,8 +41,8 @@ auto TypeInferExpr::visit(const parse::AnonFuncExprNode& n) -> void {
     return;
   }
 
-  // Lambda's inside actions are themselves actions too unless marked as pure.
-  auto isAction = hasFlag<Flags::AllowActionCalls>() && !n.isPure();
+  // Impure lambda's produce actions and are allowed to call other actions.
+  auto isAction = n.isImpure();
 
   const auto retType = inferRetType(
       m_ctx,

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -20,8 +20,8 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::Lambda:
     out << "lambda";
     break;
-  case Keyword::Pure:
-    out << "pure";
+  case Keyword::Impure:
+    out << "impure";
     break;
   case Keyword::Fork:
     out << "fork";
@@ -58,7 +58,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
       {"act", Keyword::Act},
       {"self", Keyword::Self},
       {"lambda", Keyword::Lambda},
-      {"pure", Keyword::Pure},
+      {"impure", Keyword::Impure},
       {"fork", Keyword::Fork},
       {"struct", Keyword::Struct},
       {"union", Keyword::Union},

--- a/src/parse/node_expr_anon_func.cpp
+++ b/src/parse/node_expr_anon_func.cpp
@@ -36,9 +36,9 @@ auto AnonFuncExprNode::getSpan() const -> input::Span {
   return input::Span::combine(m_kw.getSpan(), m_body->getSpan());
 }
 
-auto AnonFuncExprNode::isPure() const -> bool {
+auto AnonFuncExprNode::isImpure() const -> bool {
   return std::any_of(m_modifiers.begin(), m_modifiers.end(), [](const lex::Token& t) {
-    return getKw(t) == lex::Keyword::Pure;
+    return getKw(t) == lex::Keyword::Impure;
   });
 }
 

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -310,7 +310,7 @@ auto ParserImpl::nextExprPrimary() -> NodePtr {
     switch (*getKw(nextTok)) {
     case lex::Keyword::If:
       return nextExprSwitch();
-    case lex::Keyword::Pure: {
+    case lex::Keyword::Impure: {
       auto modifiers = std::vector<lex::Token>{consumeToken()};
       return nextExprAnonFunc(std::move(modifiers));
     }

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Analyzing anonymous functions", "[frontend]") {
 
   SECTION("Return anonymous action") {
     const auto& output = ANALYZE("act f() -> action{int} "
-                                 "  lambda () 42");
+                                 "  impure lambda () 42");
     REQUIRE(output.isSuccess());
 
     CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 42));
@@ -37,7 +37,7 @@ TEST_CASE("Analyzing anonymous functions", "[frontend]") {
 
   SECTION("Return anonymous function from action") {
     const auto& output = ANALYZE("act f() -> function{int} "
-                                 "  pure lambda () 42");
+                                 "  lambda () 42");
     REQUIRE(output.isSuccess());
 
     CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 42));
@@ -64,7 +64,7 @@ TEST_CASE("Analyzing anonymous functions", "[frontend]") {
 
   SECTION("Invoke anonymous action") {
     const auto& output = ANALYZE("act f() -> int "
-                                 "  (lambda () 1)()");
+                                 "  (impure lambda () 1)()");
     REQUIRE(output.isSuccess());
 
     CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 1));
@@ -79,7 +79,7 @@ TEST_CASE("Analyzing anonymous functions", "[frontend]") {
 
   SECTION("Invoke anonymous function from action") {
     const auto& output = ANALYZE("act f() -> int "
-                                 "  (pure lambda () 1)()");
+                                 "  (lambda () 1)()");
     REQUIRE(output.isSuccess());
 
     CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 1));
@@ -238,8 +238,8 @@ TEST_CASE("Analyzing anonymous functions", "[frontend]") {
         errUninitializedConst(src, "i", input::Span{35, 35}));
     CHECK_DIAG(
         "act a1() -> int 42 "
-        "act a2() pure lambda () a1()",
-        errUndeclaredPureFunc(src, "a1", {}, input::Span{43, 46}));
+        "act a2() lambda () a1()",
+        errUndeclaredPureFunc(src, "a1", {}, input::Span{38, 41}));
   }
 }
 

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -337,7 +337,7 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
   }
 
   SECTION("Anonymous action") {
-    const auto& output = ANALYZE("act a() lambda (int i) i == i");
+    const auto& output = ANALYZE("act a() impure lambda (int i) i == i");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "a").getOutput() == GET_TYPE_ID(output, "__action_int_bool"));
   }

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Lexing keywords", "[lex]") {
   CHECK_TOKENS("act", keywordToken(Keyword::Act));
   CHECK_TOKENS("self", keywordToken(Keyword::Self));
   CHECK_TOKENS("lambda", keywordToken(Keyword::Lambda));
-  CHECK_TOKENS("pure", keywordToken(Keyword::Pure));
+  CHECK_TOKENS("impure", keywordToken(Keyword::Impure));
   CHECK_TOKENS("fork", keywordToken(Keyword::Fork));
   CHECK_TOKENS("struct", keywordToken(Keyword::Struct));
   CHECK_TOKENS("union", keywordToken(Keyword::Union));

--- a/tests/parse/expr_anon_func_test.cpp
+++ b/tests/parse/expr_anon_func_test.cpp
@@ -11,8 +11,8 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
       "lambda () 1",
       anonFuncExprNode({}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), INT(1)));
   CHECK_EXPR(
-      "pure lambda () 1",
-      anonFuncExprNode({PURE}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), INT(1)));
+      "impure lambda () 1",
+      anonFuncExprNode({IMPURE}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), INT(1)));
   CHECK_EXPR(
       "lambda (int x) 1",
       anonFuncExprNode(
@@ -103,22 +103,25 @@ TEST_CASE("Parsing anonymous functions", "[parse]") {
                 END),
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
-        "pure function () 1",
+        "impure function () 1",
         errInvalidAnonFuncExpr(
-            {PURE},
+            {IMPURE},
             ID("function"),
             ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
             INT(1)));
     CHECK_EXPR(
-        "pure action () 1",
+        "impure action () 1",
         errInvalidAnonFuncExpr(
-            {PURE}, ID("action"), ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN), INT(1)));
+            {IMPURE},
+            ID("action"),
+            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            INT(1)));
   }
 
   SECTION("Spans") {
     CHECK_EXPR_SPAN(" lambda () 1 + 2", input::Span(1, 15));
     CHECK_EXPR_SPAN("lambda (int i) i", input::Span(0, 15));
-    CHECK_EXPR_SPAN("pure lambda (int i) i", input::Span(0, 20));
+    CHECK_EXPR_SPAN("impure lambda (int i) i", input::Span(0, 22));
   }
 }
 

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -52,7 +52,7 @@ namespace parse {
 #define FUN lex::keywordToken(lex::Keyword::Fun)
 #define ACT lex::keywordToken(lex::Keyword::Act)
 #define LAMBDA lex::keywordToken(lex::Keyword::Lambda)
-#define PURE lex::keywordToken(lex::Keyword::Pure)
+#define IMPURE lex::keywordToken(lex::Keyword::Impure)
 #define FORK lex::keywordToken(lex::Keyword::Fork)
 #define STRUCT lex::keywordToken(lex::Keyword::Struct)
 #define UNION lex::keywordToken(lex::Keyword::Union)


### PR DESCRIPTION
Lambda's created in actions are now pure by default (so returning `function`) and can be made impure (`action`) with the keyword `impure`. Reason is that it promotes using pure functions and it makes lambda's work consistently in both functions and actions.

One side-effect is that you can now make impure lambdas in functions, its kind of nonsensical as  you are not able to invoke the action from a function but it doesn't make the function itself less pure.

```c
import "std/print.nov"

act main()
  greet = (
    impure lambda (string name)
      print("hello " + name)
  );
  print("Enter your name");
  greet(conReadLine());
  sleep(1000);
  main()

main()
```