### PR TITLE
Optional return type specifier on lambda's 

### DIFF
--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -18,12 +18,15 @@ namespace parse {
     lex::Token id,
     std::optional<TypeSubstitutionList> typeSubs,
     const ArgumentListDecl& argList,
-    std::optional<FuncDeclStmtNode::RetTypeSpec> retType,
+    std::optional<RetTypeSpec> retType,
     NodePtr body) -> NodePtr;
 
 [[nodiscard]] auto errInvalidAnonFuncExpr(
-    std::vector<lex::Token> modifiers, lex::Token kw, const ArgumentListDecl& argList, NodePtr body)
-    -> NodePtr;
+    std::vector<lex::Token> modifiers,
+    lex::Token kw,
+    const ArgumentListDecl& argList,
+    std::optional<RetTypeSpec> retType,
+    NodePtr body) -> NodePtr;
 
 [[nodiscard]] auto errInvalidStmtStructDecl(
     lex::Token kw,

--- a/include/parse/node_expr_anon_func.hpp
+++ b/include/parse/node_expr_anon_func.hpp
@@ -2,6 +2,7 @@
 #include "lex/token.hpp"
 #include "parse/argument_list_decl.hpp"
 #include "parse/node.hpp"
+#include "parse/ret_type_spec.hpp"
 #include <vector>
 
 namespace parse {
@@ -9,8 +10,11 @@ namespace parse {
 class AnonFuncExprNode final : public Node {
 public:
   friend auto anonFuncExprNode(
-      std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body)
-      -> NodePtr;
+      std::vector<lex::Token> modifiers,
+      lex::Token kw,
+      ArgumentListDecl argList,
+      std::optional<RetTypeSpec> retType,
+      NodePtr body) -> NodePtr;
 
   AnonFuncExprNode() = delete;
 
@@ -23,6 +27,7 @@ public:
 
   [[nodiscard]] auto isImpure() const -> bool;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
+  [[nodiscard]] auto getRetType() const -> const std::optional<RetTypeSpec>&;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 
@@ -30,17 +35,25 @@ private:
   const std::vector<lex::Token> m_modifiers;
   const lex::Token m_kw;
   const ArgumentListDecl m_argList;
+  const std::optional<RetTypeSpec> m_retType;
   const NodePtr m_body;
 
   AnonFuncExprNode(
-      std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body);
+      std::vector<lex::Token> modifiers,
+      lex::Token kw,
+      ArgumentListDecl argList,
+      std::optional<RetTypeSpec> retType,
+      NodePtr body);
 
   auto print(std::ostream& out) const -> std::ostream& override;
 };
 
 // Factories.
 auto anonFuncExprNode(
-    std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body)
-    -> NodePtr;
+    std::vector<lex::Token> modifiers,
+    lex::Token kw,
+    ArgumentListDecl argList,
+    std::optional<RetTypeSpec> retTypeSpec,
+    NodePtr body) -> NodePtr;
 
 } // namespace parse

--- a/include/parse/node_stmt_func_decl.hpp
+++ b/include/parse/node_stmt_func_decl.hpp
@@ -2,6 +2,7 @@
 #include "lex/token.hpp"
 #include "parse/argument_list_decl.hpp"
 #include "parse/node.hpp"
+#include "parse/ret_type_spec.hpp"
 #include "parse/type_substitution_list.hpp"
 #include <utility>
 
@@ -9,20 +10,6 @@ namespace parse {
 
 class FuncDeclStmtNode final : public Node {
 public:
-  class RetTypeSpec final {
-  public:
-    RetTypeSpec(lex::Token arrow, Type type);
-
-    auto operator==(const RetTypeSpec& rhs) const noexcept -> bool;
-
-    [[nodiscard]] auto getArrow() const noexcept -> const lex::Token&;
-    [[nodiscard]] auto getType() const noexcept -> const Type&;
-
-  private:
-    lex::Token m_arrow;
-    Type m_type;
-  };
-
   friend auto funcDeclStmtNode(
       lex::Token kw,
       lex::Token id,
@@ -73,7 +60,7 @@ auto funcDeclStmtNode(
     lex::Token id,
     std::optional<TypeSubstitutionList> typeSubs,
     ArgumentListDecl argList,
-    std::optional<FuncDeclStmtNode::RetTypeSpec> retTypeSpec,
+    std::optional<RetTypeSpec> retTypeSpec,
     NodePtr body) -> NodePtr;
 
 } // namespace parse

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -3,6 +3,7 @@
 #include "parse/argument_list_decl.hpp"
 #include "parse/node.hpp"
 #include "parse/node_itr.hpp"
+#include "parse/ret_type_spec.hpp"
 #include "parse/type.hpp"
 #include "parse/type_substitution_list.hpp"
 #include <deque>
@@ -51,6 +52,7 @@ private:
   auto nextTypeParamList() -> TypeParamList;
   auto nextTypeSubstitutionList() -> TypeSubstitutionList;
   auto nextArgDeclList() -> ArgumentListDecl;
+  auto nextRetTypeSpec() -> RetTypeSpec;
 
   auto consumeToken() -> lex::Token;
   auto peekToken(size_t ahead) -> lex::Token&;

--- a/include/parse/ret_type_spec.hpp
+++ b/include/parse/ret_type_spec.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "lex/token.hpp"
+#include "parse/type.hpp"
+
+namespace parse {
+
+class RetTypeSpec final {
+public:
+  RetTypeSpec(lex::Token arrow, Type type);
+
+  auto operator==(const RetTypeSpec& rhs) const noexcept -> bool;
+  auto operator!=(const RetTypeSpec& rhs) const noexcept -> bool;
+
+  [[nodiscard]] auto getArrow() const noexcept -> const lex::Token&;
+  [[nodiscard]] auto getType() const noexcept -> const Type&;
+
+  [[nodiscard]] auto validate() const -> bool;
+
+private:
+  lex::Token m_arrow;
+  Type m_type;
+};
+
+auto operator<<(std::ostream& out, const RetTypeSpec& rhs) -> std::ostream&;
+
+} // namespace parse

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(parse STATIC
   parse/node.cpp
   parse/op_precedence.cpp
   parse/parser.cpp
+  parse/ret_type_spec.cpp
   parse/type_param_list.cpp
   parse/type_substitution_list.cpp
   parse/type.cpp

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -236,7 +236,8 @@ auto errConstNameConflictsWithTypeSubstitution(
 
 auto errUnableToInferLambdaReturnType(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Unable to infer return-type of lambda";
+  oss << "Unable to infer return-type of lambda, please specify return-type using the '-> [TYPE]' "
+         "syntax";
   return error(src, oss.str(), span);
 }
 

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -70,7 +70,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   }
 
   // Get return type.
-  auto retType = getRetType(m_ctx, nullptr, n);
+  auto retType = getRetType(m_ctx, nullptr, n.getRetType());
   if (!retType) {
     return;
   }

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -65,7 +65,7 @@ auto FuncTemplate::getRetType(const prog::sym::TypeSet& typeParams)
   if (!funcInput) {
     return std::nullopt;
   }
-  auto retType = ::frontend::internal::getRetType(m_ctx, &subTable, *m_parseNode);
+  auto retType = ::frontend::internal::getRetType(m_ctx, &subTable, m_parseNode->getRetType());
   if (!retType) {
     m_inferStack.pop_front();
     return std::nullopt;
@@ -137,7 +137,8 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
     return;
   }
 
-  instance->m_retType = ::frontend::internal::getRetType(m_ctx, &subTable, *m_parseNode);
+  instance->m_retType =
+      ::frontend::internal::getRetType(m_ctx, &subTable, m_parseNode->getRetType());
   if (!instance->m_retType) {
     assert(m_ctx->hasErrors());
 

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -44,17 +44,20 @@ auto TypeInferExpr::visit(const parse::AnonFuncExprNode& n) -> void {
   // Impure lambda's produce actions and are allowed to call other actions.
   auto isAction = n.isImpure();
 
-  const auto retType = inferRetType(
-      m_ctx,
-      m_typeSubTable,
-      n,
-      *funcInput,
-      m_constTypes,
-      isAction ? (TypeInferExpr::Flags::AllowActionCalls | TypeInferExpr::Flags::Aggressive)
-               : TypeInferExpr::Flags::Aggressive);
+  auto retType = getRetType(m_ctx, m_typeSubTable, n.getRetType());
+  if (retType && retType->isInfer()) {
+    retType = inferRetType(
+        m_ctx,
+        m_typeSubTable,
+        n,
+        *funcInput,
+        m_constTypes,
+        isAction ? (TypeInferExpr::Flags::AllowActionCalls | TypeInferExpr::Flags::Aggressive)
+                 : TypeInferExpr::Flags::Aggressive);
+  }
 
-  if (retType.isConcrete()) {
-    m_type = m_ctx->getDelegates()->getDelegate(m_ctx, isAction, *funcInput, retType);
+  if (retType && retType->isConcrete()) {
+    m_type = m_ctx->getDelegates()->getDelegate(m_ctx, isAction, *funcInput, *retType);
   }
 }
 

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -289,14 +289,14 @@ auto instType(
 }
 
 auto getRetType(
-    Context* ctx, const TypeSubstitutionTable* subTable, const parse::FuncDeclStmtNode& n)
-    -> std::optional<prog::sym::TypeId> {
+    Context* ctx,
+    const TypeSubstitutionTable* subTable,
+    const std::optional<parse::RetTypeSpec>& spec) -> std::optional<prog::sym::TypeId> {
 
-  const auto& retTypeSpec = n.getRetType();
-  if (!retTypeSpec) {
+  if (!spec) {
     return prog::sym::TypeId::inferType();
   }
-  const auto& retParseType = retTypeSpec->getType();
+  const auto& retParseType = spec->getType();
   auto retType             = getOrInstType(ctx, subTable, retParseType);
   if (!retType) {
     ctx->reportDiag(

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -43,9 +43,10 @@ getOrInstType(Context* ctx, const TypeSubstitutionTable* subTable, const parse::
     const lex::Token& nameToken,
     const parse::TypeParamList& typeParams) -> std::optional<prog::sym::TypeId>;
 
-[[nodiscard]] auto
-getRetType(Context* ctx, const TypeSubstitutionTable* subTable, const parse::FuncDeclStmtNode& n)
-    -> std::optional<prog::sym::TypeId>;
+[[nodiscard]] auto getRetType(
+    Context* ctx,
+    const TypeSubstitutionTable* subTable,
+    const std::optional<parse::RetTypeSpec>& spec) -> std::optional<prog::sym::TypeId>;
 
 template <typename FuncParseNode>
 [[nodiscard]] auto inferRetType(

--- a/src/parse/node_expr_anon_func.cpp
+++ b/src/parse/node_expr_anon_func.cpp
@@ -4,16 +4,21 @@
 namespace parse {
 
 AnonFuncExprNode::AnonFuncExprNode(
-    std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body) :
+    std::vector<lex::Token> modifiers,
+    lex::Token kw,
+    ArgumentListDecl argList,
+    std::optional<RetTypeSpec> retType,
+    NodePtr body) :
     m_modifiers{std::move(modifiers)},
     m_kw{std::move(kw)},
     m_argList{std::move(argList)},
+    m_retType{std::move(retType)},
     m_body{std::move(body)} {}
 
 auto AnonFuncExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const AnonFuncExprNode*>(&rhs);
   return r != nullptr && m_modifiers == r->m_modifiers && m_argList == r->m_argList &&
-      *m_body == *r->m_body;
+      m_retType == r->m_retType && *m_body == *r->m_body;
 }
 
 auto AnonFuncExprNode::operator!=(const Node& rhs) const noexcept -> bool {
@@ -44,6 +49,8 @@ auto AnonFuncExprNode::isImpure() const -> bool {
 
 auto AnonFuncExprNode::getArgList() const -> const ArgumentListDecl& { return m_argList; }
 
+auto AnonFuncExprNode::getRetType() const -> const std::optional<RetTypeSpec>& { return m_retType; }
+
 auto AnonFuncExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
 auto AnonFuncExprNode::print(std::ostream& out) const -> std::ostream& {
@@ -53,19 +60,28 @@ auto AnonFuncExprNode::print(std::ostream& out) const -> std::ostream& {
       out << *modKw << '-';
     }
   }
-  return out << "anonfun-" << m_argList;
-  ;
+  out << "anonfun-" << m_argList;
+  if (m_retType) {
+    out << *m_retType;
+  }
+  return out;
 }
 
 // Factories.
 auto anonFuncExprNode(
-    std::vector<lex::Token> modifiers, lex::Token kw, ArgumentListDecl argList, NodePtr body)
-    -> NodePtr {
+    std::vector<lex::Token> modifiers,
+    lex::Token kw,
+    ArgumentListDecl argList,
+    std::optional<RetTypeSpec> retType,
+    NodePtr body) -> NodePtr {
   if (body == nullptr) {
     throw std::invalid_argument{"Body cannot be null"};
   }
-  return std::unique_ptr<AnonFuncExprNode>{new AnonFuncExprNode{
-      std::move(modifiers), std::move(kw), std::move(argList), std::move(body)}};
+  return std::unique_ptr<AnonFuncExprNode>{new AnonFuncExprNode{std::move(modifiers),
+                                                                std::move(kw),
+                                                                std::move(argList),
+                                                                std::move(retType),
+                                                                std::move(body)}};
 }
 
 } // namespace parse

--- a/src/parse/node_stmt_func_decl.cpp
+++ b/src/parse/node_stmt_func_decl.cpp
@@ -7,19 +7,6 @@ static auto getIdOrErr(const lex::Token& token) {
   return getId(token).value_or(std::string("err"));
 }
 
-FuncDeclStmtNode::RetTypeSpec::RetTypeSpec(lex::Token arrow, Type type) :
-    m_arrow{std::move(arrow)}, m_type{std::move(type)} {}
-
-auto FuncDeclStmtNode::RetTypeSpec::operator==(const RetTypeSpec& rhs) const noexcept -> bool {
-  return m_arrow == rhs.m_arrow && m_type == rhs.m_type;
-}
-
-auto FuncDeclStmtNode::RetTypeSpec::getArrow() const noexcept -> const lex::Token& {
-  return m_arrow;
-}
-
-auto FuncDeclStmtNode::RetTypeSpec::getType() const noexcept -> const Type& { return m_type; }
-
 FuncDeclStmtNode::FuncDeclStmtNode(
     lex::Token kw,
     lex::Token id,
@@ -82,11 +69,8 @@ auto FuncDeclStmtNode::print(std::ostream& out) const -> std::ostream& {
     out << *m_typeSubs;
   }
   out << m_argList;
-  out << "->";
   if (m_retType) {
-    out << m_retType->getType();
-  } else {
-    out << "infer";
+    out << *m_retType;
   }
   return out;
 }
@@ -97,7 +81,7 @@ auto funcDeclStmtNode(
     lex::Token id,
     std::optional<TypeSubstitutionList> typeSubs,
     ArgumentListDecl argList,
-    std::optional<FuncDeclStmtNode::RetTypeSpec> retType,
+    std::optional<RetTypeSpec> retType,
     NodePtr body) -> NodePtr {
 
   if (body == nullptr) {

--- a/src/parse/ret_type_spec.cpp
+++ b/src/parse/ret_type_spec.cpp
@@ -1,0 +1,28 @@
+#include "parse/ret_type_spec.hpp"
+
+namespace parse {
+
+RetTypeSpec::RetTypeSpec(lex::Token arrow, Type type) :
+    m_arrow{std::move(arrow)}, m_type{std::move(type)} {}
+
+auto RetTypeSpec::operator==(const RetTypeSpec& rhs) const noexcept -> bool {
+  return m_arrow == rhs.m_arrow && m_type == rhs.m_type;
+}
+
+auto RetTypeSpec::operator!=(const RetTypeSpec& rhs) const noexcept -> bool {
+  return !RetTypeSpec::operator==(rhs);
+}
+
+auto RetTypeSpec::getArrow() const noexcept -> const lex::Token& { return m_arrow; }
+
+auto RetTypeSpec::getType() const noexcept -> const Type& { return m_type; }
+
+auto RetTypeSpec::validate() const -> bool {
+  return m_arrow.getKind() == lex::TokenKind::SepArrow && m_type.validate();
+}
+
+auto operator<<(std::ostream& out, const RetTypeSpec& rhs) -> std::ostream& {
+  return out << "->" << rhs.getType();
+}
+
+} // namespace parse

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -298,6 +298,12 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__function_int_bool"));
   }
 
+  SECTION("Anonymous function with return type spec") {
+    const auto& output = ANALYZE("fun f() lambda (int i) -> float i");
+    REQUIRE(output.isSuccess());
+    CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__function_int_float"));
+  }
+
   SECTION("Anonymous function call") {
     const auto& output = ANALYZE("fun f() (lambda (int i) i == i)(42)");
     REQUIRE(output.isSuccess());

--- a/tests/parse/stmt_func_decl_test.cpp
+++ b/tests/parse/stmt_func_decl_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "fun a(int x) -> int 1",
@@ -37,7 +37,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             std::nullopt,
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "fun a(int x, int y) -> int 1",
@@ -51,7 +51,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
                  ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))},
                 COMMAS(1),
                 CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "fun a(int x, int y, bool z) -> int x * y",
@@ -66,7 +66,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
                  ArgumentListDecl::ArgSpec(TYPE("bool"), ID("z"))},
                 COMMAS(2),
                 CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             binaryExprNode(ID_EXPR("x"), STAR, ID_EXPR("y"))));
     CHECK_STMT(
         "fun a{T}() 1",
@@ -94,7 +94,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U"), ID("W")}, COMMAS(2), CCURLY},
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("T"), ID("x"))}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("T")},
+            RetTypeSpec{ARROW, TYPE("T")},
             ID_EXPR("x")));
     CHECK_STMT(
         "fun a() -> List{T{Y}} 1",
@@ -103,7 +103,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("List", TYPE("T", TYPE("Y")))},
+            RetTypeSpec{ARROW, TYPE("List", TYPE("T", TYPE("Y")))},
             INT(1)));
     CHECK_STMT(
         "fun a{T, U, W}(T x) -> T x",
@@ -113,7 +113,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U"), ID("W")}, COMMAS(2), CCURLY},
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("T"), ID("x"))}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("T")},
+            RetTypeSpec{ARROW, TYPE("T")},
             ID_EXPR("x")));
     CHECK_STMT(
         "fun a{T, U}(T{U} x) x",
@@ -148,7 +148,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             std::nullopt,
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "act a{T, U}(T{U} x) x",
@@ -173,7 +173,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             errInvalidPrimaryExpr(END)));
     CHECK_STMT(
         "fun",
@@ -201,7 +201,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             TypeSubstitutionList{OCURLY, {}, COMMAS(0), CCURLY},
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "fun a{T U}(int x) -> int 1",
@@ -211,7 +211,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(0), CCURLY},
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "fun _() 1",
@@ -262,7 +262,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
                  ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))},
                 COMMAS(0),
                 CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("x")},
+            RetTypeSpec{ARROW, TYPE("x")},
             errInvalidPrimaryExpr(END)));
     CHECK_STMT(
         "fun a(int x int y) -> int 1",
@@ -276,7 +276,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
                  ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))},
                 COMMAS(0),
                 CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "fun a(int x,) -> int 1",
@@ -286,7 +286,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             std::nullopt,
             ArgumentListDecl(
                 OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(1), CPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW, TYPE("int")},
+            RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
         "fun a(int x,,) -> int",
@@ -309,8 +309,7 @@ TEST_CASE("Parsing function declaration statements", "[parse]") {
             ID("a"),
             std::nullopt,
             ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
-            FuncDeclStmtNode::RetTypeSpec{ARROW,
-                                          Type(ID("T"), TypeParamList(OCURLY, {}, {}, CCURLY))},
+            RetTypeSpec{ARROW, Type(ID("T"), TypeParamList(OCURLY, {}, {}, CCURLY))},
             INT(1)));
     CHECK_STMT(
         "fun a{T, U}(T{} x) x",


### PR DESCRIPTION
Adds support for the `-> [TYPE]` syntax (the same as is used on function) on lambda's.

The need to use it should be rare but there are cases where it can be cleaner to tell the compiler what you want the return-type to be.

Example:
```c
import "std/print.nov"
import "std/ascii.nov"
import "std/option.nov"

act main()
  readDigit = (
    impure lambda () -> Option{int}
      c = conRead();
      c.isDigit() ? int(c) - '0' : None()
  );
  print("Enter a digit");
  d = readDigit();
  print(d as int i ? i.string() : "I said a digit...")

main()
```