### PR TITLE
Add support for precomputing switch expressions

### DIFF
--- a/include/prog/expr/node_call.hpp
+++ b/include/prog/expr/node_call.hpp
@@ -30,6 +30,7 @@ public:
   [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getFunc() const noexcept -> sym::FuncId;
+  [[nodiscard]] auto getArgs() const noexcept -> const std::vector<NodePtr>&;
   [[nodiscard]] auto isFork() const noexcept -> bool;
 
   auto accept(NodeVisitor* visitor) const -> void override;

--- a/novstd/bench.nov
+++ b/novstd/bench.nov
@@ -42,6 +42,5 @@ act benchReport{T}(T invokable)
 assert(
   res = bench(lambda () 1 + 1);
   res.wallTime > millisecond() &&
-  res.avgDur > nanosecond() &&
   res.avgDur < res.wallTime &&
   res.iters > 100)

--- a/src/prog/expr/node_call.cpp
+++ b/src/prog/expr/node_call.cpp
@@ -47,6 +47,8 @@ auto CallExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
 
 auto CallExprNode::getFunc() const noexcept -> sym::FuncId { return m_func; }
 
+auto CallExprNode::getArgs() const noexcept -> const std::vector<NodePtr>& { return m_args; }
+
 auto CallExprNode::isFork() const noexcept -> bool { return m_fork; }
 
 auto CallExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -32,10 +32,10 @@ namespace opt {
 
 #define ASSERT_EXPR(OPT, INPUT, EXPECTED_EXPR)                                                     \
   {                                                                                                \
-    const auto& output = ANALYZE("fun testFunc() " INPUT);                                         \
+    const auto& output = ANALYZE("act test() " INPUT);                                             \
     REQUIRE(output.isSuccess());                                                                   \
     const auto prog = OPT(output.getProg());                                                       \
-    CHECK(GET_FUNC_DEF(prog, "testFunc").getExpr() == *(EXPECTED_EXPR));                           \
+    CHECK(GET_FUNC_DEF(prog, "test").getExpr() == *(EXPECTED_EXPR));                               \
   }
 
 } // namespace opt


### PR DESCRIPTION
Precompute switch expressions if the conditions are literals. Either removes individual branches of the switch if the condition is `false` or removes the switch completely if the condition is `true`.

Example program:
```
fun clamp{T}(T v, T min, T max)
    if v < min  -> min
    if v > max  -> max
    else        -> v

fun lerp(float a, float b, float t)
  a + (b - a) * clamp(t, 0.0, 1.0)

fun main()
    lerp(0.13, 0.8843, 0.591)
```
Program after optimization:
![image](https://user-images.githubusercontent.com/14230060/78811428-8930ef00-79d2-11ea-9c3a-dda9455a947d.png)
