### PR TITLE
Vm string concatenation optimization

### DIFF
--- a/src/vm/internal/allocator.hpp
+++ b/src/vm/internal/allocator.hpp
@@ -14,6 +14,7 @@ class FutureRef;
 class LongRef;
 class StreamRef;
 class StringRef;
+class StringLinkRef;
 class StructRef;
 
 class Allocator final {
@@ -31,6 +32,9 @@ public:
 
   // Allocate a string from a literal, upon failure returns {nullptr}.
   [[nodiscard]] auto allocStrLit(const std::string& literal) noexcept -> StringRef*;
+
+  // Allocate a string-link, upon failure returns {nullptr}.
+  [[nodiscard]] auto allocStrLink(Ref* prev, Value val) noexcept -> StringLinkRef*;
 
   // Allocate a struct, upon failure returns {nullptr, nullptr}.
   [[nodiscard]] auto allocStruct(uint8_t fieldCount) noexcept -> std::pair<StructRef*, Value*>;

--- a/src/vm/internal/fd_utilities.hpp
+++ b/src/vm/internal/fd_utilities.hpp
@@ -3,8 +3,8 @@
 
 #if !defined(_WIN32)
 
+#include <cstdio>
 #include <fcntl.h>
-#include <stdio.h>
 
 #endif
 

--- a/src/vm/internal/ref_kind.hpp
+++ b/src/vm/internal/ref_kind.hpp
@@ -4,11 +4,12 @@
 namespace vm::internal {
 
 enum class RefKind : uint8_t {
-  Struct = 0U,
-  Future = 1U,
-  String = 2U,
-  Long   = 3U,
-  Stream = 4U,
+  Struct     = 0U,
+  Future     = 1U,
+  String     = 2U,
+  StringLink = 3U,
+  Long       = 4U,
+  Stream     = 5U,
 };
 
 } // namespace vm::internal

--- a/src/vm/internal/ref_string.hpp
+++ b/src/vm/internal/ref_string.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "internal/ref.hpp"
 #include "internal/value.hpp"
-#include <string>
 
 namespace vm::internal {
 
@@ -35,12 +34,5 @@ private:
   inline explicit StringRef(const uint8_t* data, unsigned int size) noexcept :
       Ref(getKind()), m_data{data}, m_size{size} {}
 };
-
-inline auto getStringRef(const Value& val) noexcept {
-  auto* strRef = val.getDowncastRef<StringRef>();
-  // Assert that the string is null-terminated.
-  assert(strRef->getDataPtr()[strRef->getSize()] == '\0');
-  return strRef;
-}
 
 } // namespace vm::internal

--- a/src/vm/internal/ref_string_link.hpp
+++ b/src/vm/internal/ref_string_link.hpp
@@ -1,0 +1,86 @@
+#pragma once
+#include "internal/ref.hpp"
+#include "internal/ref_string.hpp"
+#include "internal/value.hpp"
+
+namespace vm::internal {
+
+class Allocator;
+
+// A 'StringLink' can be used to create a linked list of StringRef's. Used as an optimization when
+// concatenation strings, only when the 'result' is needed is the actual concatenation performed.
+// Note: Only forward links are supported as the common case is building up a string forwards, but
+// if building a string backwards turns out to be common also we could support a configurable
+// direction.
+class StringLinkRef final : public Ref {
+  friend class Allocator;
+
+public:
+  StringLinkRef(const StringLinkRef& rhs) = delete;
+  StringLinkRef(StringLinkRef&& rhs)      = delete;
+  ~StringLinkRef() noexcept override      = default;
+
+  auto operator=(const StringLinkRef& rhs) -> StringLinkRef& = delete;
+  auto operator=(StringLinkRef&& rhs) -> StringLinkRef& = delete;
+
+  [[nodiscard]] constexpr static auto getKind() { return RefKind::StringLink; }
+
+  // Prev can either be a StringRef or another StringLinkRef.
+  [[nodiscard]] inline auto getPrev() const noexcept { return m_prev; }
+
+  // The 'value' of the link is either a StringRef or a single character as an int.
+  [[nodiscard]] inline auto getVal() const noexcept { return m_val; }
+
+  // Size of the 'value' of the link, either the size of the StringRef or 1 incase of a character.
+  [[nodiscard]] inline auto getValSize() const noexcept {
+    if (m_val.isRef()) {
+      return m_val.getDowncastRef<StringRef>()->getSize();
+    }
+    // If its not a string it has to be a single character.
+    return 1U;
+  }
+
+  // Has a collapsed version been computed.
+  [[nodiscard]] inline auto isCollapsed() const noexcept { return m_collapsed != nullptr; }
+
+  // A collapsed version of the chain if it has been computed, otherwise null.
+  [[nodiscard]] inline auto getCollapsed() const noexcept { return m_collapsed; }
+
+  // Set a collapsed version of the chain.
+  // Note: We cannot yet clear the 'prev' and 'val' references as multiple threads might be
+  // accessing this same link. Instead we wait until the next gc cycle before we clear those.
+  inline auto setCollapsed(StringRef* stringRef) noexcept { m_collapsed = stringRef; }
+
+  // Clear the 'prev' and 'val references.
+  // Note: Should ONLY be called after a 'collapsed' version has been computed and its guaranteed no
+  // other thread is still accessing 'prev' and 'val'.
+  [[nodiscard]] inline auto clearLink() noexcept {
+    assert(m_collapsed != nullptr);
+    m_prev = nullptr;
+    m_val  = Value();
+  }
+
+private:
+  Ref* m_prev;
+  Value m_val;
+  StringRef* m_collapsed;
+
+  inline explicit StringLinkRef(Ref* prev, Value val) noexcept :
+      Ref(getKind()), m_prev{prev}, m_val{val}, m_collapsed{nullptr} {
+
+    assert(m_prev != nullptr);
+    assert(m_prev->getKind() == RefKind::String || m_prev->getKind() == RefKind::StringLink);
+  }
+};
+
+inline auto getStringLinkRef(const Value& val) noexcept {
+  return val.getDowncastRef<StringLinkRef>();
+}
+
+inline auto getStringOrLinkRef(const Value& val) noexcept {
+  auto* ref = val.getRef();
+  assert(ref->getKind() == RefKind::String || ref->getKind() == RefKind::StringLink);
+  return ref;
+}
+
+} // namespace vm::internal

--- a/src/vm/internal/string_link_utilities.hpp
+++ b/src/vm/internal/string_link_utilities.hpp
@@ -1,0 +1,92 @@
+#pragma once
+#include "internal/allocator.hpp"
+#include "internal/likely.hpp"
+#include "internal/ref_string.hpp"
+#include "internal/ref_string_link.hpp"
+#include <cstring>
+
+namespace vm::internal {
+
+// Compute the total size of a string-link.
+inline auto getStringLinkSize(StringLinkRef& l) noexcept -> unsigned int {
+  // If we've precomputed this chain then we can return that size.
+  if (l.isCollapsed()) {
+    return l.getCollapsed()->getSize();
+  }
+
+  // Otherwise walk the chain to compute the full size.
+  auto result = l.getValSize();
+  auto* cur   = l.getPrev();
+  while (true) {
+    if (cur->getKind() == RefKind::String) {
+      result += downcastRef<StringRef>(cur)->getSize();
+      break;
+    }
+    auto* curLink = downcastRef<StringLinkRef>(cur);
+    result += curLink->getValSize();
+    cur = curLink->getPrev();
+    assert(cur != nullptr);
+  }
+
+  return result;
+}
+
+// Collapse a string-link into a normal string.
+inline auto collapseStringLink(Allocator* allocator, StringLinkRef& l) noexcept -> StringRef* {
+  // If we've collapsed this link before return the previous result.
+  if (l.isCollapsed()) {
+    return l.getCollapsed();
+  }
+
+  // Allocate a new string big enough to the hold the entire chain.
+  auto size        = getStringLinkSize(l);
+  auto strRefAlloc = allocator->allocStr(size);
+  if (unlikely(strRefAlloc.first == nullptr)) {
+    return nullptr;
+  }
+
+  auto* charDataStartPtr = strRefAlloc.second;
+  auto* charDataPtr      = charDataStartPtr + size;
+
+  // Utility macro for copying to the end to our string.
+#define CPY_STR(STR_SRC)                                                                           \
+  {                                                                                                \
+    auto* strSrcPtr = (STR_SRC).getDowncastRef<StringRef>();                                       \
+    charDataPtr -= strSrcPtr->getSize();                                                           \
+    std::memcpy(charDataPtr, strSrcPtr->getDataPtr(), strSrcPtr->getSize());                       \
+  }
+
+  // Copy our own value into the string.
+  if (l.getVal().isRef()) {
+    CPY_STR(l.getVal());
+  } else {
+    *--charDataPtr = static_cast<uint8_t>(l.getVal().getInt());
+  }
+
+  // Copy the rest of the chain into the string.
+  auto* cur = l.getPrev();
+  while (true) {
+    if (cur->getKind() == RefKind::String) {
+      CPY_STR(refValue(downcastRef<StringRef>(cur)));
+      break;
+    }
+    auto* curLink = downcastRef<StringLinkRef>(cur);
+    if (curLink->getVal().isRef()) {
+      CPY_STR(curLink->getVal());
+    } else {
+      *--charDataPtr = static_cast<uint8_t>(curLink->getVal().getInt());
+    }
+    cur = curLink->getPrev();
+    assert(cur != nullptr);
+  }
+
+#undef CPY_LINK
+
+  // Set the new string as the 'collapsed' representation for that link, this caches the value for
+  // future requests on the same link.
+  l.setCollapsed(strRefAlloc.first);
+
+  return strRefAlloc.first;
+}
+
+} // namespace vm::internal

--- a/src/vm/internal/value.hpp
+++ b/src/vm/internal/value.hpp
@@ -110,7 +110,7 @@ private:
   assert(ref != nullptr);
 
   // First store the pointer in a variable of the native pointer size (might be 32 bit).
-  uintptr_t rawRef = reinterpret_cast<uintptr_t>(ref); // NOLINT: Reinterpret cast
+  auto rawRef = reinterpret_cast<uintptr_t>(ref); // NOLINT: Reinterpret cast
 
   // Then expand to 64 bit and tag it.
   return Value{static_cast<uint64_t>(rawRef) | refTag};
@@ -122,7 +122,7 @@ template <typename Type>
 [[nodiscard]] inline auto rawPtrValue(Type* ptr) noexcept -> Value {
   assert(ptr != nullptr);
 
-  uintptr_t ptrVal = reinterpret_cast<uintptr_t>(ptr); // NOLINT: Reinterpret cast
+  auto ptrVal = reinterpret_cast<uintptr_t>(ptr); // NOLINT: Reinterpret cast
 
   // Assert that the least significant bit is 0, reason is we use that bit to signify that this
   // value is a vm 'ref'.


### PR DESCRIPTION
This pr optimizes the use-case where you are building up a string by repeatedly appending to the end. Instead of doing the concatenation immediately the vm now builds up a linked list of strings and only when the string is 'observed' will it perform the concatenation.

Depending on the sizes this can have a 2x - 100x speedup.

A simple benchmark that writes a list containing `100 000` integers to a file:
```
import "std.nov"
act main()
  l = rangeList(0, 100_000);
  benchReport(impure lambda ()
    fileWrite(Path("test.output.txt"), string(l))
  )
main()
```
Before:
```
Bench: 5s (5245334027 ns) (41s / 8 itrs)
Bench: 5s (5314192724 ns) (42s / 8 itrs)
Bench: 5s (5351752398 ns) (42s / 8 itrs)
```
After:
```
Bench: 46ms (46416539 ns) (371ms / 8 itrs)
Bench: 42ms (42643758 ns) (341ms / 8 itrs)
Bench: 42ms (42900834 ns) (343ms / 8 itrs)
```

A slightly more realistic example would be parsing and pretty printing a ~ 1 megabyte file.
```
import "std.nov"
act main()
  jp = jsonParser();
  jw = jsonWriter();
  benchReport(impure lambda ()
    p = Path("test.input.json");
    j = jp(fileRead(p));
    o = jw(j ?? toJsonVal(-1));
    fileWrite(Path("test.output.json"), o.string())
  )
main()
```
Before:
```
Bench: 11s (11429265968 ns) (1m31s / 8 itrs)
Bench: 10s (10929062345 ns) (1m27s / 8 itrs)
Bench: 11s (11283870238 ns) (1m30s / 8 itrs)
```
After:
```
Bench: 2s (2027739718 ns) (16s / 8 itrs)
Bench: 2s (2023707540 ns) (16s / 8 itrs)
Bench: 1s (1924621298 ns) (15s / 8 itrs)
```

At this time its only implemented for forward concatenation (appending to the end) but in theory should be implementable for the reverse case also.