### PR TITLE
Call inlining optimisation step

### DIFF
--- a/apps/eval/main.cpp
+++ b/apps/eval/main.cpp
@@ -25,10 +25,10 @@ auto run(
   const auto src = frontend::buildSource(inputId, std::move(inputPath), inputBegin, inputEnd);
   const auto frontendOutput = frontend::analyze(src, searchPaths);
   if (frontendOutput.isSuccess()) {
-    const auto shakedProg = opt::treeshake(frontendOutput.getProg());
-    const auto asmOutput  = backend::generate(shakedProg);
-    auto iface            = vm::platform::TerminalInterface{vmEnvArgsCount, vmEnvArgs};
-    auto res              = vm::run(&asmOutput.first, &iface);
+    const auto optProg   = opt::optimize(frontendOutput.getProg());
+    const auto asmOutput = backend::generate(optProg);
+    auto iface           = vm::platform::TerminalInterface{vmEnvArgsCount, vmEnvArgs};
+    auto res             = vm::run(&asmOutput.first, &iface);
     if (res != vm::ExecState::Success) {
       std::cout << rang::style::bold << rang::bg::red << "Runtime error: " << res << '\n'
                 << rang::style::reset;

--- a/apps/lexdiag/main.cpp
+++ b/apps/lexdiag/main.cpp
@@ -113,20 +113,30 @@ auto main(int argc, char** argv) -> int {
   auto app = CLI::App{"Lexer diagnostic tool"};
   app.require_subcommand(1);
 
+  auto colorMode   = rang::control::Auto;
   auto printOutput = true;
-  app.add_flag("!--no-output", printOutput, "Skip printing the tokens")->capture_default_str();
+
+  app.add_flag(
+      "--no-color{0},-c{2},--color{2},--auto-color{1}",
+      colorMode,
+      "Set the color output behaviour");
 
   // Lex input characters.
   std::string charsInput;
   auto analyzeCmd = app.add_subcommand("analyze", "Lex the provided characters")->callback([&]() {
+    rang::setControlMode(colorMode);
+
     lexdiag::run(charsInput.begin(), charsInput.end(), printOutput);
   });
   analyzeCmd->add_option("input", charsInput, "Input characters")->required();
+  analyzeCmd->add_flag("!--no-output", printOutput, "Skip printing the tokens");
 
   // Lex input file.
   std::string filePath;
   auto analyzeFileCmd =
       app.add_subcommand("analyzefile", "Lex all characters in a file")->callback([&]() {
+        rang::setControlMode(colorMode);
+
         std::ifstream fs{filePath};
         lexdiag::run(
             std::istreambuf_iterator<char>{fs}, std::istreambuf_iterator<char>{}, printOutput);
@@ -134,6 +144,7 @@ auto main(int argc, char** argv) -> int {
   analyzeFileCmd->add_option("file", filePath, "Path to file")
       ->check(CLI::ExistingFile)
       ->required();
+  analyzeFileCmd->add_flag("!--no-output", printOutput, "Skip printing the tokens");
 
   // Parse arguments and run subcommands.
   std::atexit([]() { std::cout << rang::style::reset; });

--- a/apps/parsediag/main.cpp
+++ b/apps/parsediag/main.cpp
@@ -99,20 +99,30 @@ auto main(int argc, char** argv) -> int {
   auto app = CLI::App{"Parser diagnostic tool"};
   app.require_subcommand(1);
 
+  auto colorMode   = rang::control::Auto;
   auto printOutput = true;
-  app.add_flag("!--no-output", printOutput, "Skip printing the nodes")->capture_default_str();
+
+  app.add_flag(
+      "--no-color{0},-c{2},--color{2},--auto-color{1}",
+      colorMode,
+      "Set the color output behaviour");
 
   // Parse input characters.
   std::string charsInput;
   auto analyzeCmd = app.add_subcommand("analyze", "Parse the provided characters")->callback([&]() {
+    rang::setControlMode(colorMode);
+
     parsediag::run(charsInput.begin(), charsInput.end(), printOutput);
   });
   analyzeCmd->add_option("input", charsInput, "Input characters")->required();
+  analyzeCmd->add_flag("!--no-output", printOutput, "Skip printing the nodes");
 
   // Parse input file.
   std::string filePath;
   auto analyzeFileCmd =
       app.add_subcommand("analyzefile", "Parse all characters in a file")->callback([&]() {
+        rang::setControlMode(colorMode);
+
         std::ifstream fs{filePath};
         parsediag::run(
             std::istreambuf_iterator<char>{fs}, std::istreambuf_iterator<char>{}, printOutput);
@@ -120,6 +130,7 @@ auto main(int argc, char** argv) -> int {
   analyzeFileCmd->add_option("file", filePath, "Path to file")
       ->check(CLI::ExistingFile)
       ->required();
+  analyzeFileCmd->add_flag("!--no-output", printOutput, "Skip printing the nodes");
 
   // Parse arguments and run subcommands.
   std::atexit([]() { std::cout << rang::style::reset; });

--- a/include/opt/opt.hpp
+++ b/include/opt/opt.hpp
@@ -3,6 +3,10 @@
 
 namespace opt {
 
+auto optimize(const prog::Program& prog) -> prog::Program;
+
 auto treeshake(const prog::Program& prog) -> prog::Program;
+
+auto inlineCalls(const prog::Program& prog) -> prog::Program;
 
 } // namespace opt

--- a/include/prog/copy.hpp
+++ b/include/prog/copy.hpp
@@ -5,6 +5,7 @@ namespace prog {
 
 auto copyType(const Program& from, Program* to, sym::TypeId id) -> bool;
 
-auto copyFunc(const Program& from, Program* to, sym::FuncId id) -> bool;
+auto copyFunc(const Program& from, Program* to, sym::FuncId id, prog::expr::Rewriter* rewriter)
+    -> bool;
 
 } // namespace prog

--- a/include/prog/copy.hpp
+++ b/include/prog/copy.hpp
@@ -1,11 +1,18 @@
 #pragma once
 #include "prog/program.hpp"
+#include "prog/sym/const_decl_table.hpp"
+#include <functional>
+#include <memory>
 
 namespace prog {
 
+using RewriterFactory = typename std::function<std::unique_ptr<expr::Rewriter>(
+    const Program& prog, sym::FuncId funcId, sym::ConstDeclTable* consts)>;
+
 auto copyType(const Program& from, Program* to, sym::TypeId id) -> bool;
 
-auto copyFunc(const Program& from, Program* to, sym::FuncId id, prog::expr::Rewriter* rewriter)
+auto copyFunc(
+    const Program& from, Program* to, sym::FuncId id, const RewriterFactory& rewriterFactory = {})
     -> bool;
 
 } // namespace prog

--- a/include/prog/expr/node.hpp
+++ b/include/prog/expr/node.hpp
@@ -7,6 +7,8 @@
 
 namespace prog::expr {
 
+class Rewriter;
+
 class Node {
   friend auto operator<<(std::ostream& out, const Node& rhs) -> std::ostream&;
 
@@ -26,7 +28,7 @@ public:
   [[nodiscard]] virtual auto getType() const noexcept -> sym::TypeId       = 0;
   [[nodiscard]] virtual auto toString() const -> std::string               = 0;
 
-  [[nodiscard]] virtual auto clone() const -> std::unique_ptr<Node> = 0;
+  [[nodiscard]] virtual auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> = 0;
 
   virtual auto accept(NodeVisitor* visitor) const -> void = 0;
 

--- a/include/prog/expr/node.hpp
+++ b/include/prog/expr/node.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "prog/expr/node_kind.hpp"
 #include "prog/expr/node_visitor.hpp"
 #include "prog/sym/type_id.hpp"
 #include <iostream>
@@ -23,6 +24,8 @@ public:
   virtual auto operator==(const Node& rhs) const noexcept -> bool = 0;
   virtual auto operator!=(const Node& rhs) const noexcept -> bool = 0;
 
+  [[nodiscard]] auto getKind() const -> NodeKind;
+
   [[nodiscard]] virtual auto operator[](unsigned int) const -> const Node& = 0;
   [[nodiscard]] virtual auto getChildCount() const -> unsigned int         = 0;
   [[nodiscard]] virtual auto getType() const noexcept -> sym::TypeId       = 0;
@@ -32,8 +35,20 @@ public:
 
   virtual auto accept(NodeVisitor* visitor) const -> void = 0;
 
+  // Downcast to a node implementation, throws if node is not of the child type.
+  template <typename NodeType>
+  [[nodiscard]] auto downcast() const -> const NodeType* {
+    if (getKind() != NodeType::getKind()) {
+      throw std::logic_error{"Node is of incorrect type"};
+    }
+    return static_cast<const NodeType*>(this); // NOLINT: Downcast, we've checked it safe.
+  }
+
 protected:
-  Node() = default;
+  explicit Node(NodeKind kind);
+
+private:
+  NodeKind m_kind;
 };
 
 using NodePtr = std::unique_ptr<Node>;

--- a/include/prog/expr/node_assign.hpp
+++ b/include/prog/expr/node_assign.hpp
@@ -16,6 +16,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Assign; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_assign.hpp
+++ b/include/prog/expr/node_assign.hpp
@@ -21,7 +21,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getConst() const noexcept -> sym::ConstId;
 

--- a/include/prog/expr/node_call.hpp
+++ b/include/prog/expr/node_call.hpp
@@ -25,7 +25,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getFunc() const noexcept -> sym::FuncId;
   [[nodiscard]] auto isFork() const noexcept -> bool;

--- a/include/prog/expr/node_call.hpp
+++ b/include/prog/expr/node_call.hpp
@@ -20,6 +20,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Call; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_call_dyn.hpp
+++ b/include/prog/expr/node_call_dyn.hpp
@@ -25,7 +25,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto isFork() const noexcept -> bool;
 

--- a/include/prog/expr/node_call_dyn.hpp
+++ b/include/prog/expr/node_call_dyn.hpp
@@ -20,6 +20,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::CallDyn; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_call_self.hpp
+++ b/include/prog/expr/node_call_self.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 

--- a/include/prog/expr/node_call_self.hpp
+++ b/include/prog/expr/node_call_self.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::CallSelf; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_closure.hpp
+++ b/include/prog/expr/node_closure.hpp
@@ -15,6 +15,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Closure; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_closure.hpp
+++ b/include/prog/expr/node_closure.hpp
@@ -20,7 +20,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getFunc() const noexcept -> sym::FuncId;
 

--- a/include/prog/expr/node_const.hpp
+++ b/include/prog/expr/node_const.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Const; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_const.hpp
+++ b/include/prog/expr/node_const.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getId() const noexcept -> sym::ConstId;
 

--- a/include/prog/expr/node_fail.hpp
+++ b/include/prog/expr/node_fail.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 

--- a/include/prog/expr/node_fail.hpp
+++ b/include/prog/expr/node_fail.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Fail; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_field.hpp
+++ b/include/prog/expr/node_field.hpp
@@ -19,7 +19,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getId() const noexcept -> sym::FieldId;
 

--- a/include/prog/expr/node_field.hpp
+++ b/include/prog/expr/node_field.hpp
@@ -14,6 +14,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Field; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_group.hpp
+++ b/include/prog/expr/node_group.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 

--- a/include/prog/expr/node_group.hpp
+++ b/include/prog/expr/node_group.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Group; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_kind.hpp
+++ b/include/prog/expr/node_kind.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace prog::expr {
+
+enum class NodeKind {
+  Assign,
+  CallDyn,
+  CallSelf,
+  Call,
+  Closure,
+  Const,
+  Fail,
+  Field,
+  Group,
+  LitBool,
+  LitChar,
+  LitEnum,
+  LitFloat,
+  LitFunc,
+  LitInt,
+  LitLong,
+  LitString,
+  Switch,
+  UnionCheck,
+  UnionGet,
+};
+
+} // namespace prog::expr

--- a/include/prog/expr/node_lit_bool.hpp
+++ b/include/prog/expr/node_lit_bool.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitBool; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_bool.hpp
+++ b/include/prog/expr/node_lit_bool.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getVal() const noexcept -> bool;
 

--- a/include/prog/expr/node_lit_char.hpp
+++ b/include/prog/expr/node_lit_char.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getVal() const noexcept -> uint8_t;
 

--- a/include/prog/expr/node_lit_char.hpp
+++ b/include/prog/expr/node_lit_char.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitChar; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_enum.hpp
+++ b/include/prog/expr/node_lit_enum.hpp
@@ -19,7 +19,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getName() const noexcept -> const std::string&;
   [[nodiscard]] auto getVal() const noexcept -> int32_t;

--- a/include/prog/expr/node_lit_enum.hpp
+++ b/include/prog/expr/node_lit_enum.hpp
@@ -14,6 +14,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitEnum; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_float.hpp
+++ b/include/prog/expr/node_lit_float.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitFloat; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_float.hpp
+++ b/include/prog/expr/node_lit_float.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getVal() const noexcept -> float;
 

--- a/include/prog/expr/node_lit_func.hpp
+++ b/include/prog/expr/node_lit_func.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getFunc() const noexcept -> sym::FuncId;
 

--- a/include/prog/expr/node_lit_func.hpp
+++ b/include/prog/expr/node_lit_func.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitFunc; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_int.hpp
+++ b/include/prog/expr/node_lit_int.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitInt; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_int.hpp
+++ b/include/prog/expr/node_lit_int.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getVal() const noexcept -> int32_t;
 

--- a/include/prog/expr/node_lit_long.hpp
+++ b/include/prog/expr/node_lit_long.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getVal() const noexcept -> int64_t;
 

--- a/include/prog/expr/node_lit_long.hpp
+++ b/include/prog/expr/node_lit_long.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitLong; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_string.hpp
+++ b/include/prog/expr/node_lit_string.hpp
@@ -13,6 +13,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::LitString; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_lit_string.hpp
+++ b/include/prog/expr/node_lit_string.hpp
@@ -18,7 +18,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getVal() const noexcept -> const std::string&;
 

--- a/include/prog/expr/node_switch.hpp
+++ b/include/prog/expr/node_switch.hpp
@@ -21,7 +21,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getConditions() const noexcept -> const std::vector<NodePtr>&;
   [[nodiscard]] auto getBranches() const noexcept -> const std::vector<NodePtr>&;

--- a/include/prog/expr/node_switch.hpp
+++ b/include/prog/expr/node_switch.hpp
@@ -16,6 +16,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::Switch; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_union_check.hpp
+++ b/include/prog/expr/node_union_check.hpp
@@ -19,7 +19,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getTargetType() const noexcept -> sym::TypeId;
 

--- a/include/prog/expr/node_union_check.hpp
+++ b/include/prog/expr/node_union_check.hpp
@@ -14,6 +14,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::UnionCheck; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/node_union_get.hpp
+++ b/include/prog/expr/node_union_get.hpp
@@ -20,7 +20,7 @@ public:
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;
   [[nodiscard]] auto toString() const -> std::string override;
 
-  [[nodiscard]] auto clone() const -> std::unique_ptr<Node> override;
+  [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getConst() const noexcept -> sym::ConstId;
   [[nodiscard]] auto getTargetType() const noexcept -> sym::TypeId;

--- a/include/prog/expr/node_union_get.hpp
+++ b/include/prog/expr/node_union_get.hpp
@@ -15,6 +15,8 @@ public:
   auto operator==(const Node& rhs) const noexcept -> bool override;
   auto operator!=(const Node& rhs) const noexcept -> bool override;
 
+  [[nodiscard]] constexpr static auto getKind() { return NodeKind::UnionGet; }
+
   [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
   [[nodiscard]] auto getChildCount() const -> unsigned int override;
   [[nodiscard]] auto getType() const noexcept -> sym::TypeId override;

--- a/include/prog/expr/rewriter.hpp
+++ b/include/prog/expr/rewriter.hpp
@@ -5,6 +5,14 @@ namespace prog::expr {
 
 class Rewriter {
 public:
+  Rewriter()                        = default;
+  Rewriter(const Rewriter& rhs)     = delete;
+  Rewriter(Rewriter&& rhs) noexcept = delete;
+  virtual ~Rewriter()               = default;
+
+  auto operator=(const Rewriter& rhs) -> Rewriter& = delete;
+  auto operator=(Rewriter&& rhs) noexcept -> Rewriter& = delete;
+
   [[nodiscard]] virtual auto rewrite(const Node& expr) -> NodePtr = 0;
 };
 

--- a/include/prog/expr/rewriter.hpp
+++ b/include/prog/expr/rewriter.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "prog/expr/node.hpp"
+
+namespace prog::expr {
+
+class Rewriter {
+public:
+  [[nodiscard]] virtual auto rewrite(const Node& expr) -> NodePtr = 0;
+};
+
+} // namespace prog::expr

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -47,7 +47,7 @@ public:
   ~Program()                      = default;
 
   auto operator=(const Program& rhs) -> Program& = delete;
-  auto operator=(Program&& rhs) noexcept -> Program& = delete;
+  auto operator=(Program&& rhs) noexcept -> Program& = default;
 
   [[nodiscard]] auto beginTypeDecls() const -> TypeDeclIterator { return m_typeDecls.begin(); }
   [[nodiscard]] auto endTypeDecls() const -> TypeDeclIterator { return m_typeDecls.end(); }

--- a/include/prog/sym/const_id.hpp
+++ b/include/prog/sym/const_id.hpp
@@ -5,6 +5,7 @@ namespace prog::sym {
 
 class ConstId final {
   friend class ConstDeclTable;
+  friend class ConstIdHasher;
   friend auto operator<<(std::ostream& out, const ConstId& rhs) -> std::ostream&;
 
 public:

--- a/include/prog/sym/const_id_hasher.hpp
+++ b/include/prog/sym/const_id_hasher.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "prog/sym/const_id.hpp"
+
+namespace prog::sym {
+
+class ConstIdHasher final {
+public:
+  auto operator()(const ConstId& id) const -> std::size_t;
+};
+
+} // namespace prog::sym

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -27,7 +27,7 @@ public:
   ~FuncDeclTable()                            = default;
 
   auto operator=(const FuncDeclTable& rhs) -> FuncDeclTable& = delete;
-  auto operator=(FuncDeclTable&& rhs) noexcept -> FuncDeclTable& = delete;
+  auto operator=(FuncDeclTable&& rhs) noexcept -> FuncDeclTable& = default;
 
   [[nodiscard]] auto operator[](FuncId id) const -> const FuncDecl&;
 

--- a/include/prog/sym/func_def_table.hpp
+++ b/include/prog/sym/func_def_table.hpp
@@ -18,7 +18,7 @@ public:
   ~FuncDefTable()                           = default;
 
   auto operator=(const FuncDefTable& rhs) -> FuncDefTable& = delete;
-  auto operator=(FuncDefTable&& rhs) noexcept -> FuncDefTable& = delete;
+  auto operator=(FuncDefTable&& rhs) noexcept -> FuncDefTable& = default;
 
   [[nodiscard]] auto operator[](sym::FuncId id) const -> const FuncDef&;
 

--- a/include/prog/sym/type_decl_table.hpp
+++ b/include/prog/sym/type_decl_table.hpp
@@ -17,7 +17,7 @@ public:
   ~TypeDeclTable()                            = default;
 
   auto operator=(const TypeDeclTable& rhs) -> TypeDeclTable& = delete;
-  auto operator=(TypeDeclTable&& rhs) noexcept -> TypeDeclTable& = delete;
+  auto operator=(TypeDeclTable&& rhs) noexcept -> TypeDeclTable& = default;
 
   [[nodiscard]] auto operator[](TypeId id) const -> const TypeDecl&;
 

--- a/include/prog/sym/type_def_table.hpp
+++ b/include/prog/sym/type_def_table.hpp
@@ -22,7 +22,7 @@ public:
   ~TypeDefTable()                           = default;
 
   auto operator=(const TypeDefTable& rhs) -> TypeDefTable& = delete;
-  auto operator=(TypeDefTable&& rhs) noexcept -> TypeDefTable& = delete;
+  auto operator=(TypeDefTable&& rhs) noexcept -> TypeDefTable& = default;
 
   [[nodiscard]] auto operator[](sym::TypeId id) const -> const TypeDef&;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(prog STATIC
 
   prog/sym/const_decl_table.cpp
   prog/sym/const_decl.cpp
+  prog/sym/const_id_hasher.cpp
   prog/sym/const_id.cpp
   prog/sym/const_kind.cpp
   prog/sym/delegate_def.cpp
@@ -197,8 +198,14 @@ target_include_directories(frontend PRIVATE frontend)
 
 # Opt (optimiser).
 add_library(opt STATIC
-  opt/internal/find_funcs.cpp
-  opt/internal/find_types.cpp
+  opt/internal/const_remapper.cpp
+  opt/internal/find_called_funcs.cpp
+  opt/internal/find_used_funcs.cpp
+  opt/internal/find_used_types.cpp
+  opt/internal/func_matchers.cpp
+  opt/internal/prog_rewrite.cpp
+  opt/inline_calls.cpp
+  opt/optimize.cpp
   opt/treeshake.cpp)
 target_compile_features(opt PRIVATE cxx_std_17)
 if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,7 +204,7 @@ add_library(opt STATIC
   opt/internal/find_used_types.cpp
   opt/internal/func_matchers.cpp
   opt/internal/prog_rewrite.cpp
-  opt/inline_calls.cpp
+  opt/call_inline.cpp
   opt/optimize.cpp
   opt/treeshake.cpp)
 target_compile_features(opt PRIVATE cxx_std_17)

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -12,9 +12,9 @@
 
 namespace opt {
 
-class FuncInlineRewriter final : public prog::expr::Rewriter {
+class CallInlineRewriter final : public prog::expr::Rewriter {
 public:
-  FuncInlineRewriter(
+  CallInlineRewriter(
       const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::ConstDeclTable* consts) :
       m_prog{prog}, m_funcId{funcId}, m_consts{consts} {
 
@@ -111,7 +111,7 @@ auto inlineCalls(const prog::Program& prog) -> prog::Program {
   return internal::rewrite(
       prog,
       [](const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::ConstDeclTable* consts) {
-        return std::make_unique<FuncInlineRewriter>(prog, funcId, consts);
+        return std::make_unique<CallInlineRewriter>(prog, funcId, consts);
       });
 }
 

--- a/src/opt/inline_calls.cpp
+++ b/src/opt/inline_calls.cpp
@@ -1,0 +1,118 @@
+#include "internal/const_remapper.hpp"
+#include "internal/func_matchers.hpp"
+#include "internal/prog_rewrite.hpp"
+#include "prog/expr/node_assign.hpp"
+#include "prog/expr/node_call.hpp"
+#include "prog/expr/node_group.hpp"
+#include "prog/expr/rewriter.hpp"
+#include "prog/program.hpp"
+#include "prog/sym/const_id_hasher.hpp"
+#include <sstream>
+#include <unordered_set>
+
+namespace opt {
+
+class FuncInlineRewriter final : public prog::expr::Rewriter {
+public:
+  FuncInlineRewriter(
+      const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::ConstDeclTable* consts) :
+      m_prog{prog}, m_funcId{funcId}, m_consts{consts} {
+
+    if (m_consts == nullptr) {
+      throw std::invalid_argument{"Consts table cannot be null"};
+    }
+  }
+
+  auto isInlinable(const prog::expr::CallExprNode* callExpr) {
+    const auto funcId = callExpr->getFunc();
+
+    // Forks or non-user funcs are not inlinable.
+    if (callExpr->isFork() || !internal::isUserFunc(m_prog, funcId)) {
+      return false;
+    }
+
+    // Recursive calls cannot be inlined.
+    if (funcId == m_funcId) {
+      return false;
+    }
+
+    // Recursive functions are not inlined.
+    if (internal::isRecursive(m_prog, funcId)) {
+      return false;
+    }
+
+    // TODO(bastian): Consider adding size constraints to the functions we inline.
+    return true;
+  }
+
+  auto rewrite(const prog::expr::Node& expr) -> prog::expr::NodePtr override {
+    if (expr.getKind() == prog::expr::NodeKind::Call) {
+      auto* callExpr = expr.downcast<prog::expr::CallExprNode>();
+      if (isInlinable(callExpr)) {
+        return inlineCall(callExpr);
+      }
+    }
+    return expr.clone(this);
+  }
+
+  auto inlineCall(const prog::expr::CallExprNode* callExpr) -> prog::expr::NodePtr {
+    const auto& tgtFuncId  = callExpr->getFunc();
+    const auto& tgtFuncDef = m_prog.getFuncDef(tgtFuncId);
+    const auto& tgtConsts  = tgtFuncDef.getConsts();
+
+    // Register all the consts of the target function into this function.
+    auto constMapping = registerTargetConsts(tgtConsts);
+
+    auto tgtInputs = tgtConsts.getInputs();
+    auto exprs     = std::vector<prog::expr::NodePtr>{};
+    exprs.reserve(tgtInputs.size() + 1);
+
+    // Create expressions to assign the constants that used to be inputs to the target function.
+    for (auto i = 0U; i != tgtInputs.size(); ++i) {
+      exprs.push_back(prog::expr::assignExprNode(
+          *m_consts, constMapping.find(tgtInputs[i])->second, rewrite((*callExpr)[i])));
+    }
+
+    // Remap the constants to point to the newly registered constants.
+    auto remapper     = internal::ConstRemapper{m_prog, *m_consts, constMapping};
+    auto remappedExpr = remapper.rewrite(tgtFuncDef.getExpr());
+
+    // Run another 'rewrite' pass on the remapped expression so we can also inline calls inside the
+    // inlined function body.
+    exprs.push_back(rewrite(*remappedExpr));
+
+    return exprs.size() > 1 ? prog::expr::groupExprNode(std::move(exprs)) : std::move(exprs[0]);
+  }
+
+  auto registerTargetConsts(const prog::sym::ConstDeclTable& tgtConsts)
+      -> internal::ConstRemapTable {
+
+    auto table = internal::ConstRemapTable{};
+    for (const auto tgtConstId : tgtConsts.getAll()) {
+      const auto& tgtConstDecl = tgtConsts[tgtConstId];
+
+      std::ostringstream oss;
+      oss << "__inlined_" << m_consts->getCount() << '_' << tgtConstDecl.getName();
+
+      auto remappedConstId = m_consts->registerLocal(oss.str(), tgtConstDecl.getType());
+
+      table.insert({tgtConstId, remappedConstId});
+    }
+    return table;
+  }
+
+private:
+  const prog::Program& m_prog;
+  prog::sym::FuncId m_funcId;
+  prog::sym::ConstDeclTable* m_consts;
+};
+
+auto inlineCalls(const prog::Program& prog) -> prog::Program {
+  return internal::rewrite(
+      prog,
+      [](const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::ConstDeclTable* consts) {
+        return std::make_unique<FuncInlineRewriter>(prog, funcId, consts);
+      });
+}
+
+} // namespace opt

--- a/src/opt/internal/const_remapper.cpp
+++ b/src/opt/internal/const_remapper.cpp
@@ -1,0 +1,41 @@
+#include "internal/const_remapper.hpp"
+
+namespace opt::internal {
+
+ConstRemapper::ConstRemapper(
+    const prog::Program& prog,
+    const prog::sym::ConstDeclTable& consts,
+    const ConstRemapTable& remapTable) :
+    m_prog{prog}, m_consts{consts}, m_remapTable{remapTable} {}
+
+auto ConstRemapper::rewrite(const prog::expr::Node& expr) -> prog::expr::NodePtr {
+
+  switch (expr.getKind()) {
+  case prog::expr::NodeKind::Assign: {
+    auto* assignExpr = expr.downcast<prog::expr::AssignExprNode>();
+    return prog::expr::assignExprNode(
+        m_consts, remap(assignExpr->getConst()), rewrite((*assignExpr)[0]));
+  }
+  case prog::expr::NodeKind::Const: {
+    auto* constExpr = expr.downcast<prog::expr::ConstExprNode>();
+    return prog::expr::constExprNode(m_consts, remap(constExpr->getId()));
+  }
+  case prog::expr::NodeKind::UnionGet: {
+    auto* unionGetExpr = expr.downcast<prog::expr::UnionGetExprNode>();
+    return prog::expr::unionGetExprNode(
+        m_prog, rewrite((*unionGetExpr)[0]), m_consts, remap(unionGetExpr->getConst()));
+  }
+  default:
+    return expr.clone(this);
+  }
+}
+
+auto ConstRemapper::remap(prog::sym::ConstId constId) -> prog::sym::ConstId {
+  auto itr = m_remapTable.find(constId);
+  if (itr == m_remapTable.end()) {
+    throw std::invalid_argument{"Constant-id not found in the remap table"};
+  }
+  return itr->second;
+}
+
+} // namespace opt::internal

--- a/src/opt/internal/const_remapper.hpp
+++ b/src/opt/internal/const_remapper.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "prog/expr/node_assign.hpp"
+#include "prog/expr/nodes.hpp"
+#include "prog/expr/rewriter.hpp"
+#include "prog/sym/const_decl_table.hpp"
+#include "prog/sym/const_id_hasher.hpp"
+#include <unordered_map>
+
+namespace opt::internal {
+
+using ConstRemapTable =
+    typename std::unordered_map<prog::sym::ConstId, prog::sym::ConstId, prog::sym::ConstIdHasher>;
+
+class ConstRemapper final : public prog::expr::Rewriter {
+public:
+  ConstRemapper(
+      const prog::Program& prog,
+      const prog::sym::ConstDeclTable& consts,
+      const ConstRemapTable& remapTable);
+
+  auto rewrite(const prog::expr::Node& expr) -> prog::expr::NodePtr override;
+
+private:
+  const prog::Program& m_prog;
+  const prog::sym::ConstDeclTable& m_consts;
+  const ConstRemapTable& m_remapTable;
+
+  [[nodiscard]] auto remap(prog::sym::ConstId constId) -> prog::sym::ConstId;
+};
+
+} // namespace opt::internal

--- a/src/opt/internal/find_called_funcs.cpp
+++ b/src/opt/internal/find_called_funcs.cpp
@@ -1,30 +1,21 @@
-#include "find_funcs.hpp"
+#include "find_called_funcs.hpp"
 #include "prog/expr/nodes.hpp"
 
 namespace opt::internal {
 
-FindFuncs::FindFuncs(const prog::Program& prog, FuncSet* funcs) : m_prog{prog}, m_funcs{funcs} {
+FindCalledFuncs::FindCalledFuncs(const prog::Program& prog, FuncSet* funcs) :
+    m_prog{prog}, m_funcs{funcs} {
   if (m_funcs == nullptr) {
     throw std::invalid_argument{"Function set cannot be null"};
   }
 }
 
-auto FindFuncs::visit(const prog::expr::CallExprNode& n) -> void {
+auto FindCalledFuncs::visit(const prog::expr::CallExprNode& n) -> void {
   prog::expr::DeepNodeVisitor::visit(n);
   markFunc(n.getFunc());
 }
 
-auto FindFuncs::visit(const prog::expr::ClosureNode& n) -> void {
-  prog::expr::DeepNodeVisitor::visit(n);
-  markFunc(n.getFunc());
-}
-
-auto FindFuncs::visit(const prog::expr::LitFuncNode& n) -> void {
-  prog::expr::DeepNodeVisitor::visit(n);
-  markFunc(n.getFunc());
-}
-
-auto FindFuncs::markFunc(prog::sym::FuncId func) -> void {
+auto FindCalledFuncs::markFunc(prog::sym::FuncId func) -> void {
   if (!m_funcs->insert(func).second) {
     return;
   }

--- a/src/opt/internal/find_called_funcs.hpp
+++ b/src/opt/internal/find_called_funcs.hpp
@@ -6,16 +6,14 @@
 
 namespace opt::internal {
 
-class FindFuncs final : public prog::expr::DeepNodeVisitor {
+class FindCalledFuncs final : public prog::expr::DeepNodeVisitor {
 
   using FuncSet = typename std::unordered_set<prog::sym::FuncId, prog::sym::FuncIdHasher>;
 
 public:
-  FindFuncs(const prog::Program& prog, FuncSet* funcs);
+  FindCalledFuncs(const prog::Program& prog, FuncSet* funcs);
 
   auto visit(const prog::expr::CallExprNode& n) -> void override;
-  auto visit(const prog::expr::ClosureNode& n) -> void override;
-  auto visit(const prog::expr::LitFuncNode& n) -> void override;
 
 private:
   const prog::Program& m_prog;

--- a/src/opt/internal/find_used_funcs.cpp
+++ b/src/opt/internal/find_used_funcs.cpp
@@ -1,0 +1,41 @@
+#include "find_used_funcs.hpp"
+#include "prog/expr/nodes.hpp"
+
+namespace opt::internal {
+
+FindUsedFuncs::FindUsedFuncs(const prog::Program& prog, FuncSet* funcs) :
+    m_prog{prog}, m_funcs{funcs} {
+  if (m_funcs == nullptr) {
+    throw std::invalid_argument{"Function set cannot be null"};
+  }
+}
+
+auto FindUsedFuncs::visit(const prog::expr::CallExprNode& n) -> void {
+  prog::expr::DeepNodeVisitor::visit(n);
+  markFunc(n.getFunc());
+}
+
+auto FindUsedFuncs::visit(const prog::expr::ClosureNode& n) -> void {
+  prog::expr::DeepNodeVisitor::visit(n);
+  markFunc(n.getFunc());
+}
+
+auto FindUsedFuncs::visit(const prog::expr::LitFuncNode& n) -> void {
+  prog::expr::DeepNodeVisitor::visit(n);
+  markFunc(n.getFunc());
+}
+
+auto FindUsedFuncs::markFunc(prog::sym::FuncId func) -> void {
+  if (!m_funcs->insert(func).second) {
+    return;
+  }
+
+  // Visit any newly found user functions.
+  const auto& funcDecl = m_prog.getFuncDecl(func);
+  if (funcDecl.getKind() == prog::sym::FuncKind::User) {
+    const auto& funcDef = m_prog.getFuncDef(func);
+    funcDef.getExpr().accept(this);
+  }
+}
+
+} // namespace opt::internal

--- a/src/opt/internal/find_used_funcs.hpp
+++ b/src/opt/internal/find_used_funcs.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "prog/expr/node_visitor_deep.hpp"
+#include "prog/program.hpp"
+#include "prog/sym/func_id_hasher.hpp"
+#include <unordered_set>
+
+namespace opt::internal {
+
+class FindUsedFuncs final : public prog::expr::DeepNodeVisitor {
+
+  using FuncSet = typename std::unordered_set<prog::sym::FuncId, prog::sym::FuncIdHasher>;
+
+public:
+  FindUsedFuncs(const prog::Program& prog, FuncSet* funcs);
+
+  auto visit(const prog::expr::CallExprNode& n) -> void override;
+  auto visit(const prog::expr::ClosureNode& n) -> void override;
+  auto visit(const prog::expr::LitFuncNode& n) -> void override;
+
+private:
+  const prog::Program& m_prog;
+  FuncSet* m_funcs;
+
+  auto markFunc(prog::sym::FuncId func) -> void;
+};
+
+} // namespace opt::internal

--- a/src/opt/internal/find_used_types.cpp
+++ b/src/opt/internal/find_used_types.cpp
@@ -1,4 +1,4 @@
-#include "find_types.hpp"
+#include "find_used_types.hpp"
 #include "prog/expr/nodes.hpp"
 #include "prog/sym/delegate_def.hpp"
 #include "prog/sym/struct_def.hpp"
@@ -6,13 +6,14 @@
 
 namespace opt::internal {
 
-FindTypes::FindTypes(const prog::Program& prog, TypeSet* types) : m_prog{prog}, m_types{types} {
+FindUsedTypes::FindUsedTypes(const prog::Program& prog, TypeSet* types) :
+    m_prog{prog}, m_types{types} {
   if (m_types == nullptr) {
     throw std::invalid_argument{"Type set cannot be null"};
   }
 }
 
-auto FindTypes::markType(prog::sym::TypeId type) -> void {
+auto FindUsedTypes::markType(prog::sym::TypeId type) -> void {
   if (!m_types->insert(type).second) {
     return;
   }
@@ -55,7 +56,7 @@ auto FindTypes::markType(prog::sym::TypeId type) -> void {
   }
 }
 
-auto FindTypes::visitNode(const prog::expr::Node* n) -> void {
+auto FindUsedTypes::visitNode(const prog::expr::Node* n) -> void {
   prog::expr::DeepNodeVisitor::visitNode(n);
   markType(n->getType());
 }

--- a/src/opt/internal/find_used_types.hpp
+++ b/src/opt/internal/find_used_types.hpp
@@ -6,12 +6,12 @@
 
 namespace opt::internal {
 
-class FindTypes final : public prog::expr::DeepNodeVisitor {
+class FindUsedTypes final : public prog::expr::DeepNodeVisitor {
 
   using TypeSet = typename std::unordered_set<prog::sym::TypeId, prog::sym::TypeIdHasher>;
 
 public:
-  FindTypes(const prog::Program& prog, TypeSet* types);
+  FindUsedTypes(const prog::Program& prog, TypeSet* types);
 
   auto markType(prog::sym::TypeId type) -> void;
 

--- a/src/opt/internal/func_matchers.cpp
+++ b/src/opt/internal/func_matchers.cpp
@@ -1,0 +1,38 @@
+#include "internal/func_matchers.hpp"
+#include "internal/find_called_funcs.hpp"
+#include "prog/expr/node_call.hpp"
+#include "prog/expr/node_visitor.hpp"
+#include <unordered_set>
+
+namespace opt::internal {
+
+auto isUserFunc(const prog::Program& prog, prog::sym::FuncId funcId) -> bool {
+  const auto& decl = prog.getFuncDecl(funcId);
+  return decl.getKind() == prog::sym::FuncKind::User;
+}
+
+auto isRecursive(const prog::Program& prog, prog::sym::FuncId funcId) -> bool {
+  const auto& funcDecl = prog.getFuncDecl(funcId);
+  if (funcDecl.getKind() != prog::sym::FuncKind::User) {
+    return false;
+  }
+
+  // Check if function contains a self-call.
+  if (matchesExpr(prog, funcId, [](const prog::expr::Node& n) {
+        return n.getKind() == prog::expr::NodeKind::CallSelf;
+      })) {
+    return true;
+  }
+
+  const auto& funcDef = prog.getFuncDef(funcId);
+
+  // Gather all the functions this function (indirectly) calls.
+  auto calledFuncs     = std::unordered_set<prog::sym::FuncId, prog::sym::FuncIdHasher>{};
+  auto findCalledFuncs = FindCalledFuncs{prog, &calledFuncs};
+  funcDef.getExpr().accept(&findCalledFuncs);
+
+  // Check if this function ever (indirectly) calls itself.
+  return calledFuncs.find(funcId) != calledFuncs.end();
+}
+
+} // namespace opt::internal

--- a/src/opt/internal/func_matchers.hpp
+++ b/src/opt/internal/func_matchers.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include "prog/expr/node_visitor_deep.hpp"
+#include "prog/program.hpp"
+
+namespace opt::internal {
+
+template <typename UnaryPredicate>
+class ExprMatcher final : public prog::expr::DeepNodeVisitor {
+  static_assert(std::is_invocable_r<bool, UnaryPredicate, const prog::expr::Node&>::value);
+
+public:
+  explicit ExprMatcher(UnaryPredicate pred) : m_pred{pred}, m_found{false} {}
+
+  [[nodiscard]] auto isFound() const { return m_found; }
+
+protected:
+  auto visitNode(const prog::expr::Node* n) -> void override {
+    if (m_pred(*n)) {
+      m_found = true;
+    } else {
+      prog::expr::DeepNodeVisitor::visitNode(n);
+    }
+  }
+
+private:
+  UnaryPredicate m_pred;
+  bool m_found;
+};
+
+template <typename UnaryPredicate>
+auto matchesExpr(const prog::Program& prog, prog::sym::FuncId funcId, UnaryPredicate predicate) {
+  const auto& funcDecl = prog.getFuncDecl(funcId);
+
+  // Non-user funcs have no expressions.
+  if (funcDecl.getKind() != prog::sym::FuncKind::User) {
+    return false;
+  }
+
+  const auto& funcDef = prog.getFuncDef(funcId);
+  auto matcher        = ExprMatcher{predicate};
+  funcDef.getExpr().accept(&matcher);
+
+  return matcher.isFound();
+}
+
+auto isUserFunc(const prog::Program& prog, prog::sym::FuncId funcId) -> bool;
+
+auto isRecursive(const prog::Program& prog, prog::sym::FuncId funcId) -> bool;
+
+} // namespace opt::internal

--- a/src/opt/internal/prog_rewrite.cpp
+++ b/src/opt/internal/prog_rewrite.cpp
@@ -1,0 +1,33 @@
+#include "internal/prog_rewrite.hpp"
+#include "prog/copy.hpp"
+
+namespace opt::internal {
+
+auto rewrite(const prog::Program& prog, const prog::RewriterFactory& rewriterFactory)
+    -> prog::Program {
+
+  /* Create a new program and copy the types, funcs and execute statements over. For the funcs we
+   * rewrite them before copying them over. */
+
+  auto result = prog::Program{};
+
+  // Copy all the types to the new program.
+  for (auto typeItr = prog.beginTypeDecls(); typeItr != prog.endTypeDecls(); ++typeItr) {
+    prog::copyType(prog, &result, typeItr->first);
+  }
+
+  // Rewrite and copy all the functions to the new program.
+  for (auto funcItr = prog.beginFuncDecls(); funcItr != prog.endFuncDecls(); ++funcItr) {
+    const auto& funcId = funcItr->first;
+    prog::copyFunc(prog, &result, funcId, rewriterFactory);
+  }
+
+  // Copy all the execute statements to the new program.
+  for (auto execItr = prog.beginExecStmts(); execItr != prog.endExecStmts(); ++execItr) {
+    result.addExecStmt(execItr->getConsts(), execItr->getExpr().clone(nullptr));
+  }
+
+  return result;
+}
+
+} // namespace opt::internal

--- a/src/opt/internal/prog_rewrite.hpp
+++ b/src/opt/internal/prog_rewrite.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "prog/copy.hpp"
+#include "prog/program.hpp"
+
+namespace opt::internal {
+
+// Rewrite all the functions to a new program.
+auto rewrite(const prog::Program& prog, const prog::RewriterFactory& rewriterFactory)
+    -> prog::Program;
+
+} // namespace opt::internal

--- a/src/opt/optimize.cpp
+++ b/src/opt/optimize.cpp
@@ -1,0 +1,19 @@
+#include "opt/opt.hpp"
+
+namespace opt {
+
+auto optimize(const prog::Program& prog) -> prog::Program {
+  // Remove any unused types and functions.
+  // We start with one pass of treeshaking to avoid inlining unused functions.
+  auto result = treeshake(prog);
+
+  // Inline possible functions.
+  result = inlineCalls(result);
+
+  // Remove any functions that have become unused due to inlining.
+  result = treeshake(result);
+
+  return result;
+}
+
+} // namespace opt

--- a/src/opt/treeshake.cpp
+++ b/src/opt/treeshake.cpp
@@ -46,13 +46,13 @@ auto treeshake(const prog::Program& prog) -> prog::Program {
   // Create a new program and copy the used functions, types and the exec statements.
   auto result = prog::Program{};
   for (const auto func : funcs) {
-    prog::copyFunc(prog, &result, func);
+    prog::copyFunc(prog, &result, func, nullptr);
   }
   for (const auto type : types) {
     prog::copyType(prog, &result, type);
   }
   for (auto execItr = prog.beginExecStmts(); execItr != prog.endExecStmts(); ++execItr) {
-    result.addExecStmt(execItr->getConsts(), execItr->getExpr().clone());
+    result.addExecStmt(execItr->getConsts(), execItr->getExpr().clone(nullptr));
   }
   return result;
 }

--- a/src/opt/treeshake.cpp
+++ b/src/opt/treeshake.cpp
@@ -1,5 +1,5 @@
-#include "internal/find_funcs.hpp"
-#include "internal/find_types.hpp"
+#include "internal/find_used_funcs.hpp"
+#include "internal/find_used_types.hpp"
 #include "opt/opt.hpp"
 #include "prog/copy.hpp"
 #include "prog/sym/func_id_hasher.hpp"
@@ -15,12 +15,12 @@ auto treeshake(const prog::Program& prog) -> prog::Program {
   auto types = std::unordered_set<prog::sym::TypeId, prog::sym::TypeIdHasher>{};
 
   // Find all functions that are called from the execute statements.
-  auto findFuncs = internal::FindFuncs{prog, &funcs};
+  auto findFuncs = internal::FindUsedFuncs{prog, &funcs};
   for (auto itr = prog.beginExecStmts(); itr != prog.endExecStmts(); ++itr) {
     itr->getExpr().accept(&findFuncs);
   }
 
-  auto findTypes = internal::FindTypes{prog, &types};
+  auto findTypes = internal::FindUsedTypes{prog, &types};
 
   // Find all types used in the execute statements.
   for (auto itr = prog.beginExecStmts(); itr != prog.endExecStmts(); ++itr) {
@@ -46,7 +46,7 @@ auto treeshake(const prog::Program& prog) -> prog::Program {
   // Create a new program and copy the used functions, types and the exec statements.
   auto result = prog::Program{};
   for (const auto func : funcs) {
-    prog::copyFunc(prog, &result, func, nullptr);
+    prog::copyFunc(prog, &result, func);
   }
   for (const auto type : types) {
     prog::copyType(prog, &result, type);

--- a/src/prog/copy.cpp
+++ b/src/prog/copy.cpp
@@ -1,4 +1,5 @@
 #include "prog/copy.hpp"
+#include "prog/expr/rewriter.hpp"
 #include <stdexcept>
 
 namespace prog {
@@ -24,7 +25,9 @@ auto copyType(const Program& from, Program* to, sym::TypeId id) -> bool {
   return true;
 }
 
-auto copyFunc(const Program& from, Program* to, sym::FuncId id) -> bool {
+auto copyFunc(const Program& from, Program* to, sym::FuncId id, prog::expr::Rewriter* rewriter)
+    -> bool {
+
   const auto& fromDecl = from.getFuncDecl(id);
 
   auto& toDeclTable = internal::getFuncDeclTable(to);
@@ -47,7 +50,8 @@ auto copyFunc(const Program& from, Program* to, sym::FuncId id) -> bool {
   // Define function in the 'to' program.
   if (fromDecl.getKind() == sym::FuncKind::User) {
     auto& fromDef = from.getFuncDef(id);
-    toDefTable.registerFunc(toDeclTable, id, fromDef.getConsts(), fromDef.getExpr().clone());
+    toDefTable.registerFunc(
+        toDeclTable, id, fromDef.getConsts(), fromDef.getExpr().clone(rewriter));
   }
   return true;
 }

--- a/src/prog/expr/node.cpp
+++ b/src/prog/expr/node.cpp
@@ -2,6 +2,10 @@
 
 namespace prog::expr {
 
+Node::Node(NodeKind kind) { m_kind = kind; }
+
+auto Node::getKind() const -> NodeKind { return m_kind; }
+
 auto operator<<(std::ostream& out, const Node& rhs) -> std::ostream& {
   return out << rhs.toString();
 }

--- a/src/prog/expr/node_assign.cpp
+++ b/src/prog/expr/node_assign.cpp
@@ -7,7 +7,7 @@
 namespace prog::expr {
 
 AssignExprNode::AssignExprNode(sym::ConstId constId, NodePtr expr) :
-    m_constId{constId}, m_expr{std::move(expr)} {}
+    Node{AssignExprNode::getKind()}, m_constId{constId}, m_expr{std::move(expr)} {}
 
 auto AssignExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const AssignExprNode*>(&rhs);

--- a/src/prog/expr/node_assign.cpp
+++ b/src/prog/expr/node_assign.cpp
@@ -1,4 +1,5 @@
 #include "prog/expr/node_assign.hpp"
+#include "prog/expr/rewriter.hpp"
 #include "utilities.hpp"
 #include <sstream>
 #include <stdexcept>
@@ -34,8 +35,9 @@ auto AssignExprNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto AssignExprNode::clone() const -> std::unique_ptr<Node> {
-  return std::unique_ptr<AssignExprNode>{new AssignExprNode{m_constId, m_expr->clone()}};
+auto AssignExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
+  return std::unique_ptr<AssignExprNode>{new AssignExprNode{
+      m_constId, rewriter ? rewriter->rewrite(*m_expr) : m_expr->clone(nullptr)}};
 }
 
 auto AssignExprNode::getConst() const noexcept -> sym::ConstId { return m_constId; }

--- a/src/prog/expr/node_call.cpp
+++ b/src/prog/expr/node_call.cpp
@@ -8,7 +8,11 @@ namespace prog::expr {
 
 CallExprNode::CallExprNode(
     sym::FuncId func, sym::TypeId resultType, std::vector<NodePtr> args, bool fork) :
-    m_func{func}, m_resultType{resultType}, m_args{std::move(args)}, m_fork{fork} {}
+    Node{CallExprNode::getKind()},
+    m_func{func},
+    m_resultType{resultType},
+    m_args{std::move(args)},
+    m_fork{fork} {}
 
 auto CallExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const CallExprNode*>(&rhs);

--- a/src/prog/expr/node_call.cpp
+++ b/src/prog/expr/node_call.cpp
@@ -36,9 +36,9 @@ auto CallExprNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto CallExprNode::clone() const -> std::unique_ptr<Node> {
+auto CallExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
   return std::unique_ptr<CallExprNode>{
-      new CallExprNode{m_func, m_resultType, cloneNodes(m_args), m_fork}};
+      new CallExprNode{m_func, m_resultType, cloneNodes(m_args, rewriter), m_fork}};
 }
 
 auto CallExprNode::getFunc() const noexcept -> sym::FuncId { return m_func; }

--- a/src/prog/expr/node_call_dyn.cpp
+++ b/src/prog/expr/node_call_dyn.cpp
@@ -9,7 +9,11 @@ namespace prog::expr {
 
 CallDynExprNode::CallDynExprNode(
     NodePtr lhs, sym::TypeId resultType, std::vector<NodePtr> args, bool fork) :
-    m_lhs{std::move(lhs)}, m_resultType{resultType}, m_args{std::move(args)}, m_fork{fork} {}
+    Node{CallDynExprNode::getKind()},
+    m_lhs{std::move(lhs)},
+    m_resultType{resultType},
+    m_args{std::move(args)},
+    m_fork{fork} {}
 
 auto CallDynExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const CallDynExprNode*>(&rhs);

--- a/src/prog/expr/node_call_dyn.cpp
+++ b/src/prog/expr/node_call_dyn.cpp
@@ -1,5 +1,6 @@
 #include "prog/expr/node_call_dyn.hpp"
 #include "internal/implicit_conv.hpp"
+#include "prog/expr/rewriter.hpp"
 #include "utilities.hpp"
 #include <sstream>
 #include <stdexcept>
@@ -35,9 +36,12 @@ auto CallDynExprNode::getType() const noexcept -> sym::TypeId { return m_resultT
 
 auto CallDynExprNode::toString() const -> std::string { return "call-dyn"; }
 
-auto CallDynExprNode::clone() const -> std::unique_ptr<Node> {
+auto CallDynExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
   return std::unique_ptr<CallDynExprNode>{
-      new CallDynExprNode{m_lhs->clone(), m_resultType, cloneNodes(m_args), m_fork}};
+      new CallDynExprNode{rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr),
+                          m_resultType,
+                          cloneNodes(m_args, rewriter),
+                          m_fork}};
 }
 
 auto CallDynExprNode::isFork() const noexcept -> bool { return m_fork; }

--- a/src/prog/expr/node_call_self.cpp
+++ b/src/prog/expr/node_call_self.cpp
@@ -31,8 +31,9 @@ auto CallSelfExprNode::getType() const noexcept -> sym::TypeId { return m_result
 
 auto CallSelfExprNode::toString() const -> std::string { return "self-call"; }
 
-auto CallSelfExprNode::clone() const -> std::unique_ptr<Node> {
-  return std::unique_ptr<CallSelfExprNode>{new CallSelfExprNode{m_resultType, cloneNodes(m_args)}};
+auto CallSelfExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
+  return std::unique_ptr<CallSelfExprNode>{
+      new CallSelfExprNode{m_resultType, cloneNodes(m_args, rewriter)}};
 }
 
 auto CallSelfExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }

--- a/src/prog/expr/node_call_self.cpp
+++ b/src/prog/expr/node_call_self.cpp
@@ -7,7 +7,7 @@
 namespace prog::expr {
 
 CallSelfExprNode::CallSelfExprNode(sym::TypeId resultType, std::vector<NodePtr> args) :
-    m_resultType{resultType}, m_args{std::move(args)} {}
+    Node{CallSelfExprNode::getKind()}, m_resultType{resultType}, m_args{std::move(args)} {}
 
 auto CallSelfExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const CallSelfExprNode*>(&rhs);

--- a/src/prog/expr/node_closure.cpp
+++ b/src/prog/expr/node_closure.cpp
@@ -35,8 +35,9 @@ auto ClosureNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto ClosureNode::clone() const -> std::unique_ptr<Node> {
-  return std::unique_ptr<ClosureNode>{new ClosureNode{m_type, m_func, cloneNodes(m_boundArgs)}};
+auto ClosureNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
+  return std::unique_ptr<ClosureNode>{
+      new ClosureNode{m_type, m_func, cloneNodes(m_boundArgs, rewriter)}};
 }
 
 auto ClosureNode::getFunc() const noexcept -> sym::FuncId { return m_func; }

--- a/src/prog/expr/node_closure.cpp
+++ b/src/prog/expr/node_closure.cpp
@@ -7,7 +7,7 @@
 namespace prog::expr {
 
 ClosureNode::ClosureNode(sym::TypeId type, sym::FuncId func, std::vector<NodePtr> boundArgs) :
-    m_type{type}, m_func{func}, m_boundArgs{std::move(boundArgs)} {}
+    Node{ClosureNode::getKind()}, m_type{type}, m_func{func}, m_boundArgs{std::move(boundArgs)} {}
 
 auto ClosureNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const ClosureNode*>(&rhs);

--- a/src/prog/expr/node_const.cpp
+++ b/src/prog/expr/node_const.cpp
@@ -3,7 +3,8 @@
 
 namespace prog::expr {
 
-ConstExprNode::ConstExprNode(sym::ConstId id, sym::TypeId type) : m_id{id}, m_type{type} {}
+ConstExprNode::ConstExprNode(sym::ConstId id, sym::TypeId type) :
+    Node{ConstExprNode::getKind()}, m_id{id}, m_type{type} {}
 
 auto ConstExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const ConstExprNode*>(&rhs);

--- a/src/prog/expr/node_const.cpp
+++ b/src/prog/expr/node_const.cpp
@@ -28,7 +28,7 @@ auto ConstExprNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto ConstExprNode::clone() const -> std::unique_ptr<Node> {
+auto ConstExprNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<ConstExprNode>{new ConstExprNode{m_id, m_type}};
 }
 

--- a/src/prog/expr/node_fail.cpp
+++ b/src/prog/expr/node_fail.cpp
@@ -23,7 +23,7 @@ auto FailNode::getType() const noexcept -> sym::TypeId { return m_type; }
 
 auto FailNode::toString() const -> std::string { return "fail"; }
 
-auto FailNode::clone() const -> std::unique_ptr<Node> {
+auto FailNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<FailNode>{new FailNode{m_type}};
 }
 

--- a/src/prog/expr/node_fail.cpp
+++ b/src/prog/expr/node_fail.cpp
@@ -3,7 +3,7 @@
 
 namespace prog::expr {
 
-FailNode::FailNode(sym::TypeId type) : m_type{type} {}
+FailNode::FailNode(sym::TypeId type) : Node{FailNode::getKind()}, m_type{type} {}
 
 auto FailNode::operator==(const Node& rhs) const noexcept -> bool {
   return dynamic_cast<const FailNode*>(&rhs) != nullptr;

--- a/src/prog/expr/node_field.cpp
+++ b/src/prog/expr/node_field.cpp
@@ -1,4 +1,5 @@
 #include "prog/expr/node_field.hpp"
+#include "prog/expr/rewriter.hpp"
 #include <sstream>
 
 namespace prog::expr {
@@ -32,8 +33,9 @@ auto FieldExprNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto FieldExprNode::clone() const -> std::unique_ptr<Node> {
-  return std::unique_ptr<FieldExprNode>{new FieldExprNode{m_lhs->clone(), m_id, m_type}};
+auto FieldExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
+  return std::unique_ptr<FieldExprNode>{new FieldExprNode{
+      rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr), m_id, m_type}};
 }
 
 auto FieldExprNode::getId() const noexcept -> sym::FieldId { return m_id; }

--- a/src/prog/expr/node_field.cpp
+++ b/src/prog/expr/node_field.cpp
@@ -5,7 +5,7 @@
 namespace prog::expr {
 
 FieldExprNode::FieldExprNode(NodePtr lhs, sym::FieldId id, sym::TypeId type) :
-    m_lhs{std::move(lhs)}, m_id{id}, m_type{type} {}
+    Node{FieldExprNode::getKind()}, m_lhs{std::move(lhs)}, m_id{id}, m_type{type} {}
 
 auto FieldExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const FieldExprNode*>(&rhs);

--- a/src/prog/expr/node_group.cpp
+++ b/src/prog/expr/node_group.cpp
@@ -28,8 +28,8 @@ auto GroupExprNode::getType() const noexcept -> sym::TypeId { return m_exprs.bac
 
 auto GroupExprNode::toString() const -> std::string { return "group"; }
 
-auto GroupExprNode::clone() const -> std::unique_ptr<Node> {
-  return std::unique_ptr<GroupExprNode>{new GroupExprNode{cloneNodes(m_exprs)}};
+auto GroupExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
+  return std::unique_ptr<GroupExprNode>{new GroupExprNode{cloneNodes(m_exprs, rewriter)}};
 }
 
 auto GroupExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }

--- a/src/prog/expr/node_group.cpp
+++ b/src/prog/expr/node_group.cpp
@@ -4,7 +4,8 @@
 
 namespace prog::expr {
 
-GroupExprNode::GroupExprNode(std::vector<NodePtr> exprs) : m_exprs{std::move(exprs)} {}
+GroupExprNode::GroupExprNode(std::vector<NodePtr> exprs) :
+    Node{GroupExprNode::getKind()}, m_exprs{std::move(exprs)} {}
 
 auto GroupExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const GroupExprNode*>(&rhs);

--- a/src/prog/expr/node_lit_bool.cpp
+++ b/src/prog/expr/node_lit_bool.cpp
@@ -24,7 +24,7 @@ auto LitBoolNode::getType() const noexcept -> sym::TypeId { return m_type; }
 
 auto LitBoolNode::toString() const -> std::string { return m_val ? "true" : "false"; }
 
-auto LitBoolNode::clone() const -> std::unique_ptr<Node> {
+auto LitBoolNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitBoolNode>{new LitBoolNode{m_type, m_val}};
 }
 

--- a/src/prog/expr/node_lit_bool.cpp
+++ b/src/prog/expr/node_lit_bool.cpp
@@ -3,7 +3,8 @@
 
 namespace prog::expr {
 
-LitBoolNode::LitBoolNode(sym::TypeId type, bool val) : m_type{type}, m_val{val} {}
+LitBoolNode::LitBoolNode(sym::TypeId type, bool val) :
+    Node{LitBoolNode::getKind()}, m_type{type}, m_val{val} {}
 
 auto LitBoolNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitBoolNode*>(&rhs);

--- a/src/prog/expr/node_lit_char.cpp
+++ b/src/prog/expr/node_lit_char.cpp
@@ -29,7 +29,7 @@ auto LitCharNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto LitCharNode::clone() const -> std::unique_ptr<Node> {
+auto LitCharNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitCharNode>{new LitCharNode{m_type, m_val}};
 }
 

--- a/src/prog/expr/node_lit_char.cpp
+++ b/src/prog/expr/node_lit_char.cpp
@@ -4,7 +4,8 @@
 
 namespace prog::expr {
 
-LitCharNode::LitCharNode(sym::TypeId type, uint8_t val) : m_type{type}, m_val{val} {}
+LitCharNode::LitCharNode(sym::TypeId type, uint8_t val) :
+    Node{LitCharNode::getKind()}, m_type{type}, m_val{val} {}
 
 auto LitCharNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitCharNode*>(&rhs);

--- a/src/prog/expr/node_lit_enum.cpp
+++ b/src/prog/expr/node_lit_enum.cpp
@@ -4,7 +4,7 @@
 namespace prog::expr {
 
 LitEnumNode::LitEnumNode(sym::TypeId type, std::string entryName, int32_t val) :
-    m_type{type}, m_name{std::move(entryName)}, m_val{val} {}
+    Node{LitEnumNode::getKind()}, m_type{type}, m_name{std::move(entryName)}, m_val{val} {}
 
 auto LitEnumNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitEnumNode*>(&rhs);

--- a/src/prog/expr/node_lit_enum.cpp
+++ b/src/prog/expr/node_lit_enum.cpp
@@ -25,7 +25,7 @@ auto LitEnumNode::getType() const noexcept -> sym::TypeId { return m_type; }
 
 auto LitEnumNode::toString() const -> std::string { return m_name; }
 
-auto LitEnumNode::clone() const -> std::unique_ptr<Node> {
+auto LitEnumNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitEnumNode>{new LitEnumNode{m_type, m_name, m_val}};
 }
 

--- a/src/prog/expr/node_lit_float.cpp
+++ b/src/prog/expr/node_lit_float.cpp
@@ -24,7 +24,7 @@ auto LitFloatNode::getType() const noexcept -> sym::TypeId { return m_type; }
 
 auto LitFloatNode::toString() const -> std::string { return std::to_string(m_val); }
 
-auto LitFloatNode::clone() const -> std::unique_ptr<Node> {
+auto LitFloatNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitFloatNode>{new LitFloatNode{m_type, m_val}};
 }
 

--- a/src/prog/expr/node_lit_float.cpp
+++ b/src/prog/expr/node_lit_float.cpp
@@ -3,7 +3,8 @@
 
 namespace prog::expr {
 
-LitFloatNode::LitFloatNode(sym::TypeId type, float val) : m_type{type}, m_val{val} {}
+LitFloatNode::LitFloatNode(sym::TypeId type, float val) :
+    Node{LitFloatNode::getKind()}, m_type{type}, m_val{val} {}
 
 auto LitFloatNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitFloatNode*>(&rhs);

--- a/src/prog/expr/node_lit_func.cpp
+++ b/src/prog/expr/node_lit_func.cpp
@@ -30,7 +30,7 @@ auto LitFuncNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto LitFuncNode::clone() const -> std::unique_ptr<Node> {
+auto LitFuncNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitFuncNode>{new LitFuncNode{m_type, m_func}};
 }
 

--- a/src/prog/expr/node_lit_func.cpp
+++ b/src/prog/expr/node_lit_func.cpp
@@ -5,7 +5,8 @@
 
 namespace prog::expr {
 
-LitFuncNode::LitFuncNode(sym::TypeId type, sym::FuncId func) : m_type{type}, m_func{func} {}
+LitFuncNode::LitFuncNode(sym::TypeId type, sym::FuncId func) :
+    Node{LitFuncNode::getKind()}, m_type{type}, m_func{func} {}
 
 auto LitFuncNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitFuncNode*>(&rhs);

--- a/src/prog/expr/node_lit_int.cpp
+++ b/src/prog/expr/node_lit_int.cpp
@@ -3,7 +3,8 @@
 
 namespace prog::expr {
 
-LitIntNode::LitIntNode(sym::TypeId type, int32_t val) : m_type{type}, m_val{val} {}
+LitIntNode::LitIntNode(sym::TypeId type, int32_t val) :
+    Node{LitIntNode::getKind()}, m_type{type}, m_val{val} {}
 
 auto LitIntNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitIntNode*>(&rhs);

--- a/src/prog/expr/node_lit_int.cpp
+++ b/src/prog/expr/node_lit_int.cpp
@@ -24,7 +24,7 @@ auto LitIntNode::getType() const noexcept -> sym::TypeId { return m_type; }
 
 auto LitIntNode::toString() const -> std::string { return std::to_string(m_val); }
 
-auto LitIntNode::clone() const -> std::unique_ptr<Node> {
+auto LitIntNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitIntNode>{new LitIntNode{m_type, m_val}};
 }
 

--- a/src/prog/expr/node_lit_long.cpp
+++ b/src/prog/expr/node_lit_long.cpp
@@ -24,7 +24,7 @@ auto LitLongNode::getType() const noexcept -> sym::TypeId { return m_type; }
 
 auto LitLongNode::toString() const -> std::string { return std::to_string(m_val); }
 
-auto LitLongNode::clone() const -> std::unique_ptr<Node> {
+auto LitLongNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitLongNode>{new LitLongNode{m_type, m_val}};
 }
 

--- a/src/prog/expr/node_lit_long.cpp
+++ b/src/prog/expr/node_lit_long.cpp
@@ -3,7 +3,8 @@
 
 namespace prog::expr {
 
-LitLongNode::LitLongNode(sym::TypeId type, int64_t val) : m_type{type}, m_val{val} {}
+LitLongNode::LitLongNode(sym::TypeId type, int64_t val) :
+    Node{LitLongNode::getKind()}, m_type{type}, m_val{val} {}
 
 auto LitLongNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitLongNode*>(&rhs);

--- a/src/prog/expr/node_lit_string.cpp
+++ b/src/prog/expr/node_lit_string.cpp
@@ -5,7 +5,7 @@
 namespace prog::expr {
 
 LitStringNode::LitStringNode(sym::TypeId type, std::string val) :
-    m_type{type}, m_val{std::move(val)} {}
+    Node{LitStringNode::getKind()}, m_type{type}, m_val{std::move(val)} {}
 
 auto LitStringNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitStringNode*>(&rhs);

--- a/src/prog/expr/node_lit_string.cpp
+++ b/src/prog/expr/node_lit_string.cpp
@@ -30,7 +30,7 @@ auto LitStringNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto LitStringNode::clone() const -> std::unique_ptr<Node> {
+auto LitStringNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitStringNode>{new LitStringNode{m_type, m_val}};
 }
 

--- a/src/prog/expr/node_switch.cpp
+++ b/src/prog/expr/node_switch.cpp
@@ -38,9 +38,9 @@ auto SwitchExprNode::getType() const noexcept -> sym::TypeId {
 
 auto SwitchExprNode::toString() const -> std::string { return "switch"; }
 
-auto SwitchExprNode::clone() const -> std::unique_ptr<Node> {
+auto SwitchExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
   return std::unique_ptr<SwitchExprNode>{
-      new SwitchExprNode{cloneNodes(m_conditions), cloneNodes(m_branches)}};
+      new SwitchExprNode{cloneNodes(m_conditions, rewriter), cloneNodes(m_branches, rewriter)}};
 }
 
 auto SwitchExprNode::getConditions() const noexcept -> const std::vector<NodePtr>& {

--- a/src/prog/expr/node_switch.cpp
+++ b/src/prog/expr/node_switch.cpp
@@ -5,7 +5,9 @@
 namespace prog::expr {
 
 SwitchExprNode::SwitchExprNode(std::vector<NodePtr> conditions, std::vector<NodePtr> branches) :
-    m_conditions{std::move(conditions)}, m_branches{std::move(branches)} {}
+    Node{SwitchExprNode::getKind()},
+    m_conditions{std::move(conditions)},
+    m_branches{std::move(branches)} {}
 
 auto SwitchExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const SwitchExprNode*>(&rhs);

--- a/src/prog/expr/node_union_check.cpp
+++ b/src/prog/expr/node_union_check.cpp
@@ -7,7 +7,10 @@
 namespace prog::expr {
 
 UnionCheckExprNode::UnionCheckExprNode(sym::TypeId boolType, NodePtr lhs, sym::TypeId targetType) :
-    m_boolType{boolType}, m_lhs{std::move(lhs)}, m_targetType{targetType} {}
+    Node{UnionCheckExprNode::getKind()},
+    m_boolType{boolType},
+    m_lhs{std::move(lhs)},
+    m_targetType{targetType} {}
 
 auto UnionCheckExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const UnionCheckExprNode*>(&rhs);

--- a/src/prog/expr/node_union_check.cpp
+++ b/src/prog/expr/node_union_check.cpp
@@ -1,4 +1,5 @@
 #include "prog/expr/node_union_check.hpp"
+#include "prog/expr/rewriter.hpp"
 #include "utilities.hpp"
 #include <sstream>
 #include <stdexcept>
@@ -34,9 +35,9 @@ auto UnionCheckExprNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto UnionCheckExprNode::clone() const -> std::unique_ptr<Node> {
-  return std::unique_ptr<UnionCheckExprNode>{
-      new UnionCheckExprNode{m_boolType, m_lhs->clone(), m_targetType}};
+auto UnionCheckExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
+  return std::unique_ptr<UnionCheckExprNode>{new UnionCheckExprNode{
+      m_boolType, rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr), m_targetType}};
 }
 
 auto UnionCheckExprNode::getTargetType() const noexcept -> sym::TypeId { return m_targetType; }

--- a/src/prog/expr/node_union_get.cpp
+++ b/src/prog/expr/node_union_get.cpp
@@ -8,7 +8,11 @@ namespace prog::expr {
 
 UnionGetExprNode::UnionGetExprNode(
     sym::TypeId boolType, NodePtr lhs, sym::TypeId targetType, sym::ConstId constId) :
-    m_boolType{boolType}, m_lhs{std::move(lhs)}, m_targetType{targetType}, m_constId{constId} {}
+    Node{UnionGetExprNode::getKind()},
+    m_boolType{boolType},
+    m_lhs{std::move(lhs)},
+    m_targetType{targetType},
+    m_constId{constId} {}
 
 auto UnionGetExprNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const UnionGetExprNode*>(&rhs);

--- a/src/prog/expr/node_union_get.cpp
+++ b/src/prog/expr/node_union_get.cpp
@@ -1,4 +1,5 @@
 #include "prog/expr/node_union_get.hpp"
+#include "prog/expr/rewriter.hpp"
 #include "utilities.hpp"
 #include <sstream>
 #include <stdexcept>
@@ -36,9 +37,12 @@ auto UnionGetExprNode::toString() const -> std::string {
   return oss.str();
 }
 
-auto UnionGetExprNode::clone() const -> std::unique_ptr<Node> {
+auto UnionGetExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
   return std::unique_ptr<UnionGetExprNode>{
-      new UnionGetExprNode{m_boolType, m_lhs->clone(), m_targetType, m_constId}};
+      new UnionGetExprNode{m_boolType,
+                           rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr),
+                           m_targetType,
+                           m_constId}};
 }
 
 auto UnionGetExprNode::getConst() const noexcept -> sym::ConstId { return m_constId; }

--- a/src/prog/expr/utilities.cpp
+++ b/src/prog/expr/utilities.cpp
@@ -1,4 +1,5 @@
 #include "utilities.hpp"
+#include "prog/expr/rewriter.hpp"
 #include <algorithm>
 
 namespace prog::expr {
@@ -27,11 +28,11 @@ auto getType(const std::vector<NodePtr>& nodes) -> std::optional<sym::TypeId> {
   return type;
 }
 
-auto cloneNodes(const std::vector<NodePtr>& nodes) -> std::vector<NodePtr> {
+auto cloneNodes(const std::vector<NodePtr>& nodes, Rewriter* rewriter) -> std::vector<NodePtr> {
   auto result = std::vector<NodePtr>{};
   result.reserve(nodes.size());
   for (const auto& n : nodes) {
-    result.push_back(n->clone());
+    result.push_back(rewriter ? rewriter->rewrite(*n) : n->clone(nullptr));
   }
   return result;
 }

--- a/src/prog/expr/utilities.hpp
+++ b/src/prog/expr/utilities.hpp
@@ -11,6 +11,7 @@ namespace prog::expr {
 
 [[nodiscard]] auto getType(const std::vector<NodePtr>& nodes) -> std::optional<sym::TypeId>;
 
-[[nodiscard]] auto cloneNodes(const std::vector<NodePtr>& nodes) -> std::vector<NodePtr>;
+[[nodiscard]] auto cloneNodes(const std::vector<NodePtr>& nodes, Rewriter* rewriter)
+    -> std::vector<NodePtr>;
 
 } // namespace prog::expr

--- a/src/prog/sym/const_id_hasher.cpp
+++ b/src/prog/sym/const_id_hasher.cpp
@@ -1,0 +1,10 @@
+#include "prog/sym/const_id_hasher.hpp"
+#include <functional>
+
+namespace prog::sym {
+
+auto ConstIdHasher::operator()(const ConstId& id) const -> std::size_t {
+  return std::hash<unsigned int>{}(id.m_id);
+}
+
+} // namespace prog::sym

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(tests
   lex/seperators_test.cpp
   lex/utilities_test.cpp
 
+  opt/call_inline_test.cpp
   opt/treeshake_test.cpp
 
   parse/comment_test.cpp

--- a/tests/opt/call_inline_test.cpp
+++ b/tests/opt/call_inline_test.cpp
@@ -1,0 +1,96 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "opt/opt.hpp"
+#include "prog/expr/node_assign.hpp"
+#include "prog/expr/node_call.hpp"
+#include "prog/expr/node_const.hpp"
+#include "prog/expr/node_group.hpp"
+#include "prog/expr/node_lit_int.hpp"
+#include "prog/program.hpp"
+
+namespace opt {
+
+TEST_CASE("Call inline", "[opt]") {
+
+  SECTION("Inline basic call") {
+
+    const auto& output = ANALYZE("fun funcA() funcB(42) "
+                                 "fun funcB(int i) i");
+    REQUIRE(output.isSuccess());
+
+    auto inlinedProg = inlineCalls(output.getProg());
+
+    // Verify that 'funcB' was inlined into 'funcA' as expected.
+    auto funcBId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
+    REQUIRE(funcBId);
+
+    const auto& inlBDef = inlinedProg.getFuncDef(*funcBId);
+    auto inlBExprs      = std::vector<prog::expr::NodePtr>{};
+
+    inlBExprs.push_back(prog::expr::assignExprNode(
+        inlBDef.getConsts(),
+        *inlBDef.getConsts().lookup("__inlined_0_i"),
+        prog::expr::litIntNode(inlinedProg, 42))); // NOLINT: Magic numbers
+
+    inlBExprs.push_back(prog::expr::constExprNode(
+        inlBDef.getConsts(), *inlBDef.getConsts().lookup("__inlined_0_i")));
+
+    CHECK(inlBDef.getExpr() == *prog::expr::groupExprNode(std::move(inlBExprs)));
+  }
+
+  SECTION("Inline nested call") {
+
+    const auto& output = ANALYZE("fun funcA() funcB() "
+                                 "fun funcB() funcC(42) "
+                                 "fun funcC(int i) i");
+    REQUIRE(output.isSuccess());
+
+    auto inlinedProg = inlineCalls(output.getProg());
+
+    // Verify that 'funcB' and 'funcC' was inlined into 'funcA' as expected.
+    auto funcBId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
+    REQUIRE(funcBId);
+
+    const auto& inlBDef = inlinedProg.getFuncDef(*funcBId);
+    auto inlBExprs      = std::vector<prog::expr::NodePtr>{};
+
+    inlBExprs.push_back(prog::expr::assignExprNode(
+        inlBDef.getConsts(),
+        *inlBDef.getConsts().lookup("__inlined_0_i"),
+        prog::expr::litIntNode(inlinedProg, 42))); // NOLINT: Magic numbers
+
+    inlBExprs.push_back(prog::expr::constExprNode(
+        inlBDef.getConsts(), *inlBDef.getConsts().lookup("__inlined_0_i")));
+
+    CHECK(inlBDef.getExpr() == *prog::expr::groupExprNode(std::move(inlBExprs)));
+  }
+
+  SECTION("Inline nested call in arg") {
+
+    const auto& output = ANALYZE("fun funcA() funcC(funcB()) "
+                                 "fun funcB() 42 "
+                                 "fun funcC(int i) i");
+    REQUIRE(output.isSuccess());
+
+    auto inlinedProg = inlineCalls(output.getProg());
+
+    // Verify that 'funcB' and 'funcC' was inlined into 'funcA' as expected.
+    auto funcBId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
+    REQUIRE(funcBId);
+
+    const auto& inlBDef = inlinedProg.getFuncDef(*funcBId);
+    auto inlBExprs      = std::vector<prog::expr::NodePtr>{};
+
+    inlBExprs.push_back(prog::expr::assignExprNode(
+        inlBDef.getConsts(),
+        *inlBDef.getConsts().lookup("__inlined_0_i"),
+        prog::expr::litIntNode(inlinedProg, 42))); // NOLINT: Magic numbers
+
+    inlBExprs.push_back(prog::expr::constExprNode(
+        inlBDef.getConsts(), *inlBDef.getConsts().lookup("__inlined_0_i")));
+
+    CHECK(inlBDef.getExpr() == *prog::expr::groupExprNode(std::move(inlBExprs)));
+  }
+}
+
+} // namespace opt

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "catch2/catch.hpp"
+#include "frontend/analysis.hpp"
+#include "frontend/source.hpp"
+
+namespace opt {
+
+#define SRC(INPUT)                                                                                 \
+  frontend::buildSource("test", std::nullopt, std::string{INPUT}.begin(), std::string{INPUT}.end())
+
+#define ANALYZE(INPUT) analyze(SRC(INPUT))
+
+} // namespace opt

--- a/tests/prog/copy_test.cpp
+++ b/tests/prog/copy_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Copy", "[prog]") {
 
     // Copy to another program.
     auto progB = Program{};
-    copyFunc(progA, &progB, id, nullptr);
+    copyFunc(progA, &progB, id);
 
     // Assert its presence.
     REQUIRE(progB.lookupFunc("test", sym::TypeSet{}, OvOptions{}) == id);
@@ -49,7 +49,7 @@ TEST_CASE("Copy", "[prog]") {
     auto progA = Program{};
     auto progB = Program{};
     REQUIRE(!copyFunc(
-        progA, &progB, *progA.lookupFunc("clockNanoSteady", sym::TypeSet{}, OvOptions{}), nullptr));
+        progA, &progB, *progA.lookupFunc("clockNanoSteady", sym::TypeSet{}, OvOptions{})));
   }
 }
 

--- a/tests/prog/copy_test.cpp
+++ b/tests/prog/copy_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Copy", "[prog]") {
 
     // Copy to another program.
     auto progB = Program{};
-    copyFunc(progA, &progB, id);
+    copyFunc(progA, &progB, id, nullptr);
 
     // Assert its presence.
     REQUIRE(progB.lookupFunc("test", sym::TypeSet{}, OvOptions{}) == id);
@@ -49,7 +49,7 @@ TEST_CASE("Copy", "[prog]") {
     auto progA = Program{};
     auto progB = Program{};
     REQUIRE(!copyFunc(
-        progA, &progB, *progA.lookupFunc("clockNanoSteady", sym::TypeSet{}, OvOptions{})));
+        progA, &progB, *progA.lookupFunc("clockNanoSteady", sym::TypeSet{}, OvOptions{}), nullptr));
   }
 }
 


### PR DESCRIPTION
Adds adds a step to the optimiser that inline's function calls.

Given the simple program:
```
fun funA(int i)
  42 * i

fun funB()
  funA(1337) / 2
```
Ast before inlining:
```
 funB f-123
  Body:
   * call-f-7 t-1
      ├─call-f-122 t-1
      │  └─1337 t-1
      └─2 t-1

 funA f-122
  Consts:
   * const-0: in  i t-1
  Body:
   * call-f-6 t-1
      ├─42 t-1
      └─const-0 t-1
```
Ast after inlining:
```
 funB f-123
  Consts:
   * const-0: loc  __inlined_0_i t-1
  Body:
   * call-f-7 t-1
      ├─group t-1
      │  ├─assign-const-0 t-1
      │  │  └─1337 t-1
      │  └─call-f-6 t-1
      │     ├─42 t-1
      │     └─const-0 t-1
      └─2 t-1
```

Call arguments are assigned to local constants, a future optimisation step could remove constants that are only used once.
