### PR TITLE
Fix major bug in the vm stack

### DIFF
--- a/src/vm/internal/stack.hpp
+++ b/src/vm/internal/stack.hpp
@@ -75,7 +75,7 @@ public:
     auto result  = *tgtPtr;
     std::memmove(tgtPtr, tgtPtr + 1, sizeof(Value) * behind);
 
-    --m_stackMax;
+    --m_stackNext;
     return result;
   }
 


### PR DESCRIPTION
A bug in popAt left the stack corrupted, went unnoticed for very long as
its only used in a single p-call (StreamReadString).