### PR TITLE
Add precompute support for more intrinsics

### DIFF
--- a/src/opt/optimize.cpp
+++ b/src/opt/optimize.cpp
@@ -19,6 +19,12 @@ auto optimize(const prog::Program& prog) -> prog::Program {
   // Remove any constants where its cheaper just to 'inline' the expression.
   result = eliminateConsts(result);
 
+  // Run another precompute pass as the 'eliminateConsts' pass could have rewritten constants into
+  // literals.
+  // TODO: Consider if we need to keep running 'eliminateConsts' and 'precomputeLiterals' in a loop
+  // until no more rewrites are done.
+  result = precomputeLiterals(result);
+
   return result;
 }
 

--- a/src/opt/precompute_literals.cpp
+++ b/src/opt/precompute_literals.cpp
@@ -5,27 +5,138 @@
 #include "prog/expr/rewriter.hpp"
 #include <algorithm>
 #include <cassert>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
 
 namespace opt {
 
-static auto getInt(const prog::expr::Node& n) -> int32_t {
+[[nodiscard]] static auto getInt(const prog::expr::Node& n) -> int32_t {
   return n.downcast<prog::expr::LitIntNode>()->getVal();
 }
 
-static auto getFloat(const prog::expr::Node& n) -> float {
+[[nodiscard]] static auto getBool(const prog::expr::Node& n) -> bool {
+  return n.downcast<prog::expr::LitBoolNode>()->getVal();
+}
+
+[[nodiscard]] static auto getFloat(const prog::expr::Node& n) -> float {
   return n.downcast<prog::expr::LitFloatNode>()->getVal();
 }
 
-static auto getLong(const prog::expr::Node& n) -> int64_t {
+[[nodiscard]] static auto getLong(const prog::expr::Node& n) -> int64_t {
   return n.downcast<prog::expr::LitLongNode>()->getVal();
 }
 
-static auto getChar(const prog::expr::Node& n) -> uint8_t {
+[[nodiscard]] static auto getChar(const prog::expr::Node& n) -> uint8_t {
   return n.downcast<prog::expr::LitCharNode>()->getVal();
 }
 
-static auto getString(const prog::expr::Node& n) -> std::string {
+[[nodiscard]] static auto getString(const prog::expr::Node& n) -> std::string {
   return n.downcast<prog::expr::LitStringNode>()->getVal();
+}
+
+[[nodiscard]] static auto isSupported(prog::sym::FuncKind funcKind) -> bool {
+  switch (funcKind) {
+  // Int
+  case prog::sym::FuncKind::AddInt:
+  case prog::sym::FuncKind::SubInt:
+  case prog::sym::FuncKind::MulInt:
+  case prog::sym::FuncKind::DivInt:
+  case prog::sym::FuncKind::RemInt:
+  case prog::sym::FuncKind::NegateInt:
+  case prog::sym::FuncKind::IncrementInt:
+  case prog::sym::FuncKind::DecrementInt:
+  case prog::sym::FuncKind::ShiftLeftInt:
+  case prog::sym::FuncKind::ShiftRightInt:
+  case prog::sym::FuncKind::AndInt:
+  case prog::sym::FuncKind::OrInt:
+  case prog::sym::FuncKind::XorInt:
+  case prog::sym::FuncKind::InvInt:
+  case prog::sym::FuncKind::CheckEqInt:
+  case prog::sym::FuncKind::CheckNEqInt:
+  case prog::sym::FuncKind::CheckLeInt:
+  case prog::sym::FuncKind::CheckLeEqInt:
+  case prog::sym::FuncKind::CheckGtInt:
+  case prog::sym::FuncKind::CheckGtEqInt:
+  case prog::sym::FuncKind::ConvIntLong:
+  case prog::sym::FuncKind::ConvIntFloat:
+  case prog::sym::FuncKind::ConvIntString:
+  case prog::sym::FuncKind::ConvIntChar:
+  case prog::sym::FuncKind::DefInt:
+
+  // Float
+  case prog::sym::FuncKind::AddFloat:
+  case prog::sym::FuncKind::SubFloat:
+  case prog::sym::FuncKind::MulFloat:
+  case prog::sym::FuncKind::DivFloat:
+  case prog::sym::FuncKind::ModFloat:
+  case prog::sym::FuncKind::PowFloat:
+  case prog::sym::FuncKind::SqrtFloat:
+  case prog::sym::FuncKind::SinFloat:
+  case prog::sym::FuncKind::CosFloat:
+  case prog::sym::FuncKind::TanFloat:
+  case prog::sym::FuncKind::ASinFloat:
+  case prog::sym::FuncKind::ACosFloat:
+  case prog::sym::FuncKind::ATanFloat:
+  case prog::sym::FuncKind::ATan2Float:
+  case prog::sym::FuncKind::NegateFloat:
+  case prog::sym::FuncKind::IncrementFloat:
+  case prog::sym::FuncKind::DecrementFloat:
+  case prog::sym::FuncKind::CheckEqFloat:
+  case prog::sym::FuncKind::CheckNEqFloat:
+  case prog::sym::FuncKind::CheckLeFloat:
+  case prog::sym::FuncKind::CheckLeEqFloat:
+  case prog::sym::FuncKind::CheckGtFloat:
+  case prog::sym::FuncKind::CheckGtEqFloat:
+  case prog::sym::FuncKind::ConvFloatInt:
+  case prog::sym::FuncKind::ConvFloatString:
+  case prog::sym::FuncKind::ConvFloatChar:
+  case prog::sym::FuncKind::DefFloat:
+
+  // Long
+  case prog::sym::FuncKind::AddLong:
+  case prog::sym::FuncKind::SubLong:
+  case prog::sym::FuncKind::MulLong:
+  case prog::sym::FuncKind::DivLong:
+  case prog::sym::FuncKind::RemLong:
+  case prog::sym::FuncKind::NegateLong:
+  case prog::sym::FuncKind::IncrementLong:
+  case prog::sym::FuncKind::DecrementLong:
+  case prog::sym::FuncKind::CheckEqLong:
+  case prog::sym::FuncKind::CheckNEqLong:
+  case prog::sym::FuncKind::CheckLeLong:
+  case prog::sym::FuncKind::CheckLeEqLong:
+  case prog::sym::FuncKind::CheckGtLong:
+  case prog::sym::FuncKind::CheckGtEqLong:
+  case prog::sym::FuncKind::ConvLongInt:
+  case prog::sym::FuncKind::ConvLongString:
+  case prog::sym::FuncKind::DefLong:
+
+  // Bool
+  case prog::sym::FuncKind::InvBool:
+  case prog::sym::FuncKind::CheckEqBool:
+  case prog::sym::FuncKind::CheckNEqBool:
+  case prog::sym::FuncKind::DefBool:
+
+  // Char
+  case prog::sym::FuncKind::CombineChar:
+  case prog::sym::FuncKind::IncrementChar:
+  case prog::sym::FuncKind::DecrementChar:
+  case prog::sym::FuncKind::ConvCharString:
+
+  // String
+  case prog::sym::FuncKind::AddString:
+  case prog::sym::FuncKind::LengthString:
+  case prog::sym::FuncKind::AppendChar:
+  case prog::sym::FuncKind::CheckEqString:
+  case prog::sym::FuncKind::CheckNEqString:
+  case prog::sym::FuncKind::DefString:
+
+    return true;
+
+  default:
+    return false;
+  }
 }
 
 class PrecomputeRewriter final : public prog::expr::Rewriter {
@@ -40,7 +151,7 @@ public:
   }
 
   auto rewrite(const prog::expr::Node& expr) -> prog::expr::NodePtr override {
-    /* Rewrite calls to a certain set of computations (for example integer negation) to which all
+    /* Rewrite calls to intrinsic computations (for example integer negation) to which all
     arguments are literals. */
 
     if (expr.getKind() == prog::expr::NodeKind::Call) {
@@ -64,6 +175,9 @@ public:
               return internal::isLiteral(*n);
             })) {
           return precompute(funcKind, std::move(newArgs));
+        } else {
+          // if we cannot precompute then construct a copy of the call.
+          return prog::expr::callExprNode(m_prog, funcId, std::move(newArgs));
         }
       }
     }
@@ -77,57 +191,322 @@ private:
   prog::sym::FuncId m_funcId;
   prog::sym::ConstDeclTable* m_consts;
 
-  [[nodiscard]] auto isSupported(prog::sym::FuncKind funcKind) -> bool {
-    switch (funcKind) {
-    // Int
-    case prog::sym::FuncKind::NegateInt:
-    case prog::sym::FuncKind::ConvIntChar:
-
-    // Float
-    case prog::sym::FuncKind::NegateFloat:
-
-    // Long
-    case prog::sym::FuncKind::NegateLong:
-
-    // Char
-    case prog::sym::FuncKind::CombineChar:
-    case prog::sym::FuncKind::ConvCharString:
-
-    // String
-    case prog::sym::FuncKind::AddString:
-    case prog::sym::FuncKind::AppendChar:
-
-      return true;
-
-    default:
-      return false;
-    }
-  }
-
   [[nodiscard]] auto precompute(prog::sym::FuncKind funcKind, std::vector<prog::expr::NodePtr> args)
       -> prog::expr::NodePtr {
     switch (funcKind) {
 
     // Int
+    case prog::sym::FuncKind::AddInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) + getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::SubInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) - getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::MulInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) * getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::DivInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) / getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::RemInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) % getInt(*args[1]));
+    }
     case prog::sym::FuncKind::NegateInt: {
       assert(args.size() == 1);
       return prog::expr::litIntNode(m_prog, -getInt(*args[0]));
+    }
+    case prog::sym::FuncKind::IncrementInt: {
+      assert(args.size() == 1);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) + 1);
+    }
+    case prog::sym::FuncKind::DecrementInt: {
+      assert(args.size() == 1);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) - 1);
+    }
+    case prog::sym::FuncKind::ShiftLeftInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) << getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::ShiftRightInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) >> getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::AndInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) & getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::OrInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) | getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::XorInt: {
+      assert(args.size() == 2);
+      return prog::expr::litIntNode(m_prog, getInt(*args[0]) ^ getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::InvInt: {
+      assert(args.size() == 1);
+      return prog::expr::litIntNode(m_prog, ~getInt(*args[0]));
+    }
+    case prog::sym::FuncKind::CheckEqInt: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getInt(*args[0]) == getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckNEqInt: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getInt(*args[0]) != getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckLeInt: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getInt(*args[0]) < getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckLeEqInt: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getInt(*args[0]) <= getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckGtInt: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getInt(*args[0]) > getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckGtEqInt: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getInt(*args[0]) >= getInt(*args[1]));
+    }
+    case prog::sym::FuncKind::ConvIntLong: {
+      assert(args.size() == 1);
+      return prog::expr::litLongNode(m_prog, static_cast<int64_t>(getInt(*args[0])));
+    }
+    case prog::sym::FuncKind::ConvIntFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, static_cast<float>(getInt(*args[0])));
+    }
+    case prog::sym::FuncKind::ConvIntString: {
+      assert(args.size() == 1);
+      auto ss = std::stringstream{};
+      ss << getInt(*args[0]);
+      return prog::expr::litStringNode(m_prog, ss.str());
     }
     case prog::sym::FuncKind::ConvIntChar: {
       assert(args.size() == 1);
       return prog::expr::litCharNode(m_prog, static_cast<uint8_t>(getInt(*args[0])));
     }
+    case prog::sym::FuncKind::DefInt: {
+      assert(args.size() == 0);
+      return prog::expr::litIntNode(m_prog, 0);
+    }
 
     // Float
+    case prog::sym::FuncKind::AddFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litFloatNode(m_prog, getFloat(*args[0]) + getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::SubFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litFloatNode(m_prog, getFloat(*args[0]) - getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::MulFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litFloatNode(m_prog, getFloat(*args[0]) * getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::DivFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litFloatNode(m_prog, getFloat(*args[0]) / getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::ModFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litFloatNode(m_prog, fmodf(getFloat(*args[0]), getFloat(*args[1])));
+    }
+    case prog::sym::FuncKind::PowFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litFloatNode(m_prog, powf(getFloat(*args[0]), getFloat(*args[1])));
+    }
+    case prog::sym::FuncKind::SqrtFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, sqrtf(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::SinFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, sinf(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::CosFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, cosf(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::TanFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, tanf(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::ASinFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, asinf(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::ACosFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, acosf(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::ATanFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, atanf(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::ATan2Float: {
+      assert(args.size() == 2);
+      return prog::expr::litFloatNode(m_prog, atan2f(getFloat(*args[0]), getFloat(*args[1])));
+    }
     case prog::sym::FuncKind::NegateFloat: {
       assert(args.size() == 1);
       return prog::expr::litFloatNode(m_prog, -getFloat(*args[0]));
     }
+    case prog::sym::FuncKind::IncrementFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, getFloat(*args[0]) + 1);
+    }
+    case prog::sym::FuncKind::DecrementFloat: {
+      assert(args.size() == 1);
+      return prog::expr::litFloatNode(m_prog, getFloat(*args[0]) - 1);
+    }
+    case prog::sym::FuncKind::CheckEqFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getFloat(*args[0]) == getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckNEqFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getFloat(*args[0]) != getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckLeFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getFloat(*args[0]) < getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckLeEqFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getFloat(*args[0]) <= getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckGtFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getFloat(*args[0]) > getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckGtEqFloat: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getFloat(*args[0]) >= getFloat(*args[1]));
+    }
+    case prog::sym::FuncKind::ConvFloatInt: {
+      assert(args.size() == 1);
+      return prog::expr::litIntNode(m_prog, static_cast<int32_t>(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::ConvFloatString: {
+      assert(args.size() == 1);
+      auto f = getFloat(*args[0]);
+      if (std::isnan(f)) {
+        return prog::expr::litStringNode(m_prog, "nan");
+      }
+      auto ss = std::stringstream{};
+      ss << std::setprecision(6) << f;
+      return prog::expr::litStringNode(m_prog, ss.str());
+    }
+    case prog::sym::FuncKind::ConvFloatChar: {
+      assert(args.size() == 1);
+      return prog::expr::litCharNode(m_prog, static_cast<uint8_t>(getFloat(*args[0])));
+    }
+    case prog::sym::FuncKind::DefFloat: {
+      assert(args.size() == 0);
+      return prog::expr::litFloatNode(m_prog, 0.0);
+    }
 
     // Long
+    case prog::sym::FuncKind::AddLong: {
+      assert(args.size() == 2);
+      return prog::expr::litLongNode(m_prog, getLong(*args[0]) + getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::SubLong: {
+      assert(args.size() == 2);
+      return prog::expr::litLongNode(m_prog, getLong(*args[0]) - getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::MulLong: {
+      assert(args.size() == 2);
+      return prog::expr::litLongNode(m_prog, getLong(*args[0]) * getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::DivLong: {
+      assert(args.size() == 2);
+      return prog::expr::litLongNode(m_prog, getLong(*args[0]) / getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::RemLong: {
+      assert(args.size() == 2);
+      return prog::expr::litLongNode(m_prog, getLong(*args[0]) % getLong(*args[1]));
+    }
     case prog::sym::FuncKind::NegateLong: {
       assert(args.size() == 1);
       return prog::expr::litLongNode(m_prog, -getLong(*args[0]));
+    }
+    case prog::sym::FuncKind::IncrementLong: {
+      assert(args.size() == 1);
+      return prog::expr::litLongNode(m_prog, getLong(*args[0]) + 1);
+    }
+    case prog::sym::FuncKind::DecrementLong: {
+      assert(args.size() == 1);
+      return prog::expr::litLongNode(m_prog, getLong(*args[0]) - 1);
+    }
+    case prog::sym::FuncKind::CheckEqLong: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getLong(*args[0]) == getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckNEqLong: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getLong(*args[0]) != getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckLeLong: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getLong(*args[0]) < getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckLeEqLong: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getLong(*args[0]) <= getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckGtLong: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getLong(*args[0]) > getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckGtEqLong: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getLong(*args[0]) >= getLong(*args[1]));
+    }
+    case prog::sym::FuncKind::ConvLongInt: {
+      assert(args.size() == 1);
+      return prog::expr::litIntNode(m_prog, static_cast<int32_t>(getLong(*args[0])));
+    }
+    case prog::sym::FuncKind::ConvLongString: {
+      assert(args.size() == 1);
+      auto ss = std::stringstream{};
+      ss << getLong(*args[0]);
+      return prog::expr::litStringNode(m_prog, ss.str());
+    }
+    case prog::sym::FuncKind::DefLong: {
+      assert(args.size() == 0);
+      return prog::expr::litLongNode(m_prog, 0);
+    }
+
+    // Char
+    case prog::sym::FuncKind::InvBool: {
+      assert(args.size() == 1);
+      return prog::expr::litBoolNode(m_prog, !getBool(*args[0]));
+    }
+    case prog::sym::FuncKind::CheckEqBool: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getBool(*args[0]) == getBool(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckNEqBool: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getBool(*args[0]) != getBool(*args[1]));
+    }
+    case prog::sym::FuncKind::ConvBoolString: {
+      assert(args.size() == 1);
+      return prog::expr::litStringNode(m_prog, getBool(*args[0]) ? "true" : "false");
+    }
+    case prog::sym::FuncKind::DefBool: {
+      assert(args.size() == 0);
+      return prog::expr::litBoolNode(m_prog, false);
     }
 
     // Char
@@ -137,6 +516,14 @@ private:
       result += getChar(*args[0]);
       result += getChar(*args[1]);
       return prog::expr::litStringNode(m_prog, std::move(result));
+    }
+    case prog::sym::FuncKind::IncrementChar: {
+      assert(args.size() == 1);
+      return prog::expr::litCharNode(m_prog, static_cast<uint8_t>(getChar(*args[0]) + 1));
+    }
+    case prog::sym::FuncKind::DecrementChar: {
+      assert(args.size() == 1);
+      return prog::expr::litCharNode(m_prog, static_cast<uint8_t>(getChar(*args[0]) - 1));
     }
     case prog::sym::FuncKind::ConvCharString: {
       assert(args.size() == 1);
@@ -149,11 +536,27 @@ private:
       assert(args.size() == 2);
       return prog::expr::litStringNode(m_prog, getString(*args[0]) + getString(*args[1]));
     }
+    case prog::sym::FuncKind::LengthString: {
+      assert(args.size() == 1);
+      return prog::expr::litIntNode(m_prog, static_cast<int32_t>(getString(*args[0]).size()));
+    }
     case prog::sym::FuncKind::AppendChar: {
       assert(args.size() == 2);
       auto result = getString(*args[0]);
       result += getChar(*args[1]);
       return prog::expr::litStringNode(m_prog, std::move(result));
+    }
+    case prog::sym::FuncKind::CheckEqString: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getString(*args[0]) == getString(*args[1]));
+    }
+    case prog::sym::FuncKind::CheckNEqString: {
+      assert(args.size() == 2);
+      return prog::expr::litBoolNode(m_prog, getString(*args[0]) != getString(*args[1]));
+    }
+    case prog::sym::FuncKind::DefString: {
+      assert(args.size() == 0);
+      return prog::expr::litStringNode(m_prog, "");
     }
 
     default:

--- a/src/prog/expr/node_lit_float.cpp
+++ b/src/prog/expr/node_lit_float.cpp
@@ -8,7 +8,8 @@ LitFloatNode::LitFloatNode(sym::TypeId type, float val) :
 
 auto LitFloatNode::operator==(const Node& rhs) const noexcept -> bool {
   const auto r = dynamic_cast<const LitFloatNode*>(&rhs);
-  return r != nullptr && m_val == r->m_val;
+  // Allow for tiny differences in float value due to inaccuracies.
+  return r != nullptr && std::abs(m_val - r->m_val) < .00001;
 }
 
 auto LitFloatNode::operator!=(const Node& rhs) const noexcept -> bool {

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -41,6 +41,7 @@ Program::Program() :
       *this, Fk::IncrementInt, getFuncName(Op::PlusPlus), sym::TypeSet{m_int}, m_int);
   m_funcDecls.registerFunc(
       *this, Fk::DecrementInt, getFuncName(Op::MinusMinus), sym::TypeSet{m_int}, m_int);
+  m_funcDecls.registerFunc(*this, Fk::InvInt, getFuncName(Op::Tilde), sym::TypeSet{m_int}, m_int);
 
   // Register build-in binary int operators.
   m_funcDecls.registerFunc(

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -9,39 +9,112 @@ using namespace prog::expr;
 
 TEST_CASE("Precompute literals", "[opt]") {
   SECTION("int") {
-    ASSERT_EXPR(precomputeLiterals, "-42", litIntNode(prog, -42));        // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1 + 2", litIntNode(prog, 3));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1 - 2", litIntNode(prog, -1)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "3 * 2", litIntNode(prog, 6));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "4 / 2", litIntNode(prog, 2));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "4 % 3", litIntNode(prog, 1));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "-42", litIntNode(prog, -42));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "++1", litIntNode(prog, 2));    // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "--2", litIntNode(prog, 1));    // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "2 << 1", litIntNode(prog, 4)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "4 >> 1", litIntNode(prog, 2)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "3 & 1", litIntNode(prog, 1));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "2 | 1", litIntNode(prog, 3));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "3 ^ 1", litIntNode(prog, 2));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "~1", litIntNode(prog, -2));    // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1 == 2", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "1 != 2", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1 < 2", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1 <= 2", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1 > 2", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "1 >= 2", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "long(137)", litLongNode(prog, 137));   // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "float(137)", litFloatNode(prog, 137)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "string(1337)", litStringNode(prog, "1337"));
     ASSERT_EXPR(precomputeLiterals, "char(137)", litCharNode(prog, 137)); // NOLINT: Magic numbers
     ASSERT_EXPR(precomputeLiterals, "char(1337)", litCharNode(prog, 57)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "int()", litIntNode(prog, 0));
   }
 
   SECTION("float") {
-    ASSERT_EXPR(precomputeLiterals, "-1.337", litFloatNode(prog, -1.337)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1.1 + 1.2", litFloatNode(prog, 2.3));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1.2 - 1.1", litFloatNode(prog, 0.1));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1.1 * 1.2", litFloatNode(prog, 1.32)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "3.3 / 1.1", litFloatNode(prog, 3.0));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "5.2 % 2.2", litFloatNode(prog, 0.8));  // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals, "pow(1.1, 2.0)", litFloatNode(prog, 1.21));    // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "sqrt(4.0)", litFloatNode(prog, 2.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "sin(0.0)", litFloatNode(prog, 0.0));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "cos(0.0)", litFloatNode(prog, 1.0));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "tan(0.0)", litFloatNode(prog, 0.0));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "asin(0.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "acos(1.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "atan(0.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals, "atan2(0.0, 0.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "-1.1", litFloatNode(prog, -1.1));   // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "--1.1", litFloatNode(prog, 0.1));   // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "++1.1", litFloatNode(prog, 2.1));   // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1.1 == 1.2", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "1.1 != 1.2", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1.1 < 1.2", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1.1 <= 1.2", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1.1 > 1.2", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "1.1 >= 1.2", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "int(1337.0)", litIntNode(prog, 1337)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "string(0.0 / 0.0)", litStringNode(prog, "nan"));
+    ASSERT_EXPR(precomputeLiterals, "string(42.1337)", litStringNode(prog, "42.1337"));
+    ASSERT_EXPR(precomputeLiterals, "string(-42.1337)", litStringNode(prog, "-42.1337"));
+    ASSERT_EXPR(precomputeLiterals, "char(230.0)", litCharNode(prog, 230)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "float()", litFloatNode(prog, 0.0));
   }
 
   SECTION("long") {
-    ASSERT_EXPR(precomputeLiterals, "-42L", litLongNode(prog, -42L)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1L + 2L", litLongNode(prog, 3));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1L - 2L", litLongNode(prog, -1)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "3L * 2L", litLongNode(prog, 6));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "4L / 2L", litLongNode(prog, 2));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "4L % 3L", litLongNode(prog, 1));  // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "-42L", litLongNode(prog, -42));   // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "++1L", litLongNode(prog, 2));     // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "--2L", litLongNode(prog, 1));     // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "1L == 2L", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "1L != 2L", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1L < 2L", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1L <= 2L", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "1L > 2L", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "1L >= 2L", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "int(137L)", litIntNode(prog, 137)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "string(1337L)", litStringNode(prog, "1337"));
+    ASSERT_EXPR(precomputeLiterals, "long()", litLongNode(prog, 0));
+  }
+
+  SECTION("bool") {
+    ASSERT_EXPR(precomputeLiterals, "!false", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "false == true", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "false != true", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "bool()", litBoolNode(prog, false));
   }
 
   SECTION("char") {
-    ASSERT_EXPR(
-        precomputeLiterals, "'h' + 'w'", litStringNode(prog, "hw")); // NOLINT: Magic numbers
-    ASSERT_EXPR(
-        precomputeLiterals, "string('h')", litStringNode(prog, "h")); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "'h' + 'w'", litStringNode(prog, "hw"));
+    ASSERT_EXPR(precomputeLiterals, "string('h')", litStringNode(prog, "h"));
+    ASSERT_EXPR(precomputeLiterals, "++'a'", litCharNode(prog, 'b'));
+    ASSERT_EXPR(precomputeLiterals, "--'b'", litCharNode(prog, 'a'));
   }
 
   SECTION("string") {
+    ASSERT_EXPR(precomputeLiterals, "\"hello\" + \"world\"", litStringNode(prog, "helloworld"));
+    ASSERT_EXPR(precomputeLiterals, "\"hello\" + ' '", litStringNode(prog, "hello "));
+    ASSERT_EXPR(precomputeLiterals, "length(\"hello\")", litIntNode(prog, 5));
     ASSERT_EXPR(
-        precomputeLiterals,
-        "\"hello\" + \"world\"",
-        litStringNode(prog, "helloworld")); // NOLINT: Magic numbers
-    ASSERT_EXPR(
-        precomputeLiterals,
-        "\"hello\" + ' '",
-        litStringNode(prog, "hello ")); // NOLINT: Magic numbers
-    ASSERT_EXPR(
-        precomputeLiterals,
-        "\"hello\" + ' ' + \"world\"",
-        litStringNode(prog, "hello world")); // NOLINT: Magic numbers
+        precomputeLiterals, "\"hello\" + ' ' + \"world\"", litStringNode(prog, "hello world"));
+    ASSERT_EXPR(precomputeLiterals, "\"hello\" == \"world\"", litBoolNode(prog, false));
+    ASSERT_EXPR(precomputeLiterals, "\"hello\" == \"hello\"", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "\"hello\" != \"world\"", litBoolNode(prog, true));
+    ASSERT_EXPR(precomputeLiterals, "string()", litStringNode(prog, ""));
   }
 }
 


### PR DESCRIPTION
Most intrinsics more support being precomputed during the optimization pass if all arguments all literals.

Example:
```
fun lerp(float a, float b, float t)
  a + (b - a) * t

fun doThing(float a)
  lerp(0.32, 1.342, a) / a

fun main()
  doThing(42) * 2
```
Program after optimization:
![image](https://user-images.githubusercontent.com/14230060/78704328-5cb69d80-7914-11ea-92af-74b91c70f838.png)