### PR TITLE
Nullable struct union optimisation 

### DIFF
--- a/include/novasm/assembler.hpp
+++ b/include/novasm/assembler.hpp
@@ -91,6 +91,7 @@ public:
   auto addCheckLeInt() -> void;
   auto addCheckLeLong() -> void;
   auto addCheckLeFloat() -> void;
+  auto addCheckStructNull() -> void;
 
   auto addConvIntLong() -> void;
   auto addConvIntFloat() -> void;
@@ -105,6 +106,7 @@ public:
   auto addConvFloatChar() -> void;
 
   auto addMakeStruct(uint8_t fieldCount) -> void;
+  auto addMakeNullStruct() -> void;
   auto addLoadStructField(uint8_t fieldIndex) -> void;
 
   auto addJump(std::string label) -> void;

--- a/include/novasm/op_code.hpp
+++ b/include/novasm/op_code.hpp
@@ -78,6 +78,7 @@ enum class OpCode : uint8_t {
   CheckLeInt        = 99, //  [] (int, int)               -> (int) Check int is less.
   CheckLeLong       = 100, // [] (long, long)             -> (int) Check int is less.
   CheckLeFloat      = 101, // [] (float, float)           -> (int) Check float is less.
+  CheckStructNull   = 102, // [] (struct)                 -> (int) Check if struct is null.
 
   ConvIntLong     = 111, // [] (int)   -> (long)     Convert int to long.
   ConvIntFloat    = 112, // [] (int)   -> (float)    Convert int to float.
@@ -91,7 +92,8 @@ enum class OpCode : uint8_t {
   ConvFloatChar   = 120, // [] (float) -> (int)      Convert float to char (ascii).
 
   MakeStruct      = 190, // [uint8] (any ...) -> (struct) Create structure containing x values.
-  LoadStructField = 191, // [uint8] (struct)  -> (any)    Get value of field x in structure.
+  MakeNullStruct  = 191, // []      ()        -> struct   Create a struct without fields.
+  LoadStructField = 192, // [uint8] (struct)  -> (any)    Get value of field x in structure.
 
   Jump   = 220, // [ip] ()    -> () Jump to an instruction pointer.
   JumpIf = 221, // [ip] (int) -> () Jump to an instruction if int is not 0.

--- a/include/prog/sym/struct_def.hpp
+++ b/include/prog/sym/struct_def.hpp
@@ -20,6 +20,7 @@ public:
 
   [[nodiscard]] auto getId() const noexcept -> const TypeId&;
   [[nodiscard]] auto getFields() const noexcept -> const sym::FieldDeclTable&;
+  [[nodiscard]] auto isTagType() const noexcept -> bool;
 
 private:
   sym::TypeId m_id;

--- a/novstd/list.nov
+++ b/novstd/list.nov
@@ -109,18 +109,18 @@ fun rangeList{T}(T start, T end)
   List{T}().pushRange(start, end)
 
 fun fold{T, TResult}(List{T} l, function{TResult, T, TResult} func)
-  (
-    lambda (List{T} rem, TResult result)
-      if rem as LNode{T} n -> self(n.next, func(result, n.val))
-      if rem is LEnd       -> result
-  )(l, TResult())
+  fold(l, func, TResult())
+
+fun fold{T, TResult}(List{T} l, function{TResult, T, TResult} func, TResult result)
+    if l as LNode{T} n -> fold(n.next, func, func(result, n.val))
+    if l is LEnd       -> result
 
 fun foldRight{T, TResult}(List{T} l, function{TResult, T, TResult} func)
-  (
-    lambda (List{T} rem, TResult result)
-      if rem as LNode{T} n -> func(self(n.next, result), n.val)
-      if rem is LEnd       -> result
-  )(l, TResult())
+  foldRight(l, func, TResult())
+
+fun foldRight{T, TResult}(List{T} l, function{TResult, T, TResult} func, TResult result)
+  if l as LNode{T} n -> func(self(n.next, func, result), n.val)
+  if l is LEnd       -> result
 
 fun filter{T}(List{T} l, function{T, bool} pred)
   l.foldRight(lambda (List{T} newList, T val) pred(val) ? val :: newList : newList)

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -385,8 +385,8 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::MakeStruct: {
     auto fieldCount = n.getChildCount();
     if (fieldCount == 0U) {
-      // Empty structs are represented by the value 0 (avoids allocation).
-      m_asmb->addLoadLitInt(0);
+      // Empty structs are represented by a null-struct. (avoids allocation).
+      m_asmb->addMakeNullStruct();
       break;
     }
     if (fieldCount == 1U) {

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -12,7 +12,7 @@ GenExpr::GenExpr(
     const prog::sym::ConstDeclTable& constTable,
     std::optional<prog::sym::FuncId> curFunc,
     bool tail) :
-    m_program{program}, m_asmb{asmb}, m_constTable{constTable}, m_curFunc{curFunc}, m_tail{tail} {}
+    m_prog{program}, m_asmb{asmb}, m_constTable{constTable}, m_curFunc{curFunc}, m_tail{tail} {}
 
 auto GenExpr::visit(const prog::expr::AssignExprNode& n) -> void {
   // Expression.
@@ -22,8 +22,7 @@ auto GenExpr::visit(const prog::expr::AssignExprNode& n) -> void {
   m_asmb->addDup();
 
   // Assign op.
-  const auto constId = getConstOffset(m_constTable, n.getConst());
-  m_asmb->addStackStore(constId);
+  m_asmb->addStackStore(getConstOffset(m_constTable, n.getConst()));
 }
 
 auto GenExpr::visit(const prog::expr::SwitchExprNode& n) -> void {
@@ -62,10 +61,12 @@ auto GenExpr::visit(const prog::expr::SwitchExprNode& n) -> void {
 }
 
 auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
-  const auto& funcDecl = m_program.getFuncDecl(n.getFunc());
+  const auto& funcDecl = m_prog.getFuncDecl(n.getFunc());
+
+  // Union type creation needs special handling.
   if (funcDecl.getKind() == prog::sym::FuncKind::MakeUnion) {
-    // Union is an exception where the type-id needs to be on the stack before the argument.
-    m_asmb->addLoadLitInt(getUnionTypeId(m_program, n.getType(), n[0].getType()));
+    makeUnion(n);
+    return;
   }
 
   // Push the arguments on the stack.
@@ -88,7 +89,7 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   case prog::sym::FuncKind::User:
     m_asmb->addCall(
-        getLabel(m_program, funcDecl.getId()),
+        getLabel(m_prog, funcDecl.getId()),
         funcDecl.getInput().getCount(),
         n.isFork() ? novasm::CallMode::Forked
                    : (m_tail ? novasm::CallMode::Tail : novasm::CallMode::Normal));
@@ -401,10 +402,7 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   }
   case prog::sym::FuncKind::MakeUnion: {
-    // Unions are structs with 2 fields, first the type-id and then the value.
-    // Note: The type-id is being pushed on the stack at the top of this function.
-    m_asmb->addMakeStruct(2);
-    break;
+    throw std::logic_error{"Union creation needs specialized handling"};
   }
 
   case prog::sym::FuncKind::FutureWaitNano: {
@@ -425,7 +423,7 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     }
     auto invert = funcDecl.getKind() == prog::sym::FuncKind::CheckNEqUserType;
     m_asmb->addCall(
-        getUserTypeEqLabel(m_program, lhsType),
+        getUserTypeEqLabel(m_prog, lhsType),
         2,
         (m_tail && !invert) ? novasm::CallMode::Tail : novasm::CallMode::Normal);
     if (invert) {
@@ -521,13 +519,13 @@ auto GenExpr::visit(const prog::expr::CallSelfExprNode& n) -> void {
     throw std::logic_error{"Illegal self-call: Not inside a function"};
   }
 
-  const auto& funcDecl = m_program.getFuncDecl(*m_curFunc);
+  const auto& funcDecl = m_prog.getFuncDecl(*m_curFunc);
   if (funcDecl.getOutput() != n.getType()) {
     throw std::logic_error{
         "Illegal self-call: Result-type does not match the type of the current function"};
   }
 
-  const auto& funcDef        = m_program.getFuncDef(*m_curFunc);
+  const auto& funcDef        = m_prog.getFuncDef(*m_curFunc);
   const auto& funcConstTable = funcDef.getConsts();
 
   const auto nonBoundInputs = funcConstTable.getNonBoundInputs();
@@ -556,7 +554,7 @@ auto GenExpr::visit(const prog::expr::CallSelfExprNode& n) -> void {
 
   // Invoke the current function.
   m_asmb->addCall(
-      getLabel(m_program, funcDecl.getId()),
+      getLabel(m_prog, funcDecl.getId()),
       funcDecl.getInput().getCount(),
       m_tail ? novasm::CallMode::Tail : novasm::CallMode::Normal);
 }
@@ -569,26 +567,25 @@ auto GenExpr::visit(const prog::expr::ClosureNode& n) -> void {
 
   // Push the function instruction-pointer on the stack.
   const auto funcId = n.getFunc();
-  m_asmb->addLoadLitIp(getLabel(m_program, funcId));
+  m_asmb->addLoadLitIp(getLabel(m_prog, funcId));
 
   // Create a struct containing both the bound arguments and the function pointer.
   m_asmb->addMakeStruct(n.getChildCount() + 1);
 }
 
 auto GenExpr::visit(const prog::expr::ConstExprNode& n) -> void {
-  const auto constId = getConstOffset(m_constTable, n.getId());
-  m_asmb->addStackLoad(constId);
+  m_asmb->addStackLoad(getConstOffset(m_constTable, n.getId()));
 }
 
 auto GenExpr::visit(const prog::expr::FieldExprNode& n) -> void {
   // Load the struct.
   genSubExpr(n[0], false);
 
-  const auto& structType = m_program.getTypeDecl(n[0].getType());
+  const auto& structType = m_prog.getTypeDecl(n[0].getType());
   if (structType.getKind() != prog::sym::TypeKind::Struct) {
     throw std::logic_error{"Field expr node only works on struct types"};
   }
-  const auto& structDef = std::get<prog::sym::StructDef>(m_program.getTypeDef(structType.getId()));
+  const auto& structDef = std::get<prog::sym::StructDef>(m_prog.getTypeDef(structType.getId()));
   if (structDef.getFields().getCount() == 0) {
     throw std::logic_error{"Cannot get a field on a struct without fields"};
   }
@@ -599,8 +596,7 @@ auto GenExpr::visit(const prog::expr::FieldExprNode& n) -> void {
   }
 
   // Load the field.
-  const auto fieldId = getFieldId(n.getId());
-  m_asmb->addLoadStructField(fieldId);
+  m_asmb->addLoadStructField(getFieldOffset(n.getId()));
 }
 
 auto GenExpr::visit(const prog::expr::GroupExprNode& n) -> void {
@@ -616,18 +612,54 @@ auto GenExpr::visit(const prog::expr::GroupExprNode& n) -> void {
 }
 
 auto GenExpr::visit(const prog::expr::UnionCheckExprNode& n) -> void {
+  const auto& unionType = n[0].getType();
+
   // Load the union.
   genSubExpr(n[0], false);
 
-  // Test if the union is the correct type.
+  if (unionIsNullableStruct(m_prog, unionType)) {
+    /* For nullable struct unions this turns into a null check or a not-null check. */
+    if (structIsTagType(m_prog, n.getTargetType())) {
+      m_asmb->addCheckStructNull();
+    } else {
+      m_asmb->addCheckStructNull();
+      m_asmb->addLogicInvInt();
+    }
+    return;
+  }
+
+  // For normal unions we test if the discriminants match.
   m_asmb->addLoadStructField(0);
-  m_asmb->addLoadLitInt(getUnionTypeId(m_program, n[0].getType(), n.getTargetType()));
+  m_asmb->addLoadLitInt(getUnionDiscriminant(m_prog, n[0].getType(), n.getTargetType()));
   m_asmb->addCheckEqInt();
 }
 
 auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
   // Load the union.
   genSubExpr(n[0], false);
+  const auto& unionType = n[0].getType();
+
+  if (unionIsNullableStruct(m_prog, unionType)) {
+    /* Nullable-struct unions are either a struct or a null-struct. */
+    if (structIsTagType(m_prog, n.getTargetType())) {
+      // For the tag type (null) there is no need to actually assign the constant as there are no
+      // operations you can do on a null struct.
+      m_asmb->addCheckStructNull();
+    } else {
+      // For the non-null case we assign the constant to the union value and check if its not null.
+      m_asmb->addDup();
+      m_asmb->addStackStore(getConstOffset(m_constTable, n.getConst()));
+      m_asmb->addCheckStructNull();
+      m_asmb->addLogicInvInt();
+    }
+    return;
+  }
+
+  /*
+  Normal unions are represented by structs with 2 fields:
+    * Field 0: The discriminant indicating which type the value is.
+    * Field 1: The value.
+  */
 
   // We need the union twice on the stack, once for the type check and once for getting the value.
   m_asmb->addDup();
@@ -637,7 +669,7 @@ auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
 
   // Test if the union is the correct type.
   m_asmb->addLoadStructField(0);
-  m_asmb->addLoadLitInt(getUnionTypeId(m_program, n[0].getType(), n.getTargetType()));
+  m_asmb->addLoadLitInt(getUnionDiscriminant(m_prog, n[0].getType(), n.getTargetType()));
   m_asmb->addCheckEqInt();
   m_asmb->addJumpIf(typeEqLabel);
 
@@ -648,9 +680,8 @@ auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
   m_asmb->label(typeEqLabel);
 
   // Store the union value as a const and load 'true' on the stack.
-  const auto constId = getConstOffset(m_constTable, n.getConst());
   m_asmb->addLoadStructField(1);
-  m_asmb->addStackStore(constId);
+  m_asmb->addStackStore(getConstOffset(m_constTable, n.getConst()));
 
   m_asmb->addLoadLitInt(1); // Load true.
 
@@ -669,7 +700,7 @@ auto GenExpr::visit(const prog::expr::LitFloatNode& n) -> void {
 
 auto GenExpr::visit(const prog::expr::LitFuncNode& n) -> void {
   const auto funcId = n.getFunc();
-  m_asmb->addLoadLitIp(getLabel(m_program, funcId));
+  m_asmb->addLoadLitIp(getLabel(m_prog, funcId));
 }
 
 auto GenExpr::visit(const prog::expr::LitIntNode& n) -> void { m_asmb->addLoadLitInt(n.getVal()); }
@@ -686,8 +717,36 @@ auto GenExpr::visit(const prog::expr::LitCharNode& n) -> void { m_asmb->addLoadL
 
 auto GenExpr::visit(const prog::expr::LitEnumNode& n) -> void { m_asmb->addLoadLitInt(n.getVal()); }
 
+auto GenExpr::makeUnion(const prog::expr::CallExprNode& n) -> void {
+  if (n.getChildCount() != 1) {
+    throw std::logic_error{"Unions can only be created with one sub-expr"};
+  }
+
+  const auto& unionType  = n.getType();
+  const auto& chosenType = n[0].getType();
+
+  if (unionIsNullableStruct(m_prog, unionType)) {
+    /*
+    Nullable structs are unions that have two structs, one with fields and an empty (tag type)
+    one. For them we can optimize the union away and leaving just the struct or null in case of
+    the tag.
+    */
+    if (structIsTagType(m_prog, chosenType)) {
+      m_asmb->addMakeNullStruct();
+    } else {
+      genSubExpr(n[0], m_tail);
+    }
+    return;
+  }
+
+  // Normal unions are represented by a struct containing the discriminant and the value.
+  m_asmb->addLoadLitInt(getUnionDiscriminant(m_prog, n.getType(), chosenType));
+  genSubExpr(n[0], false);
+  m_asmb->addMakeStruct(2);
+}
+
 auto GenExpr::genSubExpr(const prog::expr::Node& n, bool tail) -> void {
-  auto genExpr = GenExpr{m_program, m_asmb, m_constTable, m_curFunc, tail};
+  auto genExpr = GenExpr{m_prog, m_asmb, m_constTable, m_curFunc, tail};
   n.accept(&genExpr);
 }
 

--- a/src/backend/internal/gen_expr.hpp
+++ b/src/backend/internal/gen_expr.hpp
@@ -37,11 +37,13 @@ public:
   auto visit(const prog::expr::LitEnumNode& n) -> void override;
 
 private:
-  const prog::Program& m_program;
+  const prog::Program& m_prog;
   novasm::Assembler* m_asmb;
   const prog::sym::ConstDeclTable& m_constTable;
   std::optional<prog::sym::FuncId> m_curFunc;
   bool m_tail;
+
+  auto makeUnion(const prog::expr::CallExprNode& n) -> void;
 
   auto genSubExpr(const prog::expr::Node& n, bool tail) -> void;
 };

--- a/src/backend/internal/gen_type_eq.hpp
+++ b/src/backend/internal/gen_type_eq.hpp
@@ -4,6 +4,6 @@
 
 namespace backend::internal {
 
-auto generateUserTypeEquality(novasm::Assembler* asmb, const prog::Program& program) -> void;
+auto generateUserTypeEquality(novasm::Assembler* asmb, const prog::Program& prog) -> void;
 
 } // namespace backend::internal

--- a/src/backend/internal/utilities.cpp
+++ b/src/backend/internal/utilities.cpp
@@ -24,7 +24,7 @@ auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId i
   return static_cast<uint8_t>(offset);
 }
 
-auto getFieldId(prog::sym::FieldId fieldId) -> uint8_t {
+auto getFieldOffset(prog::sym::FieldId fieldId) -> uint8_t {
   auto fieldNum = fieldId.getNum();
   if (fieldNum > std::numeric_limits<uint8_t>::max()) {
     throw std::logic_error{"More then 256 fields in one struct are not supported"};
@@ -32,7 +32,7 @@ auto getFieldId(prog::sym::FieldId fieldId) -> uint8_t {
   return static_cast<uint8_t>(fieldNum);
 }
 
-auto getUnionTypeId(
+auto getUnionDiscriminant(
     const prog::Program& prog, prog::sym::TypeId unionType, prog::sym::TypeId targetType)
     -> uint8_t {
   const auto& typeDef = prog.getTypeDef(unionType);
@@ -45,6 +45,62 @@ auto getUnionTypeId(
     throw std::logic_error{"More then 256 types in one union are not supported"};
   }
   return static_cast<uint8_t>(index);
+}
+
+auto structIsTagType(const prog::Program& prog, prog::sym::TypeId structType) -> bool {
+  const auto& typeDecl = prog.getTypeDecl(structType);
+  if (typeDecl.getKind() != prog::sym::TypeKind::Struct) {
+    throw std::logic_error{"Given type is not a struct"};
+  }
+  return std::get<prog::sym::StructDef>(prog.getTypeDef(structType)).isTagType();
+}
+
+auto unionIsNullableStruct(const prog::Program& prog, prog::sym::TypeId unionType) -> bool {
+  /*
+  To be eligible for the nullable struct optimisation it needs to have 2 entries:
+    * a struct with fields (2 or more), note: struct with 1 field is not eligible as backend is
+      allowed to represent 1 field strusts just by the field itself.
+    * a empty struct (sometimes called a tag type).
+  In case of nullable structs the union can be optimized away and just having a struct that is
+  'null' in case of the empty struct and non 'null' in case of the struct with fields.
+  */
+
+  const auto& typeDecl = prog.getTypeDecl(unionType);
+  if (typeDecl.getKind() != prog::sym::TypeKind::Union) {
+    throw std::logic_error{"Given type is not a union"};
+  }
+  const auto& unionDef = std::get<prog::sym::UnionDef>(prog.getTypeDef(unionType));
+  const auto& types    = unionDef.getTypes();
+
+  // Needs to have two types.
+  if (types.size() != 2) {
+    return false;
+  }
+
+  // Both types need to be structs.
+  if (!std::all_of(types.begin(), types.end(), [&prog](const auto& id) {
+        return prog.getTypeDecl(id).getKind() == prog::sym::TypeKind::Struct;
+      })) {
+    return false;
+  }
+
+  // One struct needs to be a tag type (having no fields).
+  if (!std::any_of(types.begin(), types.end(), [&prog](const auto& id) {
+        return structIsTagType(prog, id);
+      })) {
+    return false;
+  }
+
+  // One struct needs to have 2 or more fields.
+  if (!std::any_of(types.begin(), types.end(), [&prog](const auto& id) {
+        const auto& structDef = std::get<prog::sym::StructDef>(prog.getTypeDef(id));
+        return structDef.getFields().getCount() >= 2;
+      })) {
+    return false;
+  }
+
+  // Union is eligible.
+  return true;
 }
 
 } // namespace backend::internal

--- a/src/backend/internal/utilities.hpp
+++ b/src/backend/internal/utilities.hpp
@@ -8,16 +8,28 @@
 
 namespace backend::internal {
 
+// Get a label to identify the function.
 auto getLabel(const prog::Program& prog, prog::sym::FuncId funcId) -> std::string;
 
+// Get a label to identify the (generated) equality function for the user type.
 auto getUserTypeEqLabel(const prog::Program& prog, prog::sym::TypeId typeId) -> std::string;
 
+// Get the offset in the constant-table for the constant.
 auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId id) -> uint8_t;
 
-auto getFieldId(prog::sym::FieldId fieldId) -> uint8_t;
+// Get the offset the field has in the struct.
+auto getFieldOffset(prog::sym::FieldId fieldId) -> uint8_t;
 
-auto getUnionTypeId(
+// Get the discriminant (identifier) of a type in a union.
+auto getUnionDiscriminant(
     const prog::Program& prog, prog::sym::TypeId unionType, prog::sym::TypeId targetType)
     -> uint8_t;
+
+// Is the struct a tag-type (struct with no fields).
+auto structIsTagType(const prog::Program& prog, prog::sym::TypeId structType) -> bool;
+
+// Is union eligible for the nullable-struct optimisation.
+// To be eligible it needs to have 2 entries, a struct with fields and an empty struct.
+auto unionIsNullableStruct(const prog::Program& prog, prog::sym::TypeId unionType) -> bool;
 
 } // namespace backend::internal

--- a/src/novasm/assembler.cpp
+++ b/src/novasm/assembler.cpp
@@ -174,6 +174,8 @@ auto Assembler::addCheckLeLong() -> void { writeOpCode(OpCode::CheckLeLong); }
 
 auto Assembler::addCheckLeFloat() -> void { writeOpCode(OpCode::CheckLeFloat); }
 
+auto Assembler::addCheckStructNull() -> void { writeOpCode(OpCode::CheckStructNull); }
+
 auto Assembler::addConvIntLong() -> void { writeOpCode(OpCode::ConvIntLong); }
 
 auto Assembler::addConvIntFloat() -> void { writeOpCode(OpCode::ConvIntFloat); }
@@ -213,6 +215,8 @@ auto Assembler::addMakeStruct(uint8_t fieldCount) -> void {
   writeOpCode(OpCode::MakeStruct);
   writeUInt8(fieldCount);
 }
+
+auto Assembler::addMakeNullStruct() -> void { writeOpCode(OpCode::MakeNullStruct); }
 
 auto Assembler::addLoadStructField(uint8_t fieldIndex) -> void {
   writeOpCode(OpCode::LoadStructField);

--- a/src/novasm/disassembler.cpp
+++ b/src/novasm/disassembler.cpp
@@ -192,7 +192,7 @@ auto disassembleInstructions(const Assembly& assembly, const dasm::InstructionLa
     case OpCode::FutureBlock:
     case OpCode::Dup:
     case OpCode::Pop: {
-      result.push_back(Instr{opCode, offset, {}});
+      result.push_back(Instr{opCode, offset, {}, labels});
       continue;
     }
     case OpCode::LoadLitString:

--- a/src/novasm/disassembler.cpp
+++ b/src/novasm/disassembler.cpp
@@ -174,6 +174,7 @@ auto disassembleInstructions(const Assembly& assembly, const dasm::InstructionLa
     case OpCode::CheckLeInt:
     case OpCode::CheckLeLong:
     case OpCode::CheckLeFloat:
+    case OpCode::CheckStructNull:
     case OpCode::ConvIntLong:
     case OpCode::ConvIntFloat:
     case OpCode::ConvLongInt:
@@ -184,6 +185,7 @@ auto disassembleInstructions(const Assembly& assembly, const dasm::InstructionLa
     case OpCode::ConvCharString:
     case OpCode::ConvIntChar:
     case OpCode::ConvFloatChar:
+    case OpCode::MakeNullStruct:
     case OpCode::Ret:
     case OpCode::Fail:
     case OpCode::FutureWaitNano:

--- a/src/novasm/op_code.cpp
+++ b/src/novasm/op_code.cpp
@@ -196,6 +196,9 @@ auto operator<<(std::ostream& out, const OpCode& rhs) noexcept -> std::ostream& 
   case OpCode::CheckLeFloat:
     out << "check-le-float";
     break;
+  case OpCode::CheckStructNull:
+    out << "check-struct-null";
+    break;
 
   case OpCode::ConvIntLong:
     out << "conv-int-long";
@@ -230,6 +233,9 @@ auto operator<<(std::ostream& out, const OpCode& rhs) noexcept -> std::ostream& 
 
   case OpCode::MakeStruct:
     out << "make-struct";
+    break;
+  case OpCode::MakeNullStruct:
+    out << "make-null-struct";
     break;
   case OpCode::LoadStructField:
     out << "load-struct-field";

--- a/src/prog/sym/struct_def.cpp
+++ b/src/prog/sym/struct_def.cpp
@@ -9,4 +9,6 @@ auto StructDef::getId() const noexcept -> const TypeId& { return m_id; }
 
 auto StructDef::getFields() const noexcept -> const sym::FieldDeclTable& { return m_fields; }
 
+auto StructDef::isTagType() const noexcept -> bool { return m_fields.getCount() == 0; }
+
 } // namespace prog::sym

--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -544,6 +544,9 @@ auto execute(
       auto a = POP_FLOAT();
       PUSH_BOOL(a < b);
     } break;
+    case OpCode::CheckStructNull: {
+      PUSH_BOOL(POP().isNullRef());
+    } break;
 
     case OpCode::ConvIntLong: {
       PUSH_LONG(static_cast<int64_t>(POP_INT()));
@@ -591,6 +594,9 @@ auto execute(
         *(structRefAlloc.second + fieldIndex) = POP();
       }
       PUSH_REF(structRefAlloc.first);
+    } break;
+    case OpCode::MakeNullStruct: {
+      PUSH(nullRefValue());
     } break;
     case OpCode::LoadStructField: {
       const auto fieldIndex = READ_BYTE();

--- a/src/vm/internal/garbage_collector.cpp
+++ b/src/vm/internal/garbage_collector.cpp
@@ -96,7 +96,10 @@ auto GarbageCollector::populateMarkQueue(BasicStack* stack) noexcept -> void {
   for (auto* sp = stack->getBottom(); sp != stack->getNext(); ++sp) {
     assert(sp < stack->getNext());
     if (sp->isRef()) {
-      m_markQueue.push_back(sp->getRef());
+      auto* ref = sp->getRef();
+      if (ref != nullptr) {
+        m_markQueue.push_back(ref);
+      }
     }
   }
 }
@@ -121,7 +124,10 @@ auto GarbageCollector::mark() noexcept -> void {
       auto* s = downcastRef<StructRef>(cur);
       for (auto* fP = s->getFieldsBegin(); fP != s->getFieldsEnd(); ++fP) {
         if (fP->isRef()) {
-          m_markQueue.push_back(fP->getRef());
+          auto* ref = fP->getRef();
+          if (ref != nullptr) {
+            m_markQueue.push_back(ref);
+          }
         }
       }
     } break;

--- a/src/vm/internal/value.hpp
+++ b/src/vm/internal/value.hpp
@@ -14,6 +14,7 @@ class Value final {
   friend auto posLongValue(int64_t val) noexcept -> Value;
   friend auto floatValue(float val) noexcept -> Value;
   friend auto refValue(Ref* ref) noexcept -> Value;
+  friend auto nullRefValue() noexcept -> Value;
   template <typename Type>
   friend auto rawPtrValue(Type* ptr) noexcept -> Value;
 
@@ -57,6 +58,11 @@ public:
     // Mask of the tag and interpret it as a pointer (works because due to alignment lowest bit is
     // always 0).
     return reinterpret_cast<Ref*>(m_raw & valMask); // NOLINT: Reinterpret cast
+  }
+
+  [[nodiscard]] inline auto isNullRef() const noexcept -> bool {
+    assert(isRef());
+    return m_raw == refTag; // Check if all bits other then the ref tag are zero.
   }
 
   template <typename RefType>
@@ -109,6 +115,8 @@ private:
   // Then expand to 64 bit and tag it.
   return Value{static_cast<uint64_t>(rawRef) | refTag};
 }
+
+[[nodiscard]] inline auto nullRefValue() noexcept -> Value { return Value{refTag}; }
 
 template <typename Type>
 [[nodiscard]] inline auto rawPtrValue(Type* ptr) noexcept -> Value {

--- a/tests/backend/struct_test.cpp
+++ b/tests/backend/struct_test.cpp
@@ -81,10 +81,10 @@ TEST_CASE("Generating assembly for structs", "[backend]") {
           // --- conWrite statement start.
           asmb->label("prog");
           // Make struct 1 'Empty()'.
-          asmb->addLoadLitInt(0); // Empty struct is represented by '0'.
+          asmb->addMakeNullStruct(); // Empty struct is represented by a null-struct.
 
           // Make struct 2 'Empty()'.
-          asmb->addLoadLitInt(0); // Empty struct is represented by '0'.
+          asmb->addMakeNullStruct(); // Empty struct is represented by a null-struct.
 
           // Call the equality function and write the result.
           asmb->addCall("UserEq", 2, novasm::CallMode::Normal);

--- a/tests/backend/struct_test.cpp
+++ b/tests/backend/struct_test.cpp
@@ -5,7 +5,7 @@ namespace backend {
 
 TEST_CASE("Generating assembly for structs", "[backend]") {
 
-  SECTION("Create user struct and check for equality") {
+  SECTION("Normal struct") {
     CHECK_PROG(
         "struct User = string name, int age "
         "conWrite(string(User(\"hello\", 42) == User(\"world\", 1337)))",
@@ -66,7 +66,7 @@ TEST_CASE("Generating assembly for structs", "[backend]") {
         });
   }
 
-  SECTION("Create empty struct and check for equality") {
+  SECTION("Empty struct (tag type)") {
     CHECK_PROG(
         "struct Empty "
         "conWrite(string(Empty() == Empty()))",
@@ -96,7 +96,7 @@ TEST_CASE("Generating assembly for structs", "[backend]") {
           asmb->setEntrypoint("prog");
         });
 
-    SECTION("Create struct with one field, check for equality and load field") {
+    SECTION("One field struct") {
       CHECK_PROG(
           "struct Age = int years "
           "conWrite(string(Age(42) == Age(1337))) "

--- a/tests/backend/union_test.cpp
+++ b/tests/backend/union_test.cpp
@@ -5,10 +5,12 @@ namespace backend {
 
 TEST_CASE("Generating assembly for unions", "[backend]") {
 
-  SECTION("Create user union and check for equality") {
+  SECTION("Normal union") {
     CHECK_PROG(
         "union Val = int, float "
-        "conWrite(string(Val(1) == Val(1.0)))",
+        "conWrite(string(Val(1) == Val(1.0)))"
+        "conWrite(string(Val(1) is int))"
+        "conWrite(Val(1) as int i ? string(i) : \"not int\")",
         [](novasm::Assembler* asmb) -> void {
           // --- Union equality function start.
           asmb->label("ValEq");
@@ -70,8 +72,9 @@ TEST_CASE("Generating assembly for unions", "[backend]") {
           asmb->addRet();
           // --- Struct equality function end.
 
-          // --- conWrite statement start.
-          asmb->label("prog");
+          // --- first conWrite statement start.
+          asmb->label("conWrite1");
+
           // Make union with int 'Val(1)'.
           asmb->addLoadLitInt(0); // 0 because 'int' is the first type in the union.
           asmb->addLoadLitInt(1);
@@ -87,7 +90,261 @@ TEST_CASE("Generating assembly for unions", "[backend]") {
           asmb->addConvBoolString();
           asmb->addPCall(novasm::PCallCode::ConWriteString);
           asmb->addRet();
-          // --- conWrite statement end.
+          // --- first conWrite statement end.
+
+          // --- second conWrite statement start.
+          asmb->label("conWrite2");
+
+          // Make union with int 'Val(1)'.
+          asmb->addLoadLitInt(0); // 0 because 'int' is the first type in the union.
+          asmb->addLoadLitInt(1);
+          asmb->addMakeStruct(2);
+
+          // Check if union as discriminant for type int.
+          asmb->addLoadStructField(0); // Load discriminant.
+          asmb->addLoadLitInt(0);      // int is first type in union so discriminant is 0.
+          asmb->addCheckEqInt();
+
+          // Write the result.
+          asmb->addConvBoolString();
+          asmb->addPCall(novasm::PCallCode::ConWriteString);
+          asmb->addRet();
+          // --- second conWrite statement end.
+
+          // --- third conWrite statement start.
+          asmb->label("conWrite3");
+          asmb->addStackAlloc(1); // Allocate space for constant 'i'.
+
+          // Make union with int 'Val(1)'.
+          asmb->addLoadLitInt(0); // 0 because 'int' is the first type in the union.
+          asmb->addLoadLitInt(1);
+          asmb->addMakeStruct(2);
+
+          // Check if the discriminant is int.
+          asmb->addDup();
+          asmb->addLoadStructField(0); // Load discriminant.
+          asmb->addLoadLitInt(0);      // int is first type in union so discriminant is 0.
+          asmb->addCheckEqInt();
+          asmb->addJumpIf("as-check-type-is-int");
+
+          // Not int, set result of 'as' to false.
+          asmb->addPop();
+          asmb->addLoadLitInt(0);
+          asmb->addJump("as-check-end");
+
+          asmb->label("as-check-type-is-int");
+
+          // Store value in constant 'i' and set result to true.
+          asmb->addLoadStructField(1); // Value of union.
+          asmb->addStackStore(0);      // Assign to constant 'i'.
+          asmb->addLoadLitInt(1);      // Load true.
+
+          asmb->label("as-check-end");
+          asmb->addJumpIf("as-check-true");
+
+          // Not equal.
+          asmb->addLoadLitString("not int");
+          asmb->addJump("as-check-write-result");
+
+          asmb->label("as-check-true");
+          asmb->addStackLoad(0); // Load constant 'i'.
+          asmb->addConvIntString();
+
+          // Write the result.
+          asmb->label("as-check-write-result");
+          asmb->addPCall(novasm::PCallCode::ConWriteString);
+          asmb->addRet();
+          // --- third conWrite statement end.
+
+          asmb->label("prog");
+          asmb->addCall("conWrite1", 0, novasm::CallMode::Normal);
+          asmb->addCall("conWrite2", 0, novasm::CallMode::Normal);
+          asmb->addCall("conWrite3", 0, novasm::CallMode::Normal);
+          asmb->addRet();
+
+          asmb->setEntrypoint("prog");
+        });
+  }
+
+  SECTION("Nullable-struct union") {
+    /* Nullable-struct unions are an optimization where unions contains a struct with 2 or more
+    fields and an empty struct (tag type) are represented by single struct. */
+    CHECK_PROG(
+        "struct User = string name, int age "
+        "struct Null "
+        "union NullableUser = User, Null "
+        "conWrite(string(NullableUser(User(\"John\", 42)) == Null()))"
+        "conWrite(string(NullableUser(User(\"John\", 42)) is Null))"
+        "conWrite(string(NullableUser(User(\"John\", 42)) is User))"
+        "conWrite(NullableUser(User(\"John\", 42))  as User u ? u.name : \"null\")",
+        [](novasm::Assembler* asmb) -> void {
+          // -- struct 'Null' equality function start.
+          asmb->label("null-eq");
+          asmb->addLoadLitInt(1); // Always returns true.
+          asmb->addRet();
+          // -- struct 'Null' equality function end.
+
+          // -- union 'NullableUser' equality function start.
+          asmb->label("nullableuser-eq");
+
+          // Check if union a is null.
+          asmb->addStackLoad(0);
+          asmb->addCheckStructNull();
+          asmb->addJumpIf("nullableuser-eq-a-null");
+
+          // Check if union a is null.
+          asmb->addStackLoad(1);
+          asmb->addCheckStructNull();
+          asmb->addJumpIf("nullableuser-eq-b-null");
+
+          // If neither a nor b is null then call the equality function of the user struct.
+          asmb->addStackLoad(0);
+          asmb->addStackLoad(1);
+          asmb->addCall("user-eq", 2, novasm::CallMode::Tail);
+          // Note, tailcall so no ret instruction needed here.
+
+          asmb->label("nullableuser-eq-a-null");
+
+          // If a is null then return true if b is also null, otherwise return false.
+          asmb->addStackLoad(1);
+          asmb->addCheckStructNull();
+          asmb->addRet();
+
+          asmb->label("nullableuser-eq-b-null");
+
+          // If b is null (and a was not null) then return false.
+          asmb->addLoadLitInt(0);
+          asmb->addRet();
+          // -- union 'NullableUser' equality function end.
+
+          // -- struct 'User' equality function start.
+          asmb->label("user-eq");
+
+          // Check if field 1 is equal.
+          asmb->addStackLoad(0);
+          asmb->addLoadStructField(0);
+          asmb->addStackLoad(1);
+          asmb->addLoadStructField(0);
+          asmb->addCheckEqString();
+          asmb->addJumpIf("user-eq-field1equal");
+
+          // If field 1 is not equal then return false.
+          asmb->addLoadLitInt(0);
+          asmb->addRet();
+
+          asmb->label("user-eq-field1equal");
+
+          // Check if field 2 is equal.
+          asmb->addStackLoad(0);
+          asmb->addLoadStructField(1);
+          asmb->addStackLoad(1);
+          asmb->addLoadStructField(1);
+          asmb->addCheckEqInt();
+          asmb->addJumpIf("user-eq-field2equal");
+
+          // If field 2 is not equal then return false.
+          asmb->addLoadLitInt(0);
+          asmb->addRet();
+
+          asmb->label("user-eq-field2equal");
+
+          // Both are equal, return true.
+          asmb->addLoadLitInt(1);
+          asmb->addRet();
+          // -- struct 'User' equality function end.
+
+          // --- first conWrite statement start.
+          asmb->label("conWrite1");
+
+          // Create user.
+          asmb->addLoadLitString("John");
+          asmb->addLoadLitInt(42);
+          asmb->addMakeStruct(2);
+
+          // Create 'null'.
+          asmb->addMakeNullStruct();
+
+          // Call equality function of Nullable-user.
+          asmb->addCall("nullableuser-eq", 2, novasm::CallMode::Normal);
+
+          // Write the result.
+          asmb->addConvBoolString();
+          asmb->addPCall(novasm::PCallCode::ConWriteString);
+          asmb->addRet();
+          // --- first conWrite statement end.
+
+          // --- second conWrite statement start.
+          asmb->label("conWrite2");
+
+          // Create user.
+          asmb->addLoadLitString("John");
+          asmb->addLoadLitInt(42);
+          asmb->addMakeStruct(2);
+
+          // Check if user is null.
+          asmb->addCheckStructNull();
+
+          // Write the result.
+          asmb->addConvBoolString();
+          asmb->addPCall(novasm::PCallCode::ConWriteString);
+          asmb->addRet();
+          // --- second conWrite statement end.
+
+          // --- third conWrite statement start.
+          asmb->label("conWrite3");
+
+          // Create user.
+          asmb->addLoadLitString("John");
+          asmb->addLoadLitInt(42);
+          asmb->addMakeStruct(2);
+
+          // Check if user is not null.
+          asmb->addCheckStructNull();
+          asmb->addLogicInvInt();
+
+          // Write the result.
+          asmb->addConvBoolString();
+          asmb->addPCall(novasm::PCallCode::ConWriteString);
+          asmb->addRet();
+          // --- third conWrite statement end.
+
+          // --- fourth conWrite statement start.
+          asmb->label("conWrite4");
+          asmb->addStackAlloc(1); // Allocate space for the 'u' constant.
+
+          // Create user.
+          asmb->addLoadLitString("John");
+          asmb->addLoadLitInt(42);
+          asmb->addMakeStruct(2);
+
+          // Check if user is not null and set constant 'u'.
+          asmb->addDup();
+          asmb->addStackStore(0);
+          asmb->addCheckStructNull();
+          asmb->addLogicInvInt();
+          asmb->addJumpIf("user-is-not-null");
+
+          // Is null.
+          asmb->addLoadLitString("null");
+          asmb->addJump("fourth-conwrite-end");
+
+          asmb->label("user-is-not-null");
+          // Load name of user.
+          asmb->addStackLoad(0);
+          asmb->addLoadStructField(0);
+
+          asmb->label("fourth-conwrite-end");
+          // Print the result.
+          asmb->addPCall(novasm::PCallCode::ConWriteString);
+          asmb->addRet();
+          // --- fourth conWrite statement end.
+
+          asmb->label("prog");
+          asmb->addCall("conWrite1", 0, novasm::CallMode::Normal);
+          asmb->addCall("conWrite2", 0, novasm::CallMode::Normal);
+          asmb->addCall("conWrite3", 0, novasm::CallMode::Normal);
+          asmb->addCall("conWrite4", 0, novasm::CallMode::Normal);
+          asmb->addRet();
 
           asmb->setEntrypoint("prog");
         });

--- a/tests/vm/struct_op_test.cpp
+++ b/tests/vm/struct_op_test.cpp
@@ -5,6 +5,37 @@ namespace vm {
 
 TEST_CASE("Execute struct operations", "[vm]") {
 
+  SECTION("Create struct") {
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          // Create a struct.
+          asmb->addLoadLitString("hello ");
+          asmb->addLoadLitString("world");
+          asmb->addMakeStruct(2);
+
+          // Assert its not null.
+          asmb->addCheckStructNull();
+          asmb->addLogicInvInt();
+          asmb->addLoadLitString("Struct null");
+          asmb->addPCall(novasm::PCallCode::Assert);
+        },
+        "input");
+  }
+
+  SECTION("Create null struct") {
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          // Create a null struct.
+          asmb->addMakeNullStruct();
+
+          // Assert its null.
+          asmb->addCheckStructNull();
+          asmb->addLoadLitString("Struct not null");
+          asmb->addPCall(novasm::PCallCode::Assert);
+        },
+        "input");
+  }
+
   SECTION("Load field") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {


### PR DESCRIPTION
This adds an optimisation for unions consisting of a struct with (2 ore more fields) and a empty struct (sometimes called a tag type).  These unions (referred to as `nullable struct` in the backend) are now represented by the struct itself or by a null-struct in the vm. Meaning that the union itself is completely optimised away.

For example in the following linked-list implementation the `List{T}` union is optimised away and at runtime its just a `ListNode{T}` or a null struct. Essentially reducing the overhead of the linked-list by half.
```
union List{T} = ListNode{T}, ListEnd

struct ListNode{T} = T val, List{T} next
struct ListEnd
```