### PR TITLE
Include std library by default in inline evals

### DIFF
--- a/apps/novdiag-asm/main.cpp
+++ b/apps/novdiag-asm/main.cpp
@@ -163,6 +163,7 @@ auto main(int argc, char** argv) -> int {
   auto analyzeCmd = app.add_subcommand("analyze", "Analyze assembly for the provided characters")
                         ->callback([&]() {
                           rang::setControlMode(colorMode);
+                          input.append(" import \"std.nov\"");
                           exitcode =
                               run("inline",
                                   std::nullopt,

--- a/apps/novdiag-prog/main.cpp
+++ b/apps/novdiag-prog/main.cpp
@@ -319,6 +319,7 @@ auto main(int argc, char** argv) -> int {
   auto analyzeCmd =
       app.add_subcommand("analyze", "Analyze the provided characters")->callback([&]() {
         rang::setControlMode(colorMode);
+        input.append(" import \"std.nov\"");
         exitcode =
             run("inline",
                 std::nullopt,

--- a/apps/nove/main.cpp
+++ b/apps/nove/main.cpp
@@ -68,6 +68,15 @@ auto main(int argc, char** argv) noexcept -> int {
         vmEnvArgsCount,
         vnEnvArgs);
   }
-  return run<char*>(
-      "inline", std::nullopt, searchPaths, argv[1], nullptr, vmEnvArgsCount, vnEnvArgs);
+
+  auto progTxt = std::string{argv[1]};
+  progTxt.append(" import \"std.nov\"");
+  return run(
+      "inline",
+      std::nullopt,
+      searchPaths,
+      progTxt.begin(),
+      progTxt.end(),
+      vmEnvArgsCount,
+      vnEnvArgs);
 }

--- a/src/frontend/internal/import_sources.cpp
+++ b/src/frontend/internal/import_sources.cpp
@@ -43,9 +43,12 @@ auto ImportSources::visit(const parse::ImportStmtNode& n) -> void {
 }
 
 auto ImportSources::import(const Path& file, input::Span span) const -> bool {
+
   // Check if this file is same as our main source.
-  if (file.filename() == m_mainSource.getPath()->filename()) {
-    return true;
+  if (m_mainSource.getPath()) {
+    if (file.filename() == m_mainSource.getPath()->filename()) {
+      return true;
+    }
   }
 
   // Check if we've already imported this file.


### PR DESCRIPTION
For inline evaluations include the standard library by default. Makes inline evaluations more usable.

For example:
`nove 'print(pow(10.1, 3.2))'`
Now works without any imports.