### PR TITLE
Store positive longs on the stack directly

### DIFF
--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -179,6 +179,15 @@ auto execute(
   }
 #define PUSH_UINT(VAL) PUSH(uintValue(VAL))
 #define PUSH_INT(VAL) PUSH(intValue(VAL))
+#define PUSH_LONG(VAL)                                                                             \
+  {                                                                                                \
+    int64_t v = VAL;                                                                               \
+    if (v > 0) {                                                                                   \
+      PUSH(posLongValue(v));                                                                       \
+    } else {                                                                                       \
+      PUSH_REF(allocator->allocLong(v));                                                           \
+    }                                                                                              \
+  }
 #define PUSH_BOOL(VAL) PUSH(intValue(VAL))
 #define PUSH_FLOAT(VAL) PUSH(floatValue(VAL))
 #define PUSH_REF(VAL)                                                                              \
@@ -252,7 +261,7 @@ auto execute(
       PUSH_INT(1);
     } break;
     case OpCode::LoadLitLong: {
-      PUSH_REF(allocator->allocLong(READ_LONG()));
+      PUSH_LONG(READ_LONG());
     } break;
     case OpCode::LoadLitFloat: {
       PUSH_FLOAT(READ_FLOAT());
@@ -282,7 +291,7 @@ auto execute(
     } break;
     case OpCode::AddLong: {
       const auto val = getLong(POP()) + getLong(POP());
-      PUSH_REF(allocator->allocLong(val));
+      PUSH_LONG(val);
     } break;
     case OpCode::AddFloat: {
       PUSH_FLOAT(POP_FLOAT() + POP_FLOAT());
@@ -300,7 +309,7 @@ auto execute(
     case OpCode::SubLong: {
       auto b = getLong(POP());
       auto a = getLong(POP());
-      PUSH_REF(allocator->allocLong(a - b));
+      PUSH_LONG(a - b);
     } break;
     case OpCode::SubFloat: {
       auto b = POP_FLOAT();
@@ -315,7 +324,7 @@ auto execute(
     case OpCode::MulLong: {
       auto b = getLong(POP());
       auto a = getLong(POP());
-      PUSH_REF(allocator->allocLong(a * b));
+      PUSH_LONG(a * b);
     } break;
     case OpCode::MulFloat: {
       auto b = POP_FLOAT();
@@ -338,7 +347,7 @@ auto execute(
         execHandle.setState(ExecState::DivByZero);
         goto End;
       }
-      PUSH_REF(allocator->allocLong(a / b));
+      PUSH_LONG(a / b);
     } break;
     case OpCode::DivFloat: {
       auto b = POP_FLOAT();
@@ -361,7 +370,7 @@ auto execute(
         execHandle.setState(ExecState::DivByZero);
         goto End;
       }
-      PUSH_REF(allocator->allocLong(a % b));
+      PUSH_LONG(a % b);
     } break;
     case OpCode::ModFloat: {
       auto b = POP_FLOAT();
@@ -403,7 +412,7 @@ auto execute(
       PUSH_INT(-POP_INT());
     } break;
     case OpCode::NegLong: {
-      PUSH_REF(allocator->allocLong(-getLong(POP())));
+      PUSH_LONG(-getLong(POP()));
     } break;
     case OpCode::NegFloat: {
       PUSH_FLOAT(-POP_FLOAT());
@@ -521,7 +530,7 @@ auto execute(
     } break;
 
     case OpCode::ConvIntLong: {
-      PUSH_REF(allocator->allocLong(static_cast<int64_t>(POP_INT())));
+      PUSH_LONG(static_cast<int64_t>(POP_INT()));
     } break;
     case OpCode::ConvIntFloat: {
       PUSH_FLOAT(static_cast<float>(POP_INT()));
@@ -759,6 +768,7 @@ End:
 #undef PUSH
 #undef PUSH_UINT
 #undef PUSH_INT
+#undef PUSH_LONG
 #undef PUSH_BOOL
 #undef PUSH_FLOAT
 #undef PUSH_REF

--- a/src/vm/internal/pcall.hpp
+++ b/src/vm/internal/pcall.hpp
@@ -26,6 +26,15 @@ auto inline pcall(
     return;                                                                                        \
   }
 #define PUSH_INT(VAL) PUSH(intValue(VAL))
+#define PUSH_LONG(VAL)                                                                             \
+  {                                                                                                \
+    int64_t v = VAL;                                                                               \
+    if (v > 0) {                                                                                   \
+      PUSH(posLongValue(v));                                                                       \
+    } else {                                                                                       \
+      PUSH_REF(allocator->allocLong(v));                                                           \
+    }                                                                                              \
+  }
 #define PUSH_REF(VAL)                                                                              \
   {                                                                                                \
     auto* refPtr = VAL;                                                                            \
@@ -101,14 +110,12 @@ auto inline pcall(
   } break;
 
   case vm::PCallCode::ClockMicroSinceEpoch: {
-    const auto now  = std::chrono::system_clock::now().time_since_epoch();
-    uint64_t result = std::chrono::duration_cast<std::chrono::microseconds>(now).count();
-    PUSH_REF(allocator->allocLong(result));
+    const auto now = std::chrono::system_clock::now().time_since_epoch();
+    PUSH_LONG(std::chrono::duration_cast<std::chrono::microseconds>(now).count());
   } break;
   case vm::PCallCode::ClockNanoSteady: {
-    auto now        = std::chrono::steady_clock::now().time_since_epoch();
-    uint64_t result = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
-    PUSH_REF(allocator->allocLong(result));
+    auto now = std::chrono::steady_clock::now().time_since_epoch();
+    PUSH_LONG(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
   } break;
 
   case vm::PCallCode::SleepNano: {
@@ -135,6 +142,7 @@ auto inline pcall(
 
 #undef PUSH
 #undef PUSH_INT
+#undef PUSH_LONG
 #undef PUSH_REF
 #undef POP
 #undef POP_INT

--- a/src/vm/internal/ref_long.hpp
+++ b/src/vm/internal/ref_long.hpp
@@ -27,8 +27,13 @@ private:
 };
 
 inline auto getLong(const Value& val) noexcept {
-  auto* longRef = val.getDowncastRef<LongRef>();
-  return longRef->getVal();
+  // Positive long's (most significant bit always 0) are stored in the value directly, while
+  // negative longs are stored as references.
+  if (val.isRef()) {
+    auto* longRef = val.getDowncastRef<LongRef>();
+    return longRef->getVal();
+  }
+  return val.getPosLong();
 }
 
 } // namespace vm::internal

--- a/src/vm/internal/value.hpp
+++ b/src/vm/internal/value.hpp
@@ -11,6 +11,7 @@ static const uint64_t valMask = ~static_cast<uint64_t>(1U);
 class Value final {
   friend auto uintValue(uint32_t val) noexcept -> Value;
   friend auto intValue(int32_t val) noexcept -> Value;
+  friend auto posLongValue(int64_t val) noexcept -> Value;
   friend auto floatValue(float val) noexcept -> Value;
   friend auto refValue(Ref* ref) noexcept -> Value;
   template <typename Type>
@@ -38,6 +39,11 @@ public:
     assert(!isRef());
     auto upperRaw = static_cast<uint32_t>(m_raw >> 32U);
     return reinterpret_cast<int32_t&>(upperRaw); // NOLINT: Reinterpret cast
+  }
+
+  [[nodiscard]] inline auto getPosLong() const noexcept -> int64_t {
+    assert(!isRef());
+    return static_cast<int64_t>(m_raw >> 1U);
   }
 
   [[nodiscard]] inline auto getFloat() const noexcept -> float {
@@ -79,6 +85,13 @@ private:
   // Int's are stored in the upper 32 bit of the raw value.
   auto upperRaw = reinterpret_cast<uint32_t&>(val); // NOLINT: Reinterpret cast
   return Value{static_cast<uint64_t>(upperRaw) << 32U};
+}
+
+[[nodiscard]] inline auto posLongValue(int64_t val) noexcept -> Value {
+  assert(val > 0L);
+
+  // Positive longs (most significant bit is always zero), can be stored in the upper 63 bits.
+  return Value{static_cast<uint64_t>(val) << 1U};
 }
 
 [[nodiscard]] inline auto floatValue(float val) noexcept -> Value {


### PR DESCRIPTION
Values on the stack can use up to 63 bits, the least significant bit is reserved for marking values as being references. For that reason longs (64 bit signed integers) are stored as references on the heap. This has a cost however as heap memory has to be allocated and eventually garbage collected. 

This pr stores all positive longs (sign bit always 0) on the stack and only stores negative longs on the heap. 

An alternative solution that could be explored is stores values within the range representable by a 63 bit signed integer on the stack, which is probably true more often of the cases but requires slightly more costly manipulations to store it (as the sign bit has to be moved). 
