### PR TITLE
Optimize dynamic calls to func literals or closures

### DIFF
--- a/include/prog/expr/node_call_dyn.hpp
+++ b/include/prog/expr/node_call_dyn.hpp
@@ -29,6 +29,7 @@ public:
 
   [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
+  [[nodiscard]] auto getArgs() const noexcept -> const std::vector<NodePtr>&;
   [[nodiscard]] auto isFork() const noexcept -> bool;
 
   auto accept(NodeVisitor* visitor) const -> void override;

--- a/include/prog/expr/node_closure.hpp
+++ b/include/prog/expr/node_closure.hpp
@@ -25,6 +25,7 @@ public:
   [[nodiscard]] auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> override;
 
   [[nodiscard]] auto getFunc() const noexcept -> sym::FuncId;
+  [[nodiscard]] auto getBoundArgs() const noexcept -> const std::vector<NodePtr>&;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 

--- a/src/opt/optimize.cpp
+++ b/src/opt/optimize.cpp
@@ -7,6 +7,12 @@ auto optimize(const prog::Program& prog) -> prog::Program {
   // We start with one pass of treeshaking to avoid inlining unused functions.
   auto result = treeshake(prog);
 
+  // Run a single pass of const elimination and literal precompute before inlining. Reason is
+  // dynamic calls to function literals are simplified to be static calls (which we can then inlined
+  // in the next phase).
+  result = eliminateConsts(result);
+  result = precomputeLiterals(result);
+
   // Inline possible functions.
   result = inlineCalls(result);
 

--- a/src/prog/expr/node_call_dyn.cpp
+++ b/src/prog/expr/node_call_dyn.cpp
@@ -48,6 +48,8 @@ auto CallDynExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
                           m_fork}};
 }
 
+auto CallDynExprNode::getArgs() const noexcept -> const std::vector<NodePtr>& { return m_args; }
+
 auto CallDynExprNode::isFork() const noexcept -> bool { return m_fork; }
 
 auto CallDynExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }

--- a/src/prog/expr/node_closure.cpp
+++ b/src/prog/expr/node_closure.cpp
@@ -42,6 +42,10 @@ auto ClosureNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
 
 auto ClosureNode::getFunc() const noexcept -> sym::FuncId { return m_func; }
 
+auto ClosureNode::getBoundArgs() const noexcept -> const std::vector<NodePtr>& {
+  return m_boundArgs;
+}
+
 auto ClosureNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
 // Factories.


### PR DESCRIPTION
When you make a dynamic call directly on a function literal or closure its now optimized into a normal call.

The following program:
```
fun startsWith(string str, string subStr)
  (
    lambda (int idx)
      if idx >= subStr.length()   -> true
      if idx >= str.length()      -> false
      if str[idx] != subStr[idx]  -> false
      else                        -> self(++idx)
  )(0)
```
Now compiles into the exact same program as:
```
fun startsWith(string str, string subStr)
  startsWith(str, subStr, 0)

fun startsWith(string str, string subStr, int idx)
  if idx >= subStr.length()   -> true
  if idx >= str.length()      -> false
  if str[idx] != subStr[idx]  -> false
  else                        -> startsWith(str, subStr, ++idx)
```
