### PR TITLE
Fix non-printing char output in diag binaries

### DIFF
--- a/apps/novdiag-asm/main.cpp
+++ b/apps/novdiag-asm/main.cpp
@@ -25,7 +25,7 @@ auto printStringLiterals(const novasm::Assembly& assembly) -> void {
   auto id = 0U;
   for (auto itr = assembly.beginLitStrings(); itr != assembly.endLitStrings(); ++itr, ++id) {
     std::cout << "  " << rang::style::bold << std::setw(idColWidth) << std::left << id
-              << rang::style::reset << " \"" << input::escape(*itr) << '"' << '\n';
+              << rang::style::reset << " \"" << input::escapeNonPrintingAsHex(*itr) << '"' << '\n';
   }
 }
 

--- a/apps/novdiag-prog/main.cpp
+++ b/apps/novdiag-prog/main.cpp
@@ -43,8 +43,9 @@ auto printExpr(
   auto exprCol = GetExprColor{};
   n.accept(&exprCol);
 
-  std::cout << rang::style::bold << exprCol.getFgColor() << input::escape(n.toString()) << ' '
-            << rang::fg::reset << rang::style::dim << n.getType() << rang::style::reset << '\n';
+  std::cout << rang::style::bold << exprCol.getFgColor()
+            << input::escapeNonPrintingAsHex(n.toString()) << ' ' << rang::fg::reset
+            << rang::style::dim << n.getType() << rang::style::reset << '\n';
 
   const auto childCount = n.getChildCount();
   for (auto i = 0U; i < childCount; ++i) {

--- a/include/input/char_escape.hpp
+++ b/include/input/char_escape.hpp
@@ -5,8 +5,11 @@
 namespace input {
 
 auto escape(char c) -> std::optional<char>;
+
 auto escape(const std::string& str) -> std::string;
 
 auto unescape(char c) -> std::optional<char>;
+
+auto escapeNonPrintingAsHex(const std::string& str) -> std::string;
 
 } // namespace input

--- a/src/input/char_escape.cpp
+++ b/src/input/char_escape.cpp
@@ -1,4 +1,7 @@
 #include "input/char_escape.hpp"
+#include <iomanip>
+#include <locale>
+#include <sstream>
 #include <unordered_map>
 
 namespace input {
@@ -63,6 +66,22 @@ auto unescape(const char c) -> std::optional<char> {
   }
 
   return std::nullopt;
+}
+
+auto escapeNonPrintingAsHex(const std::string& str) -> std::string {
+  std::stringstream ss;
+
+  for (auto it = str.begin(); it != str.end(); ++it) {
+    const auto c = *it;
+    if (std::isprint(c)) {
+      ss << c;
+    } else {
+      ss << '\\' << std::setfill('0') << std::setw(2) << std::hex
+         << (0xff & static_cast<unsigned int>(c));
+    }
+  }
+
+  return ss.str();
 }
 
 } // namespace input

--- a/src/prog/expr/node_lit_string.cpp
+++ b/src/prog/expr/node_lit_string.cpp
@@ -24,11 +24,7 @@ auto LitStringNode::getChildCount() const -> unsigned int { return 0; }
 
 auto LitStringNode::getType() const noexcept -> sym::TypeId { return m_type; }
 
-auto LitStringNode::toString() const -> std::string {
-  auto oss = std::ostringstream{};
-  oss << '"' << m_val << '"';
-  return oss.str();
-}
+auto LitStringNode::toString() const -> std::string { return m_val; }
 
 auto LitStringNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
   return std::unique_ptr<LitStringNode>{new LitStringNode{m_type, m_val}};


### PR DESCRIPTION
Non-printing characters are now displayed as `\HEX`.
![image](https://user-images.githubusercontent.com/14230060/78595406-a048d300-7852-11ea-8464-c98729ad3c0b.png)
