### PR TITLE
Seperate compiler and runtime

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,7 +22,7 @@
       "command": "${workspaceFolder}/scripts/watch_nov.sh",
       "args": [
         "${workspaceFolder}",
-        "${workspaceFolder}/bin/nove"
+        "${workspaceFolder}/bin/novc"
       ],
       "isBackground": true,
       "problemMatcher": "$novus",

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ test: build
 clean:
 	rm -rf build
 
-# Watch for changes to '.nov' files and automatically evaluate them.
+# Watch for changes to '.nov' files and automatically compile them.
 # Requires 'inotify-tools' to be installed.
 .PHONY: watch.nov
 watch.nov:
-	./scripts/watch_nov.sh . ./bin/nove
+	./scripts/watch_nov.sh . ./bin/novc
 
 .SILENT:

--- a/README.md
+++ b/README.md
@@ -78,16 +78,29 @@ After configuring the project can be build by running `scripts/build.sh` on unix
 `scripts/build.ps1` on windows.
 
 Build output can be found in the `bin` directory.
+For more convenience you can add the `bin` directory it to your `PATH`.
 
-## Running
+## Building novus source code
 
-To run `novus` source code you can either pass the source straight to the evaluator:
+Novus source (`.nov`) can be compiled into novus assembly (`.nova`) using the `novc` executable.
+
+Example: `./bin/novc examples/fizzbuzz.nov`. The output can be found at `examples/fizzbuzz.nova`.
+
+## Running novus assembly
+
+Novus assembly (`.nova`) can be run in the novus runtime (`novrt`).
+
+Example: `./bin/novrt examples/fizzbuzz.nova`.
+
+## Evaluator
+
+Alternatively you can use the `nove` (novus evaluator) to combine the compilation and running.
+
+You can either pass the source straight to the evaluator:
 `./bin/nove 'print(pow(42, 1.337))'`.
 
 or give a `.nov` source file to the evaluator:
 `./bin/nove examples/fizzbuzz.nov`.
-
-For more convenience you can add the `bin` directory it to your `PATH`.
 
 ## Debugging
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -37,6 +37,18 @@ target_link_libraries(novc PRIVATE backend)
 target_link_libraries(novc PRIVATE novasm)
 target_link_libraries(novc PRIVATE opt)
 
+# Runtime.
+message(">> Configuring novrt executable")
+add_executable(novrt novrt/main.cpp)
+target_compile_features(novrt PUBLIC cxx_std_17)
+if(MSVC)
+  target_compile_options(novrt PUBLIC /GR-)
+else()
+  target_compile_options(novrt PUBLIC -fno-exceptions -fno-rtti)
+endif()
+target_link_libraries(novrt PRIVATE vm)
+target_link_libraries(novrt PRIVATE novasm)
+
 # Evaluator.
 message(">> Configuring nove executable")
 add_executable(nove nove/main.cpp)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -18,6 +18,25 @@ FetchContent_Declare(
   GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(rang)
 
+# Compiler.
+message(">> Configuring novc executable")
+add_executable(novc
+  novc/compiler.cpp
+  novc/main.cpp)
+target_compile_features(novc PUBLIC cxx_std_17)
+if(MSVC)
+  target_compile_options(novc PUBLIC /EHsc)
+else()
+  target_compile_options(novc PUBLIC -fexceptions)
+endif()
+target_link_libraries(novc PRIVATE CLI11::CLI11)
+target_include_directories(novc PRIVATE ${rang_SOURCE_DIR}/include)
+target_link_libraries(novc PRIVATE input)
+target_link_libraries(novc PRIVATE frontend)
+target_link_libraries(novc PRIVATE backend)
+target_link_libraries(novc PRIVATE novasm)
+target_link_libraries(novc PRIVATE opt)
+
 # Evaluator.
 message(">> Configuring nove executable")
 add_executable(nove nove/main.cpp)

--- a/apps/novc/compiler.cpp
+++ b/apps/novc/compiler.cpp
@@ -1,0 +1,150 @@
+// -- Include rang before any os headers.
+#include "../rang_include.hpp"
+// --
+
+#include "backend/generator.hpp"
+#include "compiler.hpp"
+#include "frontend/analysis.hpp"
+#include "frontend/source.hpp"
+#include "novasm/serialization.hpp"
+#include "opt/opt.hpp"
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+
+namespace novc {
+
+using Clock    = std::chrono::high_resolution_clock;
+using Duration = std::chrono::duration<double>;
+
+static auto operator<<(std::ostream& out, const Duration& rhs) -> std::ostream&;
+static auto msgHeader(std::ostream& out) -> std::ostream&;
+static auto infHeader(std::ostream& out) -> std::ostream&;
+
+auto compile(Options options) -> bool {
+
+  std::cout << rang::style::bold << "--- Novus compiler ---\n" << rang::style::reset;
+
+  auto validateOnly = options.destPath.empty();
+  if (validateOnly) {
+    msgHeader(std::cout) << "Validate: " << options.srcPath << '\n';
+  } else {
+    msgHeader(std::cout) << "Compile: " << options.srcPath << '\n';
+  }
+
+  // Load the source file.
+  const auto absSrcPath = filesystem::canonical(filesystem::absolute(options.srcPath));
+  auto srcFilestream    = std::ifstream{absSrcPath.string()};
+  if (srcFilestream.bad()) {
+    msgHeader(std::cerr) << rang::style::bold << rang::bg::red << "Failed to read source file\n"
+                         << rang::style::reset;
+    return false;
+  }
+
+  const auto compileStartTime = Clock::now();
+
+  // Parse the source.
+  const auto src = frontend::buildSource(
+      absSrcPath.filename(),
+      absSrcPath,
+      std::istreambuf_iterator<char>{srcFilestream},
+      std::istreambuf_iterator<char>{});
+
+  // Build a program out of the source.
+  const auto frontendOut = frontend::analyze(src, options.searchPaths);
+
+  const auto compileEndTime = Clock::now();
+  const auto compileDur = std::chrono::duration_cast<Duration>(compileEndTime - compileStartTime);
+
+  if (!frontendOut.isSuccess()) {
+    msgHeader(std::cerr) << rang::style::bold << rang::bg::red << "Compilation failed, errors:\n";
+    for (auto diagItr = frontendOut.beginDiags(); diagItr != frontendOut.endDiags(); ++diagItr) {
+      std::cerr << *diagItr << '\n';
+    }
+    std::cerr << rang::style::reset;
+    return false;
+  }
+
+  msgHeader(std::cout) << "Analyzed program in: " << compileDur << '\n';
+  infHeader(std::cout) << "Files: "
+                       << std::distance(
+                              frontendOut.getImportedSources().begin(),
+                              frontendOut.getImportedSources().end())
+                       << '\n';
+  infHeader(std::cout) << "Types: " << frontendOut.getProg().getTypeCount() << '\n';
+  infHeader(std::cout) << "Functions: " << frontendOut.getProg().getFuncCount() << '\n';
+  infHeader(std::cout) << "Execute statements: " << frontendOut.getProg().getExecStmtCount()
+                       << '\n';
+
+  if (validateOnly) {
+    msgHeader(std::cout) << "Successfully validated program\n";
+    return true;
+  }
+
+  auto optProg = prog::Program{};
+  if (options.optimize) {
+
+    msgHeader(std::cout) << "Optimize program\n";
+
+    const auto optStartTime = Clock::now();
+    optProg                 = opt::optimize(frontendOut.getProg());
+    const auto optEndTime   = Clock::now();
+    const auto optDur       = std::chrono::duration_cast<Duration>(optEndTime - optStartTime);
+
+    msgHeader(std::cout) << "Finished optimizing program in: " << optDur << '\n';
+    infHeader(std::cout) << "Types: " << optProg.getTypeCount() << '\n';
+    infHeader(std::cout) << "Functions: " << optProg.getFuncCount() << '\n';
+    infHeader(std::cout) << "Execute statements: " << optProg.getExecStmtCount() << '\n';
+  }
+
+  const auto& prog = options.optimize ? optProg : frontendOut.getProg();
+
+  // Generate novus assembly representation.
+  msgHeader(std::cout) << "Generate novus assembly\n";
+
+  const auto asmStartTime = Clock::now();
+  const auto asmOutput    = backend::generate(prog);
+  const auto asmEndTime   = Clock::now();
+  const auto asmDur       = std::chrono::duration_cast<Duration>(asmEndTime - asmStartTime);
+
+  msgHeader(std::cout) << "Finished generating novus assembly in: " << asmDur << '\n';
+  infHeader(std::cout) << "Instructions: " << asmOutput.first.getInstructions().size() << '\n';
+
+  // Write assembly to disk.
+  auto destFilestream = std::ofstream{options.destPath.string()};
+  if (destFilestream.bad()) {
+    msgHeader(std::cerr) << rang::style::bold << rang::bg::red << "Failed to write to output path\n"
+                         << rang::style::reset;
+    return false;
+  }
+  novasm::serialize(asmOutput.first, std::ostreambuf_iterator<char>{destFilestream});
+
+  msgHeader(std::cout) << "Successfully compiled program to: " << options.destPath << '\n';
+  return true;
+}
+
+static auto msgHeader(std::ostream& out) -> std::ostream& {
+  return out << rang::style::bold << rang::fg::green << "* " << rang::style::reset
+             << rang::fg::reset;
+}
+
+static auto infHeader(std::ostream& out) -> std::ostream& {
+  return out << rang::style::dim << rang::fg::gray << "  * " << rang::style::reset
+             << rang::fg::reset;
+}
+
+static auto operator<<(std::ostream& out, const Duration& rhs) -> std::ostream& {
+  auto s = rhs.count();
+  if (s < .000001) {                // NOLINT: Magic numbers
+    out << s * 1000000000 << " ns"; // NOLINT: Magic numbers
+  } else if (s < .001) {            // NOLINT: Magic numbers
+    out << s * 1000000 << " us";    // NOLINT: Magic numbers
+  } else if (s < 1) {               // NOLINT: Magic numbers
+    out << s * 1000 << " ms";       // NOLINT: Magic numbers
+  } else {
+    out << s << " s";
+  }
+  return out;
+}
+
+} // namespace novc

--- a/apps/novc/compiler.cpp
+++ b/apps/novc/compiler.cpp
@@ -35,7 +35,7 @@ auto compile(Options options) -> bool {
   // Load the source file.
   const auto absSrcPath = filesystem::canonical(filesystem::absolute(options.srcPath));
   auto srcFilestream    = std::ifstream{absSrcPath.string()};
-  if (srcFilestream.bad()) {
+  if (!srcFilestream.good()) {
     msgHeader(std::cerr) << rang::style::bold << rang::bg::red << "Failed to read source file\n"
                          << rang::style::reset;
     return false;
@@ -45,7 +45,7 @@ auto compile(Options options) -> bool {
 
   // Parse the source.
   const auto src = frontend::buildSource(
-      absSrcPath.filename(),
+      absSrcPath.filename().string(),
       absSrcPath,
       std::istreambuf_iterator<char>{srcFilestream},
       std::istreambuf_iterator<char>{});
@@ -111,8 +111,8 @@ auto compile(Options options) -> bool {
   infHeader(std::cout) << "Instructions: " << asmOutput.first.getInstructions().size() << '\n';
 
   // Write assembly to disk.
-  auto destFilestream = std::ofstream{options.destPath.string()};
-  if (destFilestream.bad()) {
+  auto destFilestream = std::ofstream{options.destPath.string(), std::ios::binary};
+  if (!destFilestream.good()) {
     msgHeader(std::cerr) << rang::style::bold << rang::bg::red << "Failed to write to output path\n"
                          << rang::style::reset;
     return false;

--- a/apps/novc/compiler.hpp
+++ b/apps/novc/compiler.hpp
@@ -1,0 +1,14 @@
+#include "filesystem.hpp"
+
+namespace novc {
+
+struct Options {
+  filesystem::path srcPath;
+  filesystem::path destPath;
+  const std::vector<filesystem::path>& searchPaths;
+  bool optimize;
+};
+
+auto compile(Options opts) -> bool;
+
+} // namespace novc

--- a/apps/novc/main.cpp
+++ b/apps/novc/main.cpp
@@ -1,0 +1,72 @@
+// -- Include rang before any os headers.
+#include "../rang_include.hpp"
+// --
+
+#include "CLI/CLI.hpp"
+#include "compiler.hpp"
+#include "filesystem.hpp"
+#include "input/search_paths.hpp"
+#include <algorithm>
+
+auto main(int argc, char** argv) noexcept -> int {
+  auto app = CLI::App{"Novus compiler"};
+
+  auto additionalSearchPaths = std::vector<filesystem::path>{};
+  auto colorMode             = rang::control::Auto;
+  auto optimize              = true;
+  auto validateOnly          = false;
+  filesystem::path srcPath;
+  filesystem::path outPath;
+
+  app.add_flag(
+      "--no-color{0},-c{2},--color{2},--auto-color{1}",
+      colorMode,
+      "Set the color output behaviour");
+  app.add_option("source-file", srcPath, "Path to the source file to compile")
+      ->check(CLI::ExistingFile)
+      ->required();
+  app.add_option("-o,--out", outPath, "Path to output the program to");
+  app.add_flag("--optimize,!--no-optimize", optimize, "Optimize the program");
+  app.add_flag("-v,--validate-only", validateOnly, "Only validate but do not output the program");
+  app.add_option(
+         "-s,--searchpaths", additionalSearchPaths, "Additional paths to search for imports")
+      ->check(CLI::ExistingDirectory);
+  app.validate_positionals();
+
+  // Parse arguments.
+  std::atexit([]() {
+    std::cout << rang::style::reset;
+    std::cerr << rang::style::reset;
+  });
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError& e) {
+    if (e.get_exit_code() != 0) {
+      std::cerr << rang::fg::red;
+    }
+    return app.exit(e);
+  }
+
+  rang::setControlMode(colorMode);
+
+  // If no output path is given generate one based on the source file path.
+  if (outPath.empty()) {
+    outPath = srcPath;
+    outPath.replace_extension("nova");
+  }
+
+  // In validate-only mode don't specify an output path.
+  if (validateOnly) {
+    outPath = filesystem::path{};
+  }
+
+  // Gather the default search-paths and add any manually provided ones.
+  auto searchPaths = input::getSearchPaths(argv);
+  std::copy(
+      additionalSearchPaths.begin(), additionalSearchPaths.end(), std::back_inserter(searchPaths));
+
+  auto options = novc::Options{srcPath, outPath, searchPaths, optimize};
+  auto success = novc::compile(options);
+
+  return success ? 0 : 1;
+}

--- a/apps/novdiag-asm/main.cpp
+++ b/apps/novdiag-asm/main.cpp
@@ -214,7 +214,7 @@ auto main(int argc, char** argv) -> int {
         rang::setControlMode(colorMode);
 
         auto absFilePath = filesystem::absolute(filePath);
-        std::ifstream fs{filePath.string()};
+        std::ifstream fs{filePath.string(), std::ios::binary};
         if (absFilePath.extension() == ".nova") {
           exitcode = runFromAssembly(
               std::istreambuf_iterator<char>{fs}, std::istreambuf_iterator<char>{}, printOutput);

--- a/apps/nove/main.cpp
+++ b/apps/nove/main.cpp
@@ -59,7 +59,7 @@ auto main(int argc, char** argv) noexcept -> int {
   }
 
   const auto vmEnvArgsCount = argc - 2; // 1 for program path and 1 for source.
-  auto** const vnEnvArgs    = argv + 2;
+  auto** const vmEnvArgs    = argv + 2;
   const auto searchPaths    = input::getSearchPaths(argv);
 
   auto path = filesystem::path{argv[1]};
@@ -73,7 +73,7 @@ auto main(int argc, char** argv) noexcept -> int {
         std::istreambuf_iterator<char>{fs},
         std::istreambuf_iterator<char>{},
         vmEnvArgsCount,
-        vnEnvArgs);
+        vmEnvArgs);
   }
 
   auto progTxt = std::string{argv[1]};
@@ -85,5 +85,5 @@ auto main(int argc, char** argv) noexcept -> int {
       progTxt.begin(),
       progTxt.end(),
       vmEnvArgsCount,
-      vnEnvArgs);
+      vmEnvArgs);
 }

--- a/apps/novrt/main.cpp
+++ b/apps/novrt/main.cpp
@@ -21,6 +21,7 @@ auto main(int argc, char** argv) noexcept -> int {
     }
   }
 
+  // Open a handle to the program assembly file.
   auto fs = std::ifstream{progPath.string(), std::ios::binary};
   if (!fs.good()) {
     if (implicitPath) {
@@ -37,6 +38,9 @@ auto main(int argc, char** argv) noexcept -> int {
     std::cerr << "Novus runtime - Corrupt 'nova' file\n";
     return 1;
   }
+
+  // Close the handle to the program assembly file.
+  fs.close();
 
   const auto consumedArgs   = implicitPath ? 1 : 2; // 1 for executable path and 1 for nova file.
   const auto vmEnvArgsCount = argc - consumedArgs;

--- a/apps/novrt/main.cpp
+++ b/apps/novrt/main.cpp
@@ -1,0 +1,51 @@
+#include "filesystem.hpp"
+#include "novasm/serialization.hpp"
+#include "vm/exec_state.hpp"
+#include "vm/platform_interface.hpp"
+#include "vm/vm.hpp"
+#include <cstdio>
+#include <fstream>
+
+auto main(int argc, char** argv) noexcept -> int {
+
+  /* Note: Supports either reading a 'nova' assembly file as argment 1 or looking for a 'prog.nova'
+   * in current working directory. */
+
+  auto implicitPath = true;
+  auto progPath     = filesystem::path{"prog.nova"};
+  if (argc >= 2) {
+    auto arg1Path = filesystem::path(std::string(argv[1]));
+    if (arg1Path.extension() == ".nova") {
+      progPath     = std::move(arg1Path);
+      implicitPath = false;
+    }
+  }
+
+  auto fs = std::ifstream{progPath.string(), std::ios::binary};
+  if (!fs.good()) {
+    if (implicitPath) {
+      std::cerr << "Novus runtime - Please provide path to a 'nova' file\n";
+    } else {
+      std::cerr << "Novus runtime - Failed to open file: " << progPath << '\n';
+    }
+    return 1;
+  }
+
+  const auto asmOutput =
+      novasm::deserialize(std::istreambuf_iterator<char>{fs}, std::istreambuf_iterator<char>{});
+  if (!asmOutput) {
+    std::cerr << "Novus runtime - Corrupt 'nova' file\n";
+    return 1;
+  }
+
+  const auto consumedArgs   = implicitPath ? 1 : 2; // 1 for executable path and 1 for nova file.
+  const auto vmEnvArgsCount = argc - consumedArgs;
+  auto** const vmEnvArgs    = argv + consumedArgs;
+
+  auto iface = vm::PlatformInterface{vmEnvArgsCount, vmEnvArgs, stdin, stdout, stderr};
+  auto res   = vm::run(&asmOutput.value(), &iface);
+  if (res > vm::ExecState::Failed) {
+    std::cerr << "runtime error: " << res << '\n';
+  }
+  return static_cast<int>(res);
+}

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -11,15 +11,15 @@ At the moment only basic syntax highlighting is supported.
 The extension includes a problem-matcher named `novus` to report problems based on diagnostic output
 from the nov compiler.
 
-Create a task in your `.vscode/tasks.json` file for evaluating a novus file:
-Replace `<<Path to novus nove binary>>` to where the `nove` executable is located.
+Create a task in your `.vscode/tasks.json` file for compiling a novus file:
+Replace `<<Path to novus compiler binary>>` to where the `novc` executable is located.
 ```json
 {
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "evaluate",
-      "command": "<<Path to novus nove executable>>",
+      "label": "compile",
+      "command": "<<Path to novus novc executable>>",
       "type": "shell",
       "args": [
         "${file}"
@@ -35,7 +35,7 @@ Replace `<<Path to novus nove binary>>` to where the `nove` executable is locate
 }
 ```
 
-Alternatively you can create a task that automatically evaluates files in the background:
+Alternatively you can create a task that automatically compiles files in the background:
 ```json
 {
   "version": "2.0.0",
@@ -46,7 +46,7 @@ Alternatively you can create a task that automatically evaluates files in the ba
       "command": "${workspaceFolder}/scripts/watch_nov.sh",
       "args": [
         "${workspaceFolder}",
-        "${workspaceFolder}/bin/nove"
+        "${workspaceFolder}/bin/novc"
       ],
       "isBackground": true,
       "problemMatcher": "$novus",

--- a/ide/vscode/novus/package.json
+++ b/ide/vscode/novus/package.json
@@ -49,8 +49,8 @@
         ],
         "background": {
           "activeOnStart": true,
-          "beginsPattern": "^File change detected: '(.*)'. Evaluating:$",
-          "endsPattern": "^Evaluation complete. Watching for file changes...$"
+          "beginsPattern": "^File change detected: '(.*)'. Compiling:$",
+          "endsPattern": "^Compilation complete. Watching for file changes...$"
         }
       }
     ]

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "novasm/assembly.hpp"
+#include <optional>
+
+namespace novasm {
+
+const uint16_t assemblyFormatVersion = 1U;
+
+template <typename OutputItr>
+auto serialize(const Assembly& assembly, OutputItr outItr) noexcept -> OutputItr;
+
+template <typename InputItrBegin, typename InputEndItr>
+auto deserialize(InputItrBegin begin, InputEndItr end) noexcept -> std::optional<Assembly>;
+
+} // namespace novasm

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -52,7 +52,6 @@ public:
   [[nodiscard]] auto beginTypeDecls() const -> TypeDeclIterator { return m_typeDecls.begin(); }
   [[nodiscard]] auto endTypeDecls() const -> TypeDeclIterator { return m_typeDecls.end(); }
 
-  [[nodiscard]] auto getFuncCount() const -> unsigned int { return m_funcDecls.getFuncCount(); }
   [[nodiscard]] auto beginFuncDecls() const -> FuncDeclIterator { return m_funcDecls.begin(); }
   [[nodiscard]] auto endFuncDecls() const -> FuncDeclIterator { return m_funcDecls.end(); }
 
@@ -64,6 +63,10 @@ public:
 
   [[nodiscard]] auto beginExecStmts() const -> ExecStmtIterator { return m_execStmts.begin(); }
   [[nodiscard]] auto endExecStmts() const -> ExecStmtIterator { return m_execStmts.end(); }
+
+  [[nodiscard]] auto getTypeCount() const -> unsigned int { return m_typeDecls.getCount(); }
+  [[nodiscard]] auto getFuncCount() const -> unsigned int { return m_funcDecls.getCount(); }
+  [[nodiscard]] auto getExecStmtCount() const -> unsigned int { return m_execStmts.size(); }
 
   [[nodiscard]] auto getInt() const noexcept -> sym::TypeId { return m_int; }
   [[nodiscard]] auto getLong() const noexcept -> sym::TypeId { return m_long; }

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -21,17 +21,17 @@ public:
   using Iterator = std::map<FuncId, FuncDecl>::const_iterator;
   using Id       = prog::sym::FuncId;
 
-  FuncDeclTable()                             = default;
-  FuncDeclTable(const FuncDeclTable& rhs)     = delete;
-  FuncDeclTable(FuncDeclTable&& rhs)          = default;
-  ~FuncDeclTable()                            = default;
+  FuncDeclTable()                         = default;
+  FuncDeclTable(const FuncDeclTable& rhs) = delete;
+  FuncDeclTable(FuncDeclTable&& rhs)      = default;
+  ~FuncDeclTable()                        = default;
 
   auto operator=(const FuncDeclTable& rhs) -> FuncDeclTable& = delete;
   auto operator=(FuncDeclTable&& rhs) noexcept -> FuncDeclTable& = default;
 
   [[nodiscard]] auto operator[](FuncId id) const -> const FuncDecl&;
 
-  [[nodiscard]] auto getFuncCount() const -> unsigned int;
+  [[nodiscard]] auto getCount() const -> unsigned int;
   [[nodiscard]] auto begin() const -> Iterator;
   [[nodiscard]] auto end() const -> Iterator;
 

--- a/include/prog/sym/type_decl_table.hpp
+++ b/include/prog/sym/type_decl_table.hpp
@@ -11,16 +11,17 @@ class TypeDeclTable final {
 public:
   using Iterator = typename std::map<TypeId, TypeDecl>::const_iterator;
 
-  TypeDeclTable()                             = default;
-  TypeDeclTable(const TypeDeclTable& rhs)     = delete;
-  TypeDeclTable(TypeDeclTable&& rhs)          = default;
-  ~TypeDeclTable()                            = default;
+  TypeDeclTable()                         = default;
+  TypeDeclTable(const TypeDeclTable& rhs) = delete;
+  TypeDeclTable(TypeDeclTable&& rhs)      = default;
+  ~TypeDeclTable()                        = default;
 
   auto operator=(const TypeDeclTable& rhs) -> TypeDeclTable& = delete;
   auto operator=(TypeDeclTable&& rhs) noexcept -> TypeDeclTable& = default;
 
   [[nodiscard]] auto operator[](TypeId id) const -> const TypeDecl&;
 
+  [[nodiscard]] auto getCount() const -> unsigned int;
   [[nodiscard]] auto begin() const -> Iterator;
   [[nodiscard]] auto end() const -> Iterator;
 

--- a/scripts/watch_nov.sh
+++ b/scripts/watch_nov.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 trap interupt SIGINT
 
 # --------------------------------------------------------------------------------------------------
-# Watch novus files for changes and automatically evaluate them.
+# Watch novus files for changes and automatically compile them.
 # --------------------------------------------------------------------------------------------------
 
 info()
@@ -56,32 +56,31 @@ watchFiles()
     done
 }
 
-evalNovFile()
+compileNovFile()
 {
-  [ -x "${1}" ] || fail "Provide the novus eval binary path as arg 1"
-  [ -f "${2}" ] || fail "Provide the file to evaluate as arg 2"
+  [ -x "${1}" ] || fail "Provide the novus compiler binary path as arg 1"
+  [ -f "${2}" ] || fail "Provide the file to compile as arg 2"
 
-  local evalBinPath="${1}"
+  local compilerBinPath="${1}"
   local novFilePath="${2}"
 
   clear
-  info "File change detected: '${novFilePath}'. Evaluating:"
+  info "File change detected: '${novFilePath}'. Compiling:"
 
-  # Evaluate the file.
-  # note: pipe empty input into it as we do not want to run interactivly.
-  # note: ignore exit-code because we want to keep listening even if an eval failed.
-  echo "" | "${evalBinPath}" "${novFilePath}" || true
+  # Compile the file.
+  # note: ignore exit-code because we want to keep listening even if a compilation failed.
+  "${compilerBinPath}" "${novFilePath}" --validate-only || true
 
-  info "Evaluation complete. Watching for file changes..."
+  info "Compilation complete. Watching for file changes..."
 }
 
 # Verify env args.
 [ -d "${1}" ] || fail "Provide directory to watch as arg 1"
-[ -x "${2}" ] || fail "Provide novus eval binary path as arg 2"
+[ -x "${2}" ] || fail "Provide novus compiler binary path as arg 2"
 
 readonly watchDir="${1}"
-readonly evalBin="${2}"
+readonly compilerBin="${2}"
 
-# Watch dir for nov file changes and auto evaluate.
-watchFiles "${watchDir}" "nov" evalNovFile "${evalBin}"
+# Watch dir for nov file changes and auto compile them.
+watchFiles "${watchDir}" "nov" compileNovFile "${compilerBin}"
 exit 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,7 +255,8 @@ add_library(novasm STATIC
   novasm/assembly.cpp
   novasm/disassembler.cpp
   novasm/op_code.cpp
-  novasm/pcall_code.cpp)
+  novasm/pcall_code.cpp
+  novasm/serialization.cpp)
 target_compile_features(novasm PRIVATE cxx_std_17)
 if(MSVC)
   target_compile_options(novasm PRIVATE /EHsc)

--- a/src/lex/lexer.cpp
+++ b/src/lex/lexer.cpp
@@ -602,5 +602,6 @@ template class Lexer<char*, char*>;
 template class Lexer<std::string::iterator, std::string::iterator>;
 template class Lexer<std::string::const_iterator, std::string::const_iterator>;
 template class Lexer<std::istream_iterator<char>, std::istream_iterator<char>>;
+template class Lexer<std::istreambuf_iterator<char>, std::istreambuf_iterator<char>>;
 
 } // namespace lex

--- a/src/novasm/serialization.cpp
+++ b/src/novasm/serialization.cpp
@@ -1,0 +1,242 @@
+#include "novasm/serialization.hpp"
+#include <istream>
+#include <iterator>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace novasm {
+
+template <typename ValueType, typename OutputItr>
+using Writer = void(const ValueType& val, OutputItr& outItr);
+
+template <typename ValueType, typename InputItr, typename InputEndItr>
+using Reader = std::optional<ValueType>(InputItr&, InputEndItr);
+
+template <typename OutputItr>
+static auto writeUInt8(uint8_t val, OutputItr& outItr) -> void {
+  *outItr = val;
+  ++outItr;
+}
+
+template <typename OutputItr>
+static auto writeUInt16(uint16_t val, OutputItr& outItr) -> void {
+  writeUInt8(val, outItr);
+  writeUInt8(val >> 8U, outItr); // NOLINT: Magic number
+}
+
+template <typename OutputItr>
+static auto writeUInt32(uint32_t val, OutputItr& outItr) -> void {
+  writeUInt8(val, outItr);
+  writeUInt8(val >> 8U, outItr);  // NOLINT: Magic number
+  writeUInt8(val >> 16U, outItr); // NOLINT: Magic number
+  writeUInt8(val >> 24U, outItr); // NOLINT: Magic number
+}
+
+template <typename InputItrBegin, typename InputItrEnd, typename OutputItr>
+static auto writeRaw(InputItrBegin beginItr, InputItrEnd endItr, OutputItr& outItr) -> void {
+  for (auto itr = beginItr; itr != endItr; ++itr) {
+    writeUInt8(*itr, outItr);
+  }
+}
+
+template <typename OutputItr>
+static auto writeString(const std::string& str, OutputItr& outItr) -> void {
+  // Write the length.
+  writeUInt32(str.length(), outItr);
+
+  // Write the content.
+  writeRaw(str.begin(), str.end(), outItr);
+}
+
+template <typename InputItrBegin, typename InputItrEnd, typename ElemType, typename OutputItr>
+static auto writeSet(
+    InputItrBegin beginItr,
+    InputItrEnd endItr,
+    Writer<ElemType, OutputItr>* writer,
+    OutputItr& outItr) -> void {
+
+  // Write the size.
+  auto size = endItr - beginItr;
+  writeUInt32(size, outItr);
+
+  // Write the elements.
+  for (auto itr = beginItr; itr != endItr; ++itr) {
+    writer(*itr, outItr);
+  }
+}
+
+template <typename InputItr, typename InputEndItr>
+static auto readUInt8(InputItr& itr, InputEndItr end) -> std::optional<uint8_t> {
+  if (itr == end) {
+    return std::nullopt;
+  }
+  return *itr++;
+}
+
+template <typename InputItr, typename InputEndItr>
+static auto readUInt16(InputItr& itr, InputEndItr end) -> std::optional<uint16_t> {
+  if (itr == end) {
+    return std::nullopt;
+  }
+  auto a = *itr++;
+  if (itr == end) {
+    return std::nullopt;
+  }
+  auto b = *itr++;
+  return static_cast<uint16_t>(a) | (static_cast<uint16_t>(b) << 8U);
+}
+
+template <typename InputItr, typename InputEndItr>
+static auto readUInt32(InputItr& itr, InputEndItr end) -> std::optional<uint32_t> {
+  if (itr == end) {
+    return std::nullopt;
+  }
+  auto a = *itr++;
+  if (itr == end) {
+    return std::nullopt;
+  }
+  auto b = *itr++;
+  if (itr == end) {
+    return std::nullopt;
+  }
+  auto c = *itr++;
+  if (itr == end) {
+    return std::nullopt;
+  }
+  auto d = *itr++;
+  return static_cast<uint32_t>(a) | (static_cast<uint32_t>(b) << 8U) |
+      (static_cast<uint32_t>(c) << 16U) | (static_cast<uint32_t>(d) << 24U);
+}
+
+template <typename InputItr, typename InputEndItr, typename OutputItr>
+static auto readRaw(unsigned int size, InputItr& itr, InputEndItr end, OutputItr& outItr) -> bool {
+
+  for (auto i = 0U; i != size; ++i) {
+    if (itr == end) {
+      return false;
+    }
+    *outItr = *itr++;
+    outItr++;
+  }
+  return true;
+}
+
+template <typename InputItr, typename InputEndItr>
+static auto readString(InputItr& itr, InputEndItr end) -> std::optional<std::string> {
+  auto size = readUInt32(itr, end);
+  if (!size) {
+    return std::nullopt;
+  }
+
+  auto result = std::string{};
+  result.reserve(*size);
+  auto outItr = std::back_inserter(result);
+  if (!readRaw(*size, itr, end, outItr)) {
+    return std::nullopt;
+  }
+  return result;
+}
+
+template <typename ElemType, typename InputItr, typename InputEndItr>
+static auto readSet(InputItr& itr, InputEndItr end, Reader<ElemType, InputItr, InputEndItr>* reader)
+    -> std::optional<std::vector<ElemType>> {
+
+  auto size = readUInt32(itr, end);
+  if (!size) {
+    return std::nullopt;
+  }
+
+  auto result = std::vector<ElemType>{};
+  result.reserve(*size);
+  for (auto i = 0U; i != size; ++i) {
+    auto elem = reader(itr, end);
+    if (!elem) {
+      return std::nullopt;
+    }
+    result.push_back(std::move(*elem));
+  }
+  return result;
+}
+
+template <typename OutputItr>
+auto serialize(const Assembly& assembly, OutputItr outItr) noexcept -> OutputItr {
+
+  // Format version number.
+  writeUInt16(assemblyFormatVersion, outItr);
+
+  // Program entry point.
+  writeUInt32(assembly.getEntrypoint(), outItr);
+
+  // Program string literals.
+  writeSet(assembly.beginLitStrings(), assembly.endLitStrings(), &writeString<OutputItr>, outItr);
+
+  // Program instructions.
+  const auto& instructions = assembly.getInstructions();
+  writeUInt32(instructions.size(), outItr);
+  writeRaw(instructions.begin(), instructions.end(), outItr);
+
+  return outItr;
+}
+
+template <typename InputItrBegin, typename InputEndItr>
+auto deserialize(InputItrBegin itr, InputEndItr end) noexcept -> std::optional<Assembly> {
+
+  // Format version number.
+  auto formatVersionNum = readUInt16(itr, end);
+  if (!formatVersionNum) {
+    return std::nullopt;
+  }
+
+  // Check if the version is supported.
+  if (formatVersionNum != assemblyFormatVersion) {
+    return std::nullopt;
+  }
+
+  // Program entry point.
+  auto entryPoint = readUInt32(itr, end);
+  if (!entryPoint) {
+    return std::nullopt;
+  }
+
+  // Program string literals.
+  auto stringLiterals = readSet(itr, end, &readString<InputItrBegin, InputEndItr>);
+  if (!stringLiterals) {
+    return std::nullopt;
+  }
+
+  // Program instructions.
+  auto progInstructionCount = readUInt32(itr, end);
+  if (!progInstructionCount) {
+    return std::nullopt;
+  }
+  auto instructions = std::vector<uint8_t>{};
+  instructions.reserve(*progInstructionCount);
+  auto instructionOutItr = std::back_inserter(instructions);
+  if (!readRaw(*progInstructionCount, itr, end, instructionOutItr)) {
+    return std::nullopt;
+  }
+
+  return Assembly{*entryPoint, std::move(*stringLiterals), std::move(instructions)};
+}
+
+// Explicit instantiations.
+template auto serialize(const Assembly&, std::back_insert_iterator<std::string>) noexcept
+    -> std::back_insert_iterator<std::string>;
+template auto serialize(const Assembly&, std::back_insert_iterator<std::vector<char>>) noexcept
+    -> std::back_insert_iterator<std::vector<char>>;
+template auto serialize(const Assembly&, std::ostream_iterator<char>) noexcept
+    -> std::ostream_iterator<char>;
+template auto serialize(const Assembly&, std::ostreambuf_iterator<char>) noexcept
+    -> std::ostreambuf_iterator<char>;
+
+template auto deserialize(char*, char*) -> std::optional<Assembly>;
+template auto deserialize(std::string::iterator, std::string::iterator) -> std::optional<Assembly>;
+template auto deserialize(std::string::const_iterator, std::string::const_iterator)
+    -> std::optional<Assembly>;
+template auto deserialize(std::istream_iterator<char>, std::istream_iterator<char>)
+    -> std::optional<Assembly>;
+template auto deserialize(std::istreambuf_iterator<char>, std::istreambuf_iterator<char>)
+    -> std::optional<Assembly>;
+
+} // namespace novasm

--- a/src/novasm/serialization.cpp
+++ b/src/novasm/serialization.cpp
@@ -79,11 +79,11 @@ static auto readUInt16(InputItr& itr, InputEndItr end) -> std::optional<uint16_t
   if (itr == end) {
     return std::nullopt;
   }
-  auto a = *itr++;
+  auto a = static_cast<uint8_t>(*itr++);
   if (itr == end) {
     return std::nullopt;
   }
-  auto b = *itr++;
+  auto b = static_cast<uint8_t>(*itr++);
   return static_cast<uint16_t>(a) | (static_cast<uint16_t>(b) << 8U);
 }
 
@@ -92,19 +92,19 @@ static auto readUInt32(InputItr& itr, InputEndItr end) -> std::optional<uint32_t
   if (itr == end) {
     return std::nullopt;
   }
-  auto a = *itr++;
+  auto a = static_cast<uint8_t>(*itr++);
   if (itr == end) {
     return std::nullopt;
   }
-  auto b = *itr++;
+  auto b = static_cast<uint8_t>(*itr++);
   if (itr == end) {
     return std::nullopt;
   }
-  auto c = *itr++;
+  auto c = static_cast<uint8_t>(*itr++);
   if (itr == end) {
     return std::nullopt;
   }
-  auto d = *itr++;
+  auto d = static_cast<uint8_t>(*itr++);
   return static_cast<uint32_t>(a) | (static_cast<uint32_t>(b) << 8U) |
       (static_cast<uint32_t>(c) << 16U) | (static_cast<uint32_t>(d) << 24U);
 }

--- a/src/prog/sym/func_decl_table.cpp
+++ b/src/prog/sym/func_decl_table.cpp
@@ -14,7 +14,7 @@ auto FuncDeclTable::operator[](FuncId id) const -> const FuncDecl& {
   return itr->second;
 }
 
-auto FuncDeclTable::getFuncCount() const -> unsigned int { return m_funcs.size(); }
+auto FuncDeclTable::getCount() const -> unsigned int { return m_funcs.size(); }
 
 auto FuncDeclTable::begin() const -> Iterator { return m_funcs.begin(); }
 

--- a/src/prog/sym/type_decl_table.cpp
+++ b/src/prog/sym/type_decl_table.cpp
@@ -14,6 +14,8 @@ auto TypeDeclTable::operator[](TypeId id) const -> const TypeDecl& {
   return itr->second;
 }
 
+auto TypeDeclTable::getCount() const -> unsigned int { return m_types.size(); }
+
 auto TypeDeclTable::begin() const -> Iterator { return m_types.begin(); }
 
 auto TypeDeclTable::end() const -> Iterator { return m_types.end(); }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,8 @@ add_executable(novtests
   lex/seperators_test.cpp
   lex/utilities_test.cpp
 
+  novasm/serialization_test.cpp
+
   opt/call_inline_test.cpp
   opt/const_elimination_test.cpp
   opt/precompute_literals_test.cpp

--- a/tests/novasm/helpers.hpp
+++ b/tests/novasm/helpers.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include "backend/generator.hpp"
+#include "catch2/catch.hpp"
+#include "frontend/analysis.hpp"
+
+namespace novasm {
+
+inline auto generateAssembly(std::string input) {
+  const auto src = frontend::buildSource("test", std::nullopt, input.begin(), input.end());
+  const auto frontendOutput = frontend::analyze(src);
+  REQUIRE(frontendOutput.isSuccess());
+  return backend::generate(frontendOutput.getProg()).first;
+}
+
+#define GEN_ASM(INPUT) generateAssembly(INPUT)
+
+} // namespace novasm

--- a/tests/novasm/serialization_test.cpp
+++ b/tests/novasm/serialization_test.cpp
@@ -1,0 +1,37 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "novasm/serialization.hpp"
+
+namespace novasm {
+
+static auto testSerializeAndDeserializeAsm(Assembly a) {
+  // Serialize.
+  auto outputString = std::string{};
+  serialize(a, std::back_inserter(outputString));
+  REQUIRE(outputString.size() > 0);
+
+  // Deserialize.
+  auto deserializedAssembly = deserialize(outputString.begin(), outputString.end());
+  REQUIRE(deserializedAssembly);
+
+  CHECK(*deserializedAssembly == a);
+}
+
+TEST_CASE("Assembly serialization", "[novasm]") {
+
+  SECTION("Basic program") {
+    testSerializeAndDeserializeAsm(GEN_ASM("act main(int i, float f) "
+                                           "  pow(i, f) + sin(f) "
+                                           "main(42, 1.337)"));
+  }
+
+  SECTION("Empty program") { testSerializeAndDeserializeAsm(GEN_ASM("")); }
+
+  SECTION("Basic program with string literals") {
+    testSerializeAndDeserializeAsm(GEN_ASM("act main(string strA, string strB) "
+                                           "  strA + strB "
+                                           "main(\"hello\", \"world\")"));
+  }
+}
+
+} // namespace novasm


### PR DESCRIPTION
This pr adds the `novc` (novus compiler) app that can build a `.nova` (novus assembly) file from `.nov` (novus source) files.

The `.nova` can then be run using the `novrt` (novus runtime) app.

Allow for much easier distribution of a program, it requires only shipping the `.nova` file and the `novrt` executable. And the `novrt` executable is really small atm (around 100k on unix and around 70k on windows). 