### PR TITLE
Initial precompute optimization pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,8 @@ build.release:
 	make -j$(nproc)
 
 .PHONY: test
-test:
-	cmake -B build -DCMAKE_BUILD_TYPE=Debug && \
+test: build.debug
 	cd build && \
-	make tests -j$(nproc) && \
 	make test
 
 .PHONY: clean

--- a/include/opt/opt.hpp
+++ b/include/opt/opt.hpp
@@ -11,4 +11,6 @@ auto inlineCalls(const prog::Program& prog) -> prog::Program;
 
 auto eliminateConsts(const prog::Program& prog) -> prog::Program;
 
+auto precomputeLiterals(const prog::Program& prog) -> prog::Program;
+
 } // namespace opt

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,6 +209,7 @@ add_library(opt STATIC
   opt/call_inline.cpp
   opt/const_elimination.cpp
   opt/optimize.cpp
+  opt/precompute_literals.cpp
   opt/treeshake.cpp)
 target_compile_features(opt PRIVATE cxx_std_17)
 if(MSVC)

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -1,9 +1,9 @@
 #include "internal/const_remapper.hpp"
 #include "internal/expr_matchers.hpp"
 #include "internal/prog_rewrite.hpp"
+#include "opt/opt.hpp"
 #include "prog/expr/nodes.hpp"
 #include "prog/expr/rewriter.hpp"
-#include "prog/program.hpp"
 #include "prog/sym/const_id_hasher.hpp"
 #include <sstream>
 #include <unordered_set>

--- a/src/opt/const_elimination.cpp
+++ b/src/opt/const_elimination.cpp
@@ -1,9 +1,9 @@
 #include "internal/expr_matchers.hpp"
 #include "internal/find_used_consts.hpp"
 #include "internal/prog_rewrite.hpp"
+#include "opt/opt.hpp"
 #include "prog/expr/nodes.hpp"
 #include "prog/expr/rewriter.hpp"
-#include "prog/program.hpp"
 #include "prog/sym/const_id_hasher.hpp"
 #include <cassert>
 

--- a/src/opt/optimize.cpp
+++ b/src/opt/optimize.cpp
@@ -13,6 +13,9 @@ auto optimize(const prog::Program& prog) -> prog::Program {
   // Remove any functions that have become unused due to inlining.
   result = treeshake(result);
 
+  // Precompute computations where all arguments are literals.
+  result = precomputeLiterals(result);
+
   // Remove any constants where its cheaper just to 'inline' the expression.
   result = eliminateConsts(result);
 

--- a/src/opt/precompute_literals.cpp
+++ b/src/opt/precompute_literals.cpp
@@ -1,0 +1,173 @@
+#include "internal/expr_matchers.hpp"
+#include "internal/prog_rewrite.hpp"
+#include "opt/opt.hpp"
+#include "prog/expr/nodes.hpp"
+#include "prog/expr/rewriter.hpp"
+#include <algorithm>
+#include <cassert>
+
+namespace opt {
+
+static auto getInt(const prog::expr::Node& n) -> int32_t {
+  return n.downcast<prog::expr::LitIntNode>()->getVal();
+}
+
+static auto getFloat(const prog::expr::Node& n) -> float {
+  return n.downcast<prog::expr::LitFloatNode>()->getVal();
+}
+
+static auto getLong(const prog::expr::Node& n) -> int64_t {
+  return n.downcast<prog::expr::LitLongNode>()->getVal();
+}
+
+static auto getChar(const prog::expr::Node& n) -> uint8_t {
+  return n.downcast<prog::expr::LitCharNode>()->getVal();
+}
+
+static auto getString(const prog::expr::Node& n) -> std::string {
+  return n.downcast<prog::expr::LitStringNode>()->getVal();
+}
+
+class PrecomputeRewriter final : public prog::expr::Rewriter {
+public:
+  PrecomputeRewriter(
+      const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::ConstDeclTable* consts) :
+      m_prog{prog}, m_funcId{funcId}, m_consts{consts} {
+
+    if (m_consts == nullptr) {
+      throw std::invalid_argument{"Consts table cannot be null"};
+    }
+  }
+
+  auto rewrite(const prog::expr::Node& expr) -> prog::expr::NodePtr override {
+    /* Rewrite calls to a certain set of computations (for example integer negation) to which all
+    arguments are literals. */
+
+    if (expr.getKind() == prog::expr::NodeKind::Call) {
+      const auto* callExpr = expr.downcast<prog::expr::CallExprNode>();
+      const auto funcId    = callExpr->getFunc();
+      const auto funcKind  = m_prog.getFuncDecl(funcId).getKind();
+
+      // Check if the call is a operation we support.
+      if (isSupported(funcKind)) {
+        /* Now we need to check if all the arguments are literals, to support precomputing nested
+         * calls we rewrite the arguments first. */
+
+        auto newArgs = std::vector<prog::expr::NodePtr>{};
+        newArgs.reserve(expr.getChildCount());
+        for (auto i = 0U; i != expr.getChildCount(); ++i) {
+          newArgs.push_back(rewrite(expr[i]));
+        }
+
+        // If all the arguments are literals we can precompute the value.
+        if (std::all_of(newArgs.begin(), newArgs.end(), [](const prog::expr::NodePtr& n) {
+              return internal::isLiteral(*n);
+            })) {
+          return precompute(funcKind, std::move(newArgs));
+        }
+      }
+    }
+
+    // If we don't want to rewrite this expression just make a clone.
+    return expr.clone(this);
+  }
+
+private:
+  const prog::Program& m_prog;
+  prog::sym::FuncId m_funcId;
+  prog::sym::ConstDeclTable* m_consts;
+
+  [[nodiscard]] auto isSupported(prog::sym::FuncKind funcKind) -> bool {
+    switch (funcKind) {
+    // Int
+    case prog::sym::FuncKind::NegateInt:
+    case prog::sym::FuncKind::ConvIntChar:
+
+    // Float
+    case prog::sym::FuncKind::NegateFloat:
+
+    // Long
+    case prog::sym::FuncKind::NegateLong:
+
+    // Char
+    case prog::sym::FuncKind::CombineChar:
+    case prog::sym::FuncKind::ConvCharString:
+
+    // String
+    case prog::sym::FuncKind::AddString:
+    case prog::sym::FuncKind::AppendChar:
+
+      return true;
+
+    default:
+      return false;
+    }
+  }
+
+  [[nodiscard]] auto precompute(prog::sym::FuncKind funcKind, std::vector<prog::expr::NodePtr> args)
+      -> prog::expr::NodePtr {
+    switch (funcKind) {
+
+    // Int
+    case prog::sym::FuncKind::NegateInt: {
+      assert(args.size() == 1);
+      return prog::expr::litIntNode(m_prog, -getInt(*args[0]));
+    }
+    case prog::sym::FuncKind::ConvIntChar: {
+      assert(args.size() == 1);
+      return prog::expr::litCharNode(m_prog, static_cast<uint8_t>(getInt(*args[0])));
+    }
+
+    // Float
+    case prog::sym::FuncKind::NegateFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, -getFloat(*args[0]));
+    }
+
+    // Long
+    case prog::sym::FuncKind::NegateLong: {
+      assert(args.size() == 1);
+      return prog::expr::litLongNode(m_prog, -getLong(*args[0]));
+    }
+
+    // Char
+    case prog::sym::FuncKind::CombineChar: {
+      assert(args.size() == 2);
+      auto result = std::string{};
+      result += getChar(*args[0]);
+      result += getChar(*args[1]);
+      return prog::expr::litStringNode(m_prog, std::move(result));
+    }
+    case prog::sym::FuncKind::ConvCharString: {
+      assert(args.size() == 1);
+      auto c = getChar(*args[0]);
+      return prog::expr::litStringNode(m_prog, std::string(1, c));
+    }
+
+    // String
+    case prog::sym::FuncKind::AddString: {
+      assert(args.size() == 2);
+      return prog::expr::litStringNode(m_prog, getString(*args[0]) + getString(*args[1]));
+    }
+    case prog::sym::FuncKind::AppendChar: {
+      assert(args.size() == 2);
+      auto result = getString(*args[0]);
+      result += getChar(*args[1]);
+      return prog::expr::litStringNode(m_prog, std::move(result));
+    }
+
+    default:
+      throw std::logic_error{"Unsupported func-kind"};
+    }
+  }
+};
+
+auto precomputeLiterals(const prog::Program& prog) -> prog::Program {
+  return internal::rewrite(
+      prog,
+      [](const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::ConstDeclTable* consts) {
+        return std::make_unique<PrecomputeRewriter>(prog, funcId, consts);
+      });
+}
+
+} // namespace opt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ add_executable(novtests
 
   opt/call_inline_test.cpp
   opt/const_elimination_test.cpp
+  opt/precompute_literals_test.cpp
   opt/treeshake_test.cpp
 
   parse/comment_test.cpp

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -12,7 +12,7 @@ namespace opt {
 
 #define ANALYZE(INPUT) analyze(SRC(INPUT))
 
-#define GET_TYPE_ID(PROG, TYPE_NAME) PROG.lookupType(TYPE_NAME).value()
+#define GET_TYPE_ID(PROG, TYPE_NAME) (PROG).lookupType(TYPE_NAME).value()
 
 #define GET_OP_FUNC_ID(PROG, OPERATOR, ...)                                                        \
   PROG.lookupFunc(                                                                                 \
@@ -27,6 +27,15 @@ namespace opt {
 #define GET_FUNC_DECL(PROG, FUNCNAME, ...)                                                         \
   PROG.getFuncDecl(GET_FUNC_ID(PROG, FUNCNAME, __VA_ARGS__))
 
-#define GET_FUNC_DEF(PROG, FUNCNAME, ...) PROG.getFuncDef(GET_FUNC_ID(PROG, FUNCNAME, __VA_ARGS__))
+#define GET_FUNC_DEF(PROG, FUNCNAME, ...)                                                          \
+  (PROG).getFuncDef(GET_FUNC_ID(PROG, FUNCNAME, __VA_ARGS__))
+
+#define ASSERT_EXPR(OPT, INPUT, EXPECTED_EXPR)                                                     \
+  {                                                                                                \
+    const auto& output = ANALYZE("fun testFunc() " INPUT);                                         \
+    REQUIRE(output.isSuccess());                                                                   \
+    const auto prog = OPT(output.getProg());                                                       \
+    CHECK(GET_FUNC_DEF(prog, "testFunc").getExpr() == *(EXPECTED_EXPR));                           \
+  }
 
 } // namespace opt

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -1,0 +1,48 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "opt/opt.hpp"
+#include "prog/expr/nodes.hpp"
+
+namespace opt {
+
+using namespace prog::expr;
+
+TEST_CASE("Precompute literals", "[opt]") {
+  SECTION("int") {
+    ASSERT_EXPR(precomputeLiterals, "-42", litIntNode(prog, -42));        // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "char(137)", litCharNode(prog, 137)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "char(1337)", litCharNode(prog, 57)); // NOLINT: Magic numbers
+  }
+
+  SECTION("float") {
+    ASSERT_EXPR(precomputeLiterals, "-1.337", litFloatNode(prog, -1.337)); // NOLINT: Magic numbers
+  }
+
+  SECTION("long") {
+    ASSERT_EXPR(precomputeLiterals, "-42L", litLongNode(prog, -42L)); // NOLINT: Magic numbers
+  }
+
+  SECTION("char") {
+    ASSERT_EXPR(
+        precomputeLiterals, "'h' + 'w'", litStringNode(prog, "hw")); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals, "string('h')", litStringNode(prog, "h")); // NOLINT: Magic numbers
+  }
+
+  SECTION("string") {
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "\"hello\" + \"world\"",
+        litStringNode(prog, "helloworld")); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "\"hello\" + ' '",
+        litStringNode(prog, "hello ")); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "\"hello\" + ' ' + \"world\"",
+        litStringNode(prog, "hello world")); // NOLINT: Magic numbers
+  }
+}
+
+} // namespace opt


### PR DESCRIPTION
Precompute supported computations when all arguments are literals.

At the moment only a small subset of computations are supported but more can be added when time permits. 

Example:
```
fun f1()
  -42

fun f2()
  char(53) + char(67) + char(78) + char(73) + char(79)
```
Before:
![image](https://user-images.githubusercontent.com/14230060/78507865-87c1b580-778b-11ea-9680-091fc722bd51.png)
After:
![image](https://user-images.githubusercontent.com/14230060/78507873-91e3b400-778b-11ea-8241-ff7e0b9e8cbe.png)