### PR TITLE
macos AppleClang in ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,11 +46,11 @@ jobs:
 
     - name: build
       working-directory: build
-      run: make -j$(nproc)
+      run: make -j$(./scripts/nproc.sh)
 
     - name: test
       working-directory: build
-      run: make test -j$(nproc)
+      run: make test
 
     - name: archive
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    name: ${{matrix.config.image}}-${{matrix.config.arch}}-${{matrix.config.cc}}
+    name: ${{matrix.config.image}}-${{matrix.config.arch}}-${{matrix.config.compiler}}
     runs-on: ${{matrix.config.image}}
     strategy:
       fail-fast: false
@@ -16,16 +16,28 @@ jobs:
         - {
             image: ubuntu-16.04,
             arch: x86_64,
-            dist: "xenial",
-            cc: "gcc-7",
-            cxx: "g++-7"
+            os: ubuntu,
+            dist: xenial,
+            compiler: gcc7,
+            cc: gcc-7,
+            cxx: g++-7
           }
         - {
             image: ubuntu-16.04,
             arch: x86_64,
-            dist: "xenial",
-            cc: "clang-9",
-            cxx: "clang++-9"
+            os: ubuntu,
+            dist: xenial,
+            compiler: clang9,
+            cc: clang-9,
+            cxx: clang++-9
+          }
+        - {
+            image: macos-10.15,
+            arch: x86_64,
+            os: macos,
+            compiler: appleclang,
+            cc: clang,
+            cxx: clang++
           }
     env:
       CC: ${{matrix.config.cc}}
@@ -33,20 +45,29 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: install
+    - name: install-ubuntu
+      if: matrix.config.os == 'ubuntu'
       run: |
         readonly dist=${{matrix.config.dist}}
-        echo "Add llvm ppa";             sudo apt-add-repository \
+        echo "Add llvm ppa";              sudo apt-add-repository \
           "deb http://apt.llvm.org/${dist}/ llvm-toolchain-${dist}-9 main"
-        echo "Installing clang-tidy-9";  sudo apt install clang-tidy-9
-        echo "clang-tidy-9 --version:";  clang-tidy-9 --version
+        echo "Installing clang-tidy-9";   sudo apt install clang-tidy-9
+        echo "clang-tidy-9 --version:";   clang-tidy-9 --version
+
+    - name: install-macos
+      if: matrix.config.os == 'macos'
+      run: |
+        readonly llvm9Path="$(brew --prefix llvm@9)"
+        echo "Symlinking clang-tidy from '${llvm9Path}' to '/usr/local/bin'"
+        ln -s "${llvm9Path}/bin/clang-tidy" "/usr/local/bin/clang-tidy-9"
+        echo "clang-tidy-9 --version:"; clang-tidy-9 --version
 
     - name: configure
       run: cmake -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: build
       working-directory: build
-      run: make -j$(./scripts/nproc.sh)
+      run: make -j$(../scripts/nproc.sh)
 
     - name: test
       working-directory: build
@@ -55,5 +76,5 @@ jobs:
     - name: archive
       uses: actions/upload-artifact@v1
       with:
-        name: ${{matrix.config.image}}-${{matrix.config.arch}}-${{matrix.config.cc}}
+        name: ${{matrix.config.image}}-${{matrix.config.arch}}-${{matrix.config.compiler}}
         path: bin

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,26 @@ default: build.debug
 # Convenient development utlitities.
 # --------------------------------------------------------------------------------------------------
 
+nproc := $(shell ./scripts/nproc.sh)
+
 .PHONY: build.debug
 build.debug:
 	cmake -B build -DCMAKE_BUILD_TYPE=Debug && \
 	cd build && \
-	make -j$(shell nproc)
+	make -j$(nproc)
 
 .PHONY: build.release
 build.release:
 	cmake -B build -DCMAKE_BUILD_TYPE=Release && \
 	cd build && \
-	make -j$(shell nproc)
+	make -j$(nproc)
 
 .PHONY: test
 test:
 	cmake -B build -DCMAKE_BUILD_TYPE=Debug && \
 	cd build && \
-	make tests -j$(shell nproc) && \
-	ctest
+	make tests -j$(nproc) && \
+	make test
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note this is intended as an academic exercise and not meant for production proje
 
 ## Requirements
 
-* Modern C++ compiler (Tested with `gcc 7` and `clang 9.0.0`).
+* Modern C++ compiler (Tested with `gcc 7`, `clang 9.0.0` and `apple clang 11`).
 * CMake (At least version `3.15`).
 
 ## Testing

--- a/scripts/nproc.sh
+++ b/scripts/nproc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+# --------------------------------------------------------------------------------------------------
+# Cross platform wrapper around the linux nproc executable (which returns the number of processors).
+# --------------------------------------------------------------------------------------------------
+
+isMacos()
+{
+  [[ "$(uname -s)" = Darwin* ]]
+}
+
+hasCommand()
+{
+  [ -x "$(command -v "${1}")" ]
+}
+
+if hasCommand nproc
+then
+  nproc
+  exit 0
+fi
+
+if isMacos
+then
+  sysctl -n hw.ncpu
+  exit 0
+fi
+
+echo "no nproc (or alternatives) not found" >&2
+exit 1


### PR DESCRIPTION
Add macos 15 with default Apple clang 11 (as installed on the github macos 15 runner) to ci.