### PR TITLE
Benchmarking utility

### DIFF
--- a/novstd/CMakeLists.txt
+++ b/novstd/CMakeLists.txt
@@ -11,6 +11,7 @@ endfunction(configure_novstd_file)
 
 # Standard nov library.
 configure_novstd_file(ascii)
+configure_novstd_file(bench)
 configure_novstd_file(console)
 configure_novstd_file(either)
 configure_novstd_file(env)

--- a/novstd/bench.nov
+++ b/novstd/bench.nov
@@ -1,0 +1,44 @@
+import "time.nov"
+import "math.nov"
+import "console.nov"
+
+// -- Types
+
+struct BenchResult =
+  Duration  avgDur,
+  Duration  wallTime,
+  int       iters
+
+// -- Actions
+
+act bench{T}(T invokable)
+  exec = ( impure lambda ()
+    ts = timestamp();
+    invokable();
+    timestamp() - ts
+  );
+  execMany = ( impure lambda (int itrsRem, Duration elapsed)
+    if itrsRem <= 0 -> elapsed
+    else            -> self(--itrsRem, elapsed + exec())
+  );
+  minIters  = 32;
+  minTime   = milliseconds(5);
+  warmup    = exec();
+  ballpark  = exec();
+  iters     = max(minIters, int(minTime / ballpark));
+  wallTime  = execMany(iters, Duration(0));
+  avgDur    = wallTime / iters;
+  BenchResult(avgDur, wallTime, iters)
+
+act benchReport{T}(T invokable)
+  res = bench(invokable);
+  print("Bench: " + res.avgDur + " (" + res.wallTime + " / " + res.iters + " itrs)")
+
+// -- Tests
+
+assert(
+  res = bench(lambda () 1 + 1);
+  res.wallTime > millisecond() &&
+  res.avgDur > nanosecond() &&
+  res.avgDur < res.wallTime &&
+  res.iters > 100)

--- a/novstd/bench.nov
+++ b/novstd/bench.nov
@@ -32,7 +32,10 @@ act bench{T}(T invokable)
 
 act benchReport{T}(T invokable)
   res = bench(invokable);
-  print("Bench: " + res.avgDur + " (" + res.wallTime + " / " + res.iters + " itrs)")
+  print(
+    "Bench: " + res.avgDur +
+    " (" + res.avgDur.ns + " ns)" +
+    " (" + res.wallTime + " / " + res.iters + " itrs)")
 
 // -- Tests
 

--- a/novstd/time.nov
+++ b/novstd/time.nov
@@ -156,6 +156,7 @@ fun -(Duration d1, Duration d2)   Duration(d1.ns - d2.ns)
 fun +(Duration d1, Duration d2)   Duration(d1.ns + d2.ns)
 fun *(Duration d, long l)         Duration(d.ns * l)
 fun /(Duration d1, Duration d2)   d1.ns / d2.ns
+fun /(Duration d1, long l)        Duration(d1.ns / l)
 fun %(Duration d1, Duration d2)   Duration(d1.ns % d2.ns)
 fun <(Duration d1, Duration d2)   d1.ns < d2.ns
 fun >(Duration d1, Duration d2)   d1.ns > d2.ns


### PR DESCRIPTION
Usage example:
```
import "std/noise.nov"
import "std/bench.nov"

benchReport(lambda () perlinNoise3d(42.42, 1.337, 99))

// OUTPUT: 'Bench: 2µs (2443 ns) (3ms / 1517 itrs)'
```
Does't take into account its own overhead yet so that needs to be considering when benchmarking code less then 500ns or so.
