### PR TITLE
Add docker distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,40 +2,43 @@ cmake_minimum_required(VERSION 3.15)
 
 project(
   Novus
-  VERSION 0.1
+  VERSION 0.1.0
   LANGUAGES CXX)
 
 # Custom options options
 set(LINTING "Off" CACHE BOOL "Should source linting be enabled")
 
 # Print some diagnostic information.
-message(">> Configuring Novus")
-message("-- Host system: ${CMAKE_HOST_SYSTEM}")
-message("-- Host processor: ${CMAKE_SYSTEM_PROCESSOR}")
-message("-- CMake version: ${CMAKE_VERSION}")
-message("-- Build type: ${CMAKE_BUILD_TYPE}")
-message("-- Linting: ${LINTING}")
-message("-- Source path: ${PROJECT_SOURCE_DIR}")
-message("-- Build path: ${PROJECT_BINARY_DIR}")
-message("-- Ouput path: ${PROJECT_SOURCE_DIR}/bin")
-message("-- Compiler: ${CMAKE_CXX_COMPILER_ID}")
-message("-- Generator: ${CMAKE_GENERATOR}")
+message(STATUS "Configuring Novus")
+message(STATUS "* Host system: ${CMAKE_HOST_SYSTEM}")
+message(STATUS "* Host processor: ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "* CMake version: ${CMAKE_VERSION}")
+message(STATUS "* Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "* Linting: ${LINTING}")
+message(STATUS "* Source path: ${PROJECT_SOURCE_DIR}")
+message(STATUS "* Build path: ${PROJECT_BINARY_DIR}")
+message(STATUS "* Ouput path: ${PROJECT_SOURCE_DIR}/bin")
+message(STATUS "* Compiler: ${CMAKE_CXX_COMPILER_ID}")
+message(STATUS "* Generator: ${CMAKE_GENERATOR}")
 
 # Output executables to bin dir.
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${PROJECT_SOURCE_DIR}/bin>)
 
+# Write a 'VERSION' file to the bin dir with the cmake project version.
+file(WRITE ${EXECUTABLE_OUTPUT_PATH}/VERSION ${CMAKE_PROJECT_VERSION})
+
 # Enable 'CTest' testing.
-message(">> Enable CTest dependency")
+message(STATUS "Enable CTest dependency")
 include(CTest)
 enable_testing()
 
 # Global compiler flags.
 if(MSVC)
-  message(">> Setting msvc compiler flags")
+  message(STATUS "Setting msvc compiler flags")
   set(CMAKE_CXX_FLAGS "/std:c++17 /WX /wd4530 /wd26451")
 else()
-  message(">> Setting unix compiler flags")
+  message(STATUS "Setting unix compiler flags")
   set(CXX_FLAGS_SHARED "-std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing")
   set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -fno-omit-frame-pointer ${CXX_FLAGS_SHARED}")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG ${CXX_FLAGS_SHARED}")
@@ -44,12 +47,12 @@ endif()
 # Older version of libstdc++ require linking against the <experimental/filesystem> library directly.
 # TODO(bastian): Investigate if there is a better way to handle this.
 if((UNIX AND NOT APPLE) OR MINGW)
-  message(">> Add linking to stdc++fs (filesystem library)")
+  message(STATUS "Add linking to stdc++fs (filesystem library)")
   link_libraries(stdc++fs)
 endif()
 
 # Find the threads library.
-message(">> Finding threads package")
+message(STATUS "Finding threads package")
 set(CMAKE_THREAD_PREFER_PTHREAD On)
 find_package(Threads REQUIRED)
 
@@ -64,7 +67,7 @@ if(LINTING)
   # Use the clang-tidy linter if installed.
   find_program(CLANG_TIDY_BIN NAMES "clang-tidy" "clang-tidy-9")
   if(CLANG_TIDY_BIN)
-    message(">> Enabling clang-tidy linter")
+    message(STATUS "Enabling clang-tidy linter")
     set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_BIN})
   endif()
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+
+# --------------------------------------------------------------------------------------------------
+# Docker container with the compiler, runtime and examples.
+# --------------------------------------------------------------------------------------------------
+
+# -- Build container.
+FROM alpine:latest as build
+
+LABEL description="Novus - build container"
+
+# Update the package manager.
+RUN apk update
+
+# Install build deps: gcc, make, cmake, libc-dev, bash, git and other basic build dependencies.
+RUN apk add --no-cache build-base cmake bash git
+
+# Copy sources into the build container.
+COPY apps           /novus/apps
+COPY include        /novus/include
+COPY novstd         /novus/novstd
+COPY scripts        /novus/scripts
+COPY src            /novus/src
+COPY CMakeLists.txt /novus/CMakeLists.txt
+WORKDIR /novus
+
+# Configure.
+RUN bash ./scripts/configure.sh
+
+# Build.
+RUN bash ./scripts/build.sh
+
+# -- Run container.
+FROM alpine:latest as runtime
+
+LABEL description="Novus - run container"
+
+# Update package manager.
+RUN apk update
+
+# Install libstdc++ runtime library.
+RUN apk add --no-cache libstdc++
+
+# Copy the binaries from the build container.
+RUN mkdir /novus
+COPY --from=build /novus/bin/. /novus
+
+# Add the novus directory to the path.
+ENV PATH="/novus:${PATH}"
+
+# Copy the examples into the run container.
+COPY examples /examples

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,8 @@ clean:
 watch.nov:
 	./scripts/watch_nov.sh . ./bin/novc
 
+.PHONY: docker.run
+docker.run:
+	sudo docker build -t novus . && sudo docker run --rm -it novus
+
 .SILENT:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![build-test](https://img.shields.io/github/workflow/status/bastianblokland/novus/build-test/master)](https://github.com/BastianBlokland/novus/actions?query=workflow%3Abuild-test)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**-Work in progress-**
-
 Novus is a statically typed functional programming language, it compiles into instructions for a
 stack based vm. Compiler is fully handwritten with a recursive decedent parser, multiple stages
 of syntax analysis and optimizations.
@@ -20,6 +18,15 @@ knowledge about types or functions so there is no runtime type introspection, in
 focusses on making it easier to generate code at compile time (through function and type templates).
 
 Note this is intended as an academic exercise and not meant for production projects.
+
+## Docker
+
+You can quickly try it out using docker.
+Open a interactive container with the compiler, runtime and examples installed:
+`docker run --rm -it bastianblokland/novus bin/sh`
+
+Run an example:
+`nove examples/fizzbuzz.nov`
 
 ## Requirements
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(FetchContent)
 
 # Cli11 command line parser.
-message(">> Fetching dependency: cli11")
+message(STATUS "Fetching dependency: cli11")
 FetchContent_Declare(
   cli11
   GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
@@ -10,7 +10,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cli11)
 
 # Rang library for colored command line output.
-message(">> Fetching dependency: rang")
+message(STATUS "Fetching dependency: rang")
 FetchContent_Declare(
   rang
   GIT_REPOSITORY https://github.com/agauniyal/rang.git
@@ -19,7 +19,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(rang)
 
 # Compiler.
-message(">> Configuring novc executable")
+message(STATUS "Configuring novc executable")
 add_executable(novc
   novc/compiler.cpp
   novc/main.cpp)
@@ -38,7 +38,7 @@ target_link_libraries(novc PRIVATE novasm)
 target_link_libraries(novc PRIVATE opt)
 
 # Runtime.
-message(">> Configuring novrt executable")
+message(STATUS "Configuring novrt executable")
 add_executable(novrt novrt/main.cpp)
 target_compile_features(novrt PUBLIC cxx_std_17)
 if(MSVC)
@@ -50,7 +50,7 @@ target_link_libraries(novrt PRIVATE vm)
 target_link_libraries(novrt PRIVATE novasm)
 
 # Evaluator.
-message(">> Configuring nove executable")
+message(STATUS "Configuring nove executable")
 add_executable(nove nove/main.cpp)
 target_compile_features(nove PUBLIC cxx_std_17)
 if(MSVC)
@@ -66,7 +66,7 @@ target_link_libraries(nove PRIVATE vm)
 target_link_libraries(nove PRIVATE opt)
 
 # Lexer diagnostic tool.
-message(">> Configuring novdiag-lex executable")
+message(STATUS "Configuring novdiag-lex executable")
 add_executable(novdiag-lex novdiag-lex/main.cpp)
 target_compile_features(novdiag-lex PUBLIC cxx_std_17)
 if(MSVC)
@@ -79,7 +79,7 @@ target_include_directories(novdiag-lex PRIVATE ${rang_SOURCE_DIR}/include)
 target_link_libraries(novdiag-lex PRIVATE lex)
 
 # Parser diagnostic tool.
-message(">> Configuring novdiag-parse executable")
+message(STATUS "Configuring novdiag-parse executable")
 add_executable(novdiag-parse novdiag-parse/main.cpp)
 target_compile_features(novdiag-parse PUBLIC cxx_std_17)
 if(MSVC)
@@ -92,7 +92,7 @@ target_include_directories(novdiag-parse PRIVATE ${rang_SOURCE_DIR}/include)
 target_link_libraries(novdiag-parse PRIVATE parse)
 
 # Program diagnostic tool.
-message(">> Configuring novdiag-prog executable")
+message(STATUS "Configuring novdiag-prog executable")
 add_executable(novdiag-prog novdiag-prog/main.cpp)
 target_compile_features(novdiag-prog PUBLIC cxx_std_17)
 if(MSVC)
@@ -107,7 +107,7 @@ target_link_libraries(novdiag-prog PRIVATE frontend)
 target_link_libraries(novdiag-prog PRIVATE opt)
 
 # Assembly diagnostic tool.
-message(">> Configuring novdiag-asm executable")
+message(STATUS "Configuring novdiag-asm executable")
 add_executable(novdiag-asm novdiag-asm/main.cpp)
 target_compile_features(novdiag-asm PUBLIC cxx_std_17)
 if(MSVC)

--- a/novstd/CMakeLists.txt
+++ b/novstd/CMakeLists.txt
@@ -12,7 +12,7 @@ function(configure_novstd_file file)
   set(srcFile ${file}.nov)
   set(tgtFile ${EXECUTABLE_OUTPUT_PATH}/std/${file}.nov)
 
-  message(">> Configuring ${file}.nov")
+  message(STATUS "Configuring ${file}.nov")
 
   # Copy to output dir.
   configure_file(${srcFile} ${tgtFile} COPYONLY)

--- a/scripts/docker_publish.sh
+++ b/scripts/docker_publish.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+# --------------------------------------------------------------------------------------------------
+# Build and publish the docker container.
+# --------------------------------------------------------------------------------------------------
+
+info()
+{
+  echo "${1}"
+}
+
+error()
+{
+  echo "ERROR: ${1}" >&2
+}
+
+fail()
+{
+  error "${1}"
+  exit 1
+}
+
+hasCommand()
+{
+  [ -x "$(command -v "${1}")" ]
+}
+
+printUsage()
+{
+  echo "Options:"
+  echo "-h,--help    Print this usage information"
+  echo "-f,--file    Path to the dockerfile, default: 'Dockerfile'"
+  echo "-r,--repo    Docker repository, default: 'bastianblokland/novus'"
+}
+
+getVersionFromDockerImage()
+{
+  local tgtImg="${1}"
+  test -n "${tgtImg}" || fail "Provide docker image name as arg 1"
+
+  local versionNum
+  versionNum=$(sudo docker run --rm --entrypoint cat "${tgtImg}" /novus/VERSION)
+
+  test -n "${versionNum}" || fail "Failed to retreive version number"
+
+  echo "${versionNum}"
+}
+
+# Defaults.
+dockerFile="Dockerfile"
+repository="bastianblokland/novus"
+
+# Parse options.
+while [[ $# -gt 0 ]]
+do
+  case "${1}" in
+    -h|--help)
+      echo "Novus -- Docker publish"
+      printUsage
+      exit 0
+      ;;
+    -f|--file)
+      dockerFile="${2}"
+      shift 2
+      ;;
+    -r|--repo)
+      repository="${2}"
+      shift 2
+      ;;
+    *)
+      error "Unknown option '${1}'"
+      printUsage
+      exit 1
+      ;;
+  esac
+done
+
+# Verify dependencies.
+hasCommand docker || fail "'docker' not found on path, it is required"
+
+readonly imageName="novus"
+
+info "Building docker image"
+sudo docker build -t "${imageName}" . --file "${dockerFile}"
+
+readonly tag=$(getVersionFromDockerImage "${imageName}")
+
+info "Puhsing image: ${repository}:${tag} to repository"
+sudo docker tag "${imageName}" "${repository}:${tag}"
+
+info "Tagging image: ${repository}:latest"
+sudo docker tag "${imageName}" "${repository}:latest"
+
+info "Pushing image to repository"
+sudo docker push "${repository}:${tag}"
+sudo docker push "${repository}:latest"
+
+info "Sucesfully published docker image"
+exit 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Input.
-message(">> Configuring input library")
+message(STATUS "Configuring input library")
 add_library(input STATIC
   input/char_escape.cpp
   input/info.cpp
@@ -16,7 +16,7 @@ target_include_directories(input PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(input PRIVATE input)
 
 # Lexer.
-message(">> Configuring lex library")
+message(STATUS "Configuring lex library")
 add_library(lex STATIC
   lex/error.cpp
   lex/lexer.cpp
@@ -38,7 +38,7 @@ target_include_directories(lex PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(lex PRIVATE lex)
 
 # Parser.
-message(">> Configuring parse library")
+message(STATUS "Configuring parse library")
 add_library(parse STATIC
   parse/argument_list_decl.cpp
   parse/error.cpp
@@ -86,7 +86,7 @@ target_include_directories(parse PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(parse PRIVATE parse)
 
 # Program (internal representation).
-message(">> Configuring prog library")
+message(STATUS "Configuring prog library")
 add_library(prog STATIC
   prog/expr/node_assign.cpp
   prog/expr/node_call_dyn.cpp
@@ -157,7 +157,7 @@ target_include_directories(prog PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(prog PRIVATE prog)
 
 # Frontend.
-message(">> Configuring frontend library")
+message(STATUS "Configuring frontend library")
 add_library(frontend STATIC
   frontend/internal/call_modifiers.cpp
   frontend/internal/check_inf_recursion.cpp
@@ -205,7 +205,7 @@ target_include_directories(frontend PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(frontend PRIVATE frontend)
 
 # Opt (optimiser).
-message(">> Configuring opt library")
+message(STATUS "Configuring opt library")
 add_library(opt STATIC
   opt/internal/const_remapper.cpp
   opt/internal/expr_matchers.cpp
@@ -230,7 +230,7 @@ target_include_directories(opt PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(opt PRIVATE opt)
 
 # Backend (assembly generator).
-message(">> Configuring backend library")
+message(STATUS "Configuring backend library")
 add_library(backend STATIC
   backend/internal/gen_expr.cpp
   backend/internal/gen_lazy.cpp
@@ -249,7 +249,7 @@ target_include_directories(backend PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(backend PRIVATE backend)
 
 # Novus Assembly.
-message(">> Configuring novasm library")
+message(STATUS "Configuring novasm library")
 add_library(novasm STATIC
   novasm/assembler.cpp
   novasm/assembly.cpp
@@ -267,7 +267,7 @@ target_include_directories(novasm PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(novasm PRIVATE novasm)
 
 # Virtual Machine.
-message(">> Configuring vm library")
+message(STATUS "Configuring vm library")
 add_library(vm STATIC
   vm/internal/executor_registry.cpp
   vm/internal/executor.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(FetchContent)
 
 # 'Catch2' testing framework.
-message(">> Fetching dependency: catch2")
+message(STATUS "Fetching dependency: catch2")
 FetchContent_Declare(
   catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
 # 'novtests' executable.
-message(">> Configuring novtests executable")
+message(STATUS "Configuring novtests executable")
 add_executable(novtests
   main.cpp
 
@@ -144,5 +144,5 @@ target_link_libraries(novtests PRIVATE opt)
 target_link_libraries(novtests PRIVATE vm)
 
 # Register novtests to CTest.
-message(">> Registering tests to CTest")
+message(STATUS "Registering tests to CTest")
 catch_discover_tests(novtests)


### PR DESCRIPTION
Adds a docker container with the compiler, runtime and examples installed:
https://hub.docker.com/repository/docker/bastianblokland/novus

Can be run interactively as a playground:
`docker run --rm -it bastianblokland/novus bin/sh`

`/novus/` contents:
* `VERSION`
* `novc`
* `novdiag-asm`
* `novdiag-lex`
* `novdiag-parse`
* `novdiag-prog`
* `nove`
* `novrt`
* `std`
* `std.nov`

`/novus` directory is added to the PATH env.
Examples are copied to: `/examples/`.

Base image is `alpine`.