### PR TITLE
Optimize temporary structs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: test
       working-directory: build
-      run: make test
+      run: make CTEST_OUTPUT_ON_FAILURE=1 test
 
     - name: archive
       uses: actions/upload-artifact@v1

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build.release:
 .PHONY: test
 test: build.debug
 	cd build && \
-	make test
+	make CTEST_OUTPUT_ON_FAILURE=1 test
 
 .PHONY: clean
 clean:

--- a/novstd/bench.nov
+++ b/novstd/bench.nov
@@ -22,7 +22,7 @@ act bench{T}(T invokable)
     else            -> self(--itrsRem, elapsed + exec())
   );
   minIters  = 32;
-  minTime   = milliseconds(5);
+  minTime   = milliseconds(10);
   warmup    = exec();
   ballpark  = exec();
   iters     = max(minIters, int(minTime / ballpark));

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -214,6 +214,14 @@ TEST_CASE("Precompute literals", "[opt]") {
       CHECK(GET_FUNC_DEF(prog, "f").getExpr() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
     }
   }
+
+  SECTION("temporary structs") {
+    const auto& output = ANALYZE("struct s = int i "
+                                 "fun f() s(42).i");
+    REQUIRE(output.isSuccess());
+    const auto prog = precomputeLiterals(output.getProg());
+    CHECK(GET_FUNC_DEF(prog, "f").getExpr() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
+  }
 }
 
 } // namespace opt


### PR DESCRIPTION
When a struct is created and then a field is immediately loaded we can optimize away the struct creation.

For example, this program:
```
struct Duration = long ns

fun *(Duration d, long l)         Duration(d.ns * l)
fun /(Duration d1, Duration d2)   d1.ns / d2.ns

fun nanosecond()  Duration(1L)
fun microsecond() nanosecond()  * 1_000L
fun millisecond() microsecond() * 1_000L
fun second()      millisecond() * 1_000L
fun minute()      second()      * 60L
fun hour()        minute()      * 60L
fun day()         hour()        * 24L
fun week()        day()         * 7L

fun nanoseconds(long count)   nanosecond()  * count
fun microseconds(long count)  microsecond() * count
fun milliseconds(long count)  millisecond() * count
fun seconds(long count)       second()      * count
fun minutes(long count)       minute()      * count
fun hours(long count)         hour()        * count
fun days(long count)          day()         * count
fun weeks(long count)         week()        * count

fun getMinutesInTwoWeeks()
  weeks(2) / minute()
```
Can now be optimized to:
![image](https://user-images.githubusercontent.com/14230060/78992731-a7b6f780-7b44-11ea-83ee-1e0088b3715a.png)