### PR TITLE
Rename 'stream' to 'sys_stream'

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The Novus type system contains some basic types build in to the language:
 * `string`
 * `char` (8 bit unsigned integer)
 
-(Plus a few more niche types: `stream`, `function`, `action`, `future` and `lazy`).
+(Plus a few more niche types: `sys_stream`, `function`, `action`, `future` and `lazy`).
 
 Note: These are the types the language itself supports, there are however many more types
 implemented in the [standard library](https://github.com/BastianBlokland/novus/tree/master/novstd).

--- a/examples/perlin.nov
+++ b/examples/perlin.nov
@@ -33,7 +33,7 @@ fun min(Box b)
 fun max(Box b)
   b.origin + b.size
 
-act draw(I2 pos, stream out, Settings s, Duration t)
+act draw(I2 pos, sys_stream out, Settings s, Duration t)
   n = perlinNoise3d(pos.x * s.xyScale, pos.y * s.xyScale, float(t) * s.speed) * s.intensityScale;
   out.termCursorPos(pos.y, pos.x);
   (
@@ -47,7 +47,7 @@ act draw(I2 pos, stream out, Settings s, Duration t)
   out.streamWrite(n < s.fillThreshold ? "○" : "●");
   out.streamFlush()
 
-act loop(stream in, stream out, Settings s, Timestamp begin, int frame)
+act loop(sys_stream in, sys_stream out, Settings s, Timestamp begin, int frame)
   if in.readToEnd().length() != 0 || isInteruptRequested() -> false
   else ->
     now     = timestamp();
@@ -103,13 +103,13 @@ main()
 act getWindow()
   Box(I2(1, 1), I2(termGetWidth(), termGetHeight()))
 
-act setupTerminal(stream in, stream out)
+act setupTerminal(sys_stream in, sys_stream out)
   termSetOptions(TermOptions.NoEcho | TermOptions.NoBuffer);
   termAltScreen(out, true);
   termCursorShow(out, false);
   setOptions(in, StreamOptions.NoBlock)
 
-act resetTerminal(stream in, stream out)
+act resetTerminal(sys_stream in, sys_stream out)
   termCursorShow(out, true);
   termAltScreen(out, false);
   termStyle(out, TermStyle.Reset);

--- a/examples/snake.nov
+++ b/examples/snake.nov
@@ -171,10 +171,10 @@ fun simulateGameover(GameState g)
 
 // -- Game loop
 
-act loop(stream in, stream out)
+act loop(sys_stream in, sys_stream out)
   loop(in, out, Duration(0), createGame(rngInit(), getWindow()))
 
-act loop(stream in, stream out, Duration prevFrameDur, GameState state)
+act loop(sys_stream in, sys_stream out, Duration prevFrameDur, GameState state)
   t1      = timestamp();
   window  = getWindow();
   input   = getInput(in.readToEnd());
@@ -190,14 +190,14 @@ act loop(stream in, stream out, Duration prevFrameDur, GameState state)
 
 // --- Draw game state
 
-act drawGame(stream out, GameState g, Box window, Duration frameDur)
+act drawGame(sys_stream out, GameState g, Box window, Duration frameDur)
   out.termClearScreen();
   out.drawBackground(g, window, frameDur);
   out.drawPickups(g.pickups);
   out.drawPlayer(g.player);
   out.streamFlush()
 
-act drawBackground(stream out, GameState g, Box window, Duration frameDur)
+act drawBackground(sys_stream out, GameState g, Box window, Duration frameDur)
   out.termStyle(TermStyle.FgBrightWhite);
   out.termStyle(g.gameover ? TermStyle.BgBrightRed : TermStyle.BgGreen);
   out.drawBox(window);
@@ -210,10 +210,10 @@ act drawBackground(stream out, GameState g, Box window, Duration frameDur)
     I2(5, 1));
   out.termStyle(TermStyle.Reset)
 
-act drawPickups(stream out, List{PickupState} pickups)
+act drawPickups(sys_stream out, List{PickupState} pickups)
   pickups.mapReverse(impure lambda (PickupState p) out.drawPickup(p))
 
-act drawPickup(stream out, PickupState pickup)
+act drawPickup(sys_stream out, PickupState pickup)
   out.termStyle(
     if pickup.value == 3 -> TermStyle.FgBrightYellow
     if pickup.value == 2 -> TermStyle.FgBrightCyan
@@ -222,7 +222,7 @@ act drawPickup(stream out, PickupState pickup)
   out.drawAt("●", pickup.pos);
   out.termStyle(TermStyle.Reset)
 
-act drawPlayer(stream out, PlayerState player)
+act drawPlayer(sys_stream out, PlayerState player)
   out.drawAt(
     if player.dir == Dir.up     -> "▲"
     if player.dir == Dir.down   -> "▼"
@@ -232,7 +232,7 @@ act drawPlayer(stream out, PlayerState player)
 
 // --- Misc drawing
 
-act drawBox(stream out, Box b)
+act drawBox(sys_stream out, Box b)
   out.drawAt(   "┌",  b.origin);
   out.drawAt(   "┐",  b.origin + I2(b.size.x - 1, 0));
   out.drawAt(   "└",  b.origin + I2(0,            b.size.y));
@@ -242,7 +242,7 @@ act drawBox(stream out, Box b)
   out.drawAtVer("│",  b.origin + I2(0,            1),         b.size.y - 2);
   out.drawAtVer("│",  b.origin + I2(b.size.x - 1, 1),         b.size.y - 2)
 
-act drawAtHor(stream out, string str, I2 pos, int times)
+act drawAtHor(sys_stream out, string str, I2 pos, int times)
   drawTimes = ( impure lambda (int times)
     if times <= 0 -> true
     else          -> out.streamWrite(str); self(--times)
@@ -250,7 +250,7 @@ act drawAtHor(stream out, string str, I2 pos, int times)
   out.termCursorPos(pos.y, pos.x);
   drawTimes(times)
 
-act drawAtVer(stream out, string str, I2 pos, int times)
+act drawAtVer(sys_stream out, string str, I2 pos, int times)
   drawTimes = ( impure lambda (int i)
     if i >= times -> true
     else          ->
@@ -260,7 +260,7 @@ act drawAtVer(stream out, string str, I2 pos, int times)
   );
   drawTimes(0)
 
-act drawAt(stream out, string str, I2 pos)
+act drawAt(sys_stream out, string str, I2 pos)
   out.termCursorPos(pos.y, pos.x);
   out.streamWrite(str)
 
@@ -280,13 +280,13 @@ main()
 act getWindow()
   Box(I2(1, 1), I2(termGetWidth(), termGetHeight()))
 
-act setupTerminal(stream in, stream out)
+act setupTerminal(sys_stream in, sys_stream out)
   termSetOptions(TermOptions.NoEcho | TermOptions.NoBuffer);
   termAltScreen(out, true);
   termCursorShow(out, false);
   setOptions(in, StreamOptions.NoBlock)
 
-act resetTerminal(stream in, stream out)
+act resetTerminal(sys_stream in, sys_stream out)
   termCursorShow(out, true);
   termAltScreen(out, false);
   termStyle(out, TermStyle.Reset);

--- a/ide/nano/novus.nanorc
+++ b/ide/nano/novus.nanorc
@@ -12,7 +12,7 @@ color brightyellow "((\b(is|as)\b)|(\+\+)|(\-\-)|(\&\&)|(\|\|)|(\<\<)|(\>\>)|(\<
 color cyan "\(|\)|\,|\;|\=|\{|\}|\."
 
 # Build-in types.
-color green "\b(int|long|float|bool|string|char|stream|function|action|future|lazy)\b"
+color green "\b(int|long|float|bool|string|char|sys_stream|function|action|future|lazy)\b"
 
 # Constants - Bool.
 color brightmagenta "\b(true|false)\b"

--- a/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
+++ b/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
@@ -39,7 +39,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(int|long|float|bool|string|char|stream|function|action|future|lazy)\b</string>
+					<string>\b(int|long|float|bool|string|char|sys_stream|function|action|future|lazy)\b</string>
 					<key>name</key>
 					<string>keyword.other.buildin.source.novus</string>
 				</dict>

--- a/ide/vscode/novus/syntaxes/novus.tmLanguage.json
+++ b/ide/vscode/novus/syntaxes/novus.tmLanguage.json
@@ -22,7 +22,7 @@
     "buildin_type": {
       "patterns": [
         {
-          "match": "\\b(int|long|float|bool|string|char|stream|function|action|future|lazy)\\b",
+          "match": "\\b(int|long|float|bool|string|char|sys_stream|function|action|future|lazy)\\b",
           "name": "keyword.other.buildin.source.novus"
         }
       ]

--- a/novstd/stream.nov
+++ b/novstd/stream.nov
@@ -7,31 +7,31 @@ import "text.nov"
 enum StreamOptions =
   NoBlock : 0b1
 
-struct StreamReadState = string txt, stream src
+struct StreamReadState = string txt, sys_stream src
 
 // -- Constructors
 
-fun StreamReadState(stream src)
+fun StreamReadState(sys_stream src)
   StreamReadState("", src)
 
 // -- Actions
 
-act isValid(stream s)
+act isValid(sys_stream s)
   s.streamCheckValid()
 
-act setOptions(stream s, StreamOptions opts)
+act setOptions(sys_stream s, StreamOptions opts)
   s.streamSetOptions(int(opts))
 
-act unsetOptions(stream s, StreamOptions opts)
+act unsetOptions(sys_stream s, StreamOptions opts)
   s.streamUnsetOptions(int(opts))
 
-act write(stream s, string str)
+act write(sys_stream s, string str)
   s.streamWrite(str)
 
-act write(stream s, char c)
+act write(sys_stream s, char c)
   s.streamWrite(c)
 
-act readToEnd(stream s)
+act readToEnd(sys_stream s)
   (
     impure lambda (string result)
       read = s.streamRead(512);
@@ -39,10 +39,10 @@ act readToEnd(stream s)
       else                  -> result
   )("")
 
-act readChar(stream s)
+act readChar(sys_stream s)
   s.streamRead()
 
-act readLine(stream s)
+act readLine(sys_stream s)
   (
     impure lambda (string result)
       c = s.streamRead();
@@ -51,7 +51,7 @@ act readLine(stream s)
       else                      -> self(result + c)
   )("")
 
-act copy(stream from, stream to)
+act copy(sys_stream from, sys_stream to)
   (
     impure lambda(int bytesCopied)
       read        = from.streamRead(512);

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -4,11 +4,11 @@ import "future.nov"
 // -- Types
 
 struct TcpServer =
-  stream socket,
+  sys_stream socket,
   int    port
 
 struct TcpConnection =
-  stream socket
+  sys_stream socket
 
 // -- Actions
 

--- a/novstd/terminal.nov
+++ b/novstd/terminal.nov
@@ -65,7 +65,7 @@ fun termEsc() char(27)
 act termStyle(TermStyle style)
   termStyle(consoleOpen(ConsoleKind.StdOut), style)
 
-act termStyle(stream s, TermStyle style)
+act termStyle(sys_stream s, TermStyle style)
   s.streamWrite(termEsc());
   s.streamWrite('[');
   s.streamWrite(string(style));
@@ -79,10 +79,10 @@ act termColor(float r, float g, float b)
 act termColor(float r, float g, float b, bool background)
   termColor(consoleOpen(ConsoleKind.StdOut), r, g, b, background)
 
-act termColor(stream s, float r, float g, float b)
+act termColor(sys_stream s, float r, float g, float b)
   termColor(s, r, g, b, false)
 
-act termColor(stream s, float r, float g, float b, bool background)
+act termColor(sys_stream s, float r, float g, float b, bool background)
   toDiscrete = ( lambda (float v)
     int(clamp(v, 0.0, 1.0) * 5.0 + 0.5)
   );
@@ -99,7 +99,7 @@ act termColor(stream s, float r, float g, float b, bool background)
 act termCursorMove(TermStyle s, TermDir dir, int amount)
   termCursorMove(consoleOpen(ConsoleKind.StdOut), dir, amount)
 
-act termCursorMove(stream s, TermDir dir, int amount)
+act termCursorMove(sys_stream s, TermDir dir, int amount)
   s.streamWrite(termEsc());
   s.streamWrite('[');
   s.streamWrite(string(amount));
@@ -112,7 +112,7 @@ act termCursorMove(stream s, TermDir dir, int amount)
 act termCursorCol(int column)
   termCursorCol(consoleOpen(ConsoleKind.StdOut), column)
 
-act termCursorCol(stream s, int column)
+act termCursorCol(sys_stream s, int column)
   s.streamWrite(termEsc());
   s.streamWrite('[');
   s.streamWrite(string(column));
@@ -121,7 +121,7 @@ act termCursorCol(stream s, int column)
 act termCursorPos(int row, int column)
   termCursorPos(consoleOpen(ConsoleKind.StdOut), row, column)
 
-act termCursorPos(stream s, int row, int column)
+act termCursorPos(sys_stream s, int row, int column)
   s.streamWrite(termEsc());
   s.streamWrite('[');
   s.streamWrite(string(row));
@@ -132,7 +132,7 @@ act termCursorPos(stream s, int row, int column)
 act termCursorShow(bool show)
   termCursorShow(consoleOpen(ConsoleKind.StdOut), show)
 
-act termCursorShow(stream s, bool show)
+act termCursorShow(sys_stream s, bool show)
   s.streamWrite(termEsc());
   s.streamWrite("[?25");
   s.streamWrite(show ? 'h' : 'l')
@@ -142,7 +142,7 @@ act termCursorShow(stream s, bool show)
 act termAltScreen(bool active)
   termAltScreen(consoleOpen(ConsoleKind.StdOut), active)
 
-act termAltScreen(stream s, bool active)
+act termAltScreen(sys_stream s, bool active)
   s.streamWrite(termEsc());
   s.streamWrite("[?1049");
   s.streamWrite(active ? 'h' : 'l')
@@ -152,13 +152,13 @@ act termAltScreen(stream s, bool active)
 act termClearScreen()
   termClearScreen(consoleOpen(ConsoleKind.StdOut), TermClearMode.All)
 
-act termClearScreen(stream s)
+act termClearScreen(sys_stream s)
   termClearScreen(s, TermClearMode.All)
 
 act termClearScreen(TermClearMode mode)
   termClearScreen(consoleOpen(ConsoleKind.StdOut), mode)
 
-act termClearScreen(stream s, TermClearMode mode)
+act termClearScreen(sys_stream s, TermClearMode mode)
   s.streamWrite(termEsc());
   s.streamWrite('[');
   s.streamWrite(string(mode));
@@ -167,7 +167,7 @@ act termClearScreen(stream s, TermClearMode mode)
 act termClearLine(TermClearMode mode)
   termClearLine(consoleOpen(ConsoleKind.StdOut), mode)
 
-act termClearLine(stream s, TermClearMode mode)
+act termClearLine(sys_stream s, TermClearMode mode)
   s.streamWrite(termEsc());
   s.streamWrite('[');
   s.streamWrite(string(mode));
@@ -178,7 +178,7 @@ act termClearLine(stream s, TermClearMode mode)
 act termReset()
   termReset(consoleOpen(ConsoleKind.StdOut))
 
-act termReset(stream s)
+act termReset(sys_stream s)
   s.streamWrite(termEsc());
   s.streamWrite('c')
 

--- a/src/frontend/internal/const_binder.cpp
+++ b/src/frontend/internal/const_binder.cpp
@@ -98,7 +98,7 @@ auto ConstBinder::getAllConstTypes() -> std::unordered_map<std::string, prog::sy
 
   ConstBinder* current = this;
   while (current) {
-    for (const auto visibleConst : *current->m_visibleConsts) {
+    for (const auto& visibleConst : *current->m_visibleConsts) {
       const auto& name = (*current->m_consts)[visibleConst].getName();
       const auto& type = (*current->m_consts)[visibleConst].getType();
       result.insert({name, type});

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -42,11 +42,11 @@ GetExpr::GetExpr(
 
 auto GetExpr::getValue() -> prog::expr::NodePtr& { return m_expr; }
 
-auto GetExpr::visit(const parse::CommentNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::CommentNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
-auto GetExpr::visit(const parse::ErrorNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::ErrorNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
@@ -61,7 +61,7 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
 
   // Gather the input types for the anonymous function.
   auto inputTypes = std::vector<prog::sym::TypeId>{};
-  for (const auto constId : consts.getNonBoundInputs()) {
+  for (const auto& constId : consts.getNonBoundInputs()) {
     inputTypes.push_back(consts[constId].getType());
   }
 
@@ -96,13 +96,13 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
   // Analyze the body of the anonymous function.
   auto visibleConsts = consts.getAll();
   auto constBinder   = ConstBinder{&consts, &visibleConsts, m_constBinder};
-  auto getExpr       = GetExpr{m_ctx,
-                         m_typeSubTable,
-                         &constBinder,
-                         *retType,
-                         selfSignature,
-                         isAction ? (Flags::AllowActionCalls | Flags::AllowPureFuncCalls)
-                                  : Flags::AllowPureFuncCalls};
+  auto getExpr       = GetExpr{
+      m_ctx,
+      m_typeSubTable,
+      &constBinder,
+      *retType,
+      selfSignature,
+      isAction ? (Flags::AllowActionCalls | Flags::AllowPureFuncCalls) : Flags::AllowPureFuncCalls};
   n[0].accept(&getExpr);
   if (!getExpr.m_expr) {
     assert(m_ctx->hasErrors());
@@ -123,7 +123,7 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
   }
 
   // Add the bound input types for this function.
-  for (const auto constId : consts.getBoundInputs()) {
+  for (const auto& constId : consts.getBoundInputs()) {
     inputTypes.push_back(consts[constId].getType());
   }
 
@@ -145,7 +145,7 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
     m_expr = getLitFunc(m_ctx, funcId);
   } else {
     auto boundArgs = std::vector<prog::expr::NodePtr>{};
-    for (const auto parentConstId : constBinder.getBoundParentConsts()) {
+    for (const auto& parentConstId : constBinder.getBoundParentConsts()) {
       boundArgs.push_back(prog::expr::constExprNode(*m_constBinder->getConsts(), parentConstId));
     }
     m_expr = getFuncClosure(m_ctx, funcId, std::move(boundArgs));
@@ -582,11 +582,11 @@ auto GetExpr::visit(const parse::ParenExprNode& n) -> void {
   m_expr = getSubExpr(n[0], m_typeHint, hasFlag<Flags::CheckedConstsAccess>());
 }
 
-auto GetExpr::visit(const parse::SwitchExprElseNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::SwitchExprElseNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
-auto GetExpr::visit(const parse::SwitchExprIfNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::SwitchExprIfNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
@@ -685,27 +685,27 @@ auto GetExpr::visit(const parse::UnaryExprNode& n) -> void {
   m_expr = prog::expr::callExprNode(*m_ctx->getProg(), func.value(), std::move(args));
 }
 
-auto GetExpr::visit(const parse::EnumDeclStmtNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::EnumDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
-auto GetExpr::visit(const parse::ExecStmtNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::ExecStmtNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
-auto GetExpr::visit(const parse::FuncDeclStmtNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::FuncDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
-auto GetExpr::visit(const parse::ImportStmtNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::ImportStmtNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
-auto GetExpr::visit(const parse::StructDeclStmtNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::StructDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 
-auto GetExpr::visit(const parse::UnionDeclStmtNode & /*unused*/) -> void {
+auto GetExpr::visit(const parse::UnionDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"GetExpr is not implemented for this node type"};
 }
 

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -177,7 +177,7 @@ auto isReservedTypeName(const std::string& name) -> bool {
       "bool",
       "string",
       "char",
-      "stream",
+      "sys_stream",
       "function",
       "action",
       "future",

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -90,7 +90,7 @@ public:
       -> internal::ConstRemapTable {
 
     auto table = internal::ConstRemapTable{};
-    for (const auto tgtConstId : tgtConsts.getAll()) {
+    for (const auto& tgtConstId : tgtConsts.getAll()) {
       const auto& tgtConstDecl = tgtConsts[tgtConstId];
 
       std::ostringstream oss;

--- a/src/opt/treeshake.cpp
+++ b/src/opt/treeshake.cpp
@@ -31,7 +31,7 @@ auto treeshake(const prog::Program& prog) -> prog::Program {
   }
 
   // Find all types used in user functions.
-  for (const auto funcId : funcs) {
+  for (const auto& funcId : funcs) {
     const auto& decl = prog.getFuncDecl(funcId);
     if (decl.getKind() == prog::sym::FuncKind::User) {
       const auto& def = prog.getFuncDef(funcId);
@@ -45,10 +45,10 @@ auto treeshake(const prog::Program& prog) -> prog::Program {
 
   // Create a new program and copy the used functions, types and the exec statements.
   auto result = prog::Program{};
-  for (const auto func : funcs) {
+  for (const auto& func : funcs) {
     prog::copyFunc(prog, &result, func);
   }
-  for (const auto type : types) {
+  for (const auto& type : types) {
     prog::copyType(prog, &result, type);
   }
   for (auto execItr = prog.beginExecStmts(); execItr != prog.endExecStmts(); ++execItr) {

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -28,7 +28,7 @@ Program::Program() :
     m_bool{m_typeDecls.registerType(sym::TypeKind::Bool, "bool")},
     m_string{m_typeDecls.registerType(sym::TypeKind::String, "string")},
     m_char{m_typeDecls.registerType(sym::TypeKind::Char, "char")},
-    m_stream{m_typeDecls.registerType(sym::TypeKind::Stream, "stream")} {
+    m_stream{m_typeDecls.registerType(sym::TypeKind::Stream, "sys_stream")} {
 
   using Fk = prog::sym::FuncKind;
   using Op = prog::Operator;


### PR DESCRIPTION
Main reasons:
- 'stream' was too generic and conflicted with var names often.
- 'sys_stream' makes it clearer that its interacting with the system.