### PR TITLE
Add invoke utilities to novstd

### DIFF
--- a/examples/perlin.nov
+++ b/examples/perlin.nov
@@ -79,13 +79,13 @@ act forBox(Box box, action{I2, bool} a, int itr, int numItrs)
   yOffset = itr % numItrs;
   xMax    = box.max().x;
   yMax    = box.max().y;
-  for = ( impure lambda (int x, int y)
+  invoke( impure lambda (int x, int y)
     if y >= yMax  -> true
     if x >= xMax  -> self(0, y + numItrs)
     else ->
       if !a(I2(x, y)) -> false
       else            -> self(++x, y)
-  ); for(box.min().x, box.min().y + yOffset)
+    , box.min().x, box.min().y + yOffset)
 
 // --- Entry point
 

--- a/include/opt/opt.hpp
+++ b/include/opt/opt.hpp
@@ -11,6 +11,7 @@ auto treeshake(const prog::Program& prog) -> prog::Program;
 
 // Inline function bodies into the callsites.
 auto inlineCalls(const prog::Program& prog) -> prog::Program;
+auto inlineCalls(const prog::Program& prog, bool& modified) -> prog::Program;
 
 // Remove unneeded constants.
 // * Unused constants are removed.

--- a/include/prog/sym/const_decl_table.hpp
+++ b/include/prog/sym/const_decl_table.hpp
@@ -49,6 +49,8 @@ public:
   [[nodiscard]] auto lookup(const std::string& name) const -> std::optional<ConstId>;
 
   [[nodiscard]] auto getOffset(ConstId id) const -> unsigned int;
+  [[nodiscard]] auto getHighestConstId() const -> ConstId;
+  [[nodiscard]] auto getNextConstId() const noexcept -> ConstId;
 
   auto registerBound(TypeId type) -> ConstId;
   auto registerInput(std::string name, TypeId type) -> ConstId;

--- a/novstd/env.nov
+++ b/novstd/env.nov
@@ -53,11 +53,11 @@ act getEnvOpt(string name)
   findEnvOpt(getEnvArgs(), name)
 
 act getEnvArgs()
-  (
+  invoke(
     impure lambda (int idx, List{string} result)
       if idx < 0  -> result
       else        -> self(--idx, getEnvArg(idx) :: result)
-  )(--getEnvArgCount(), List{string}())
+    , --getEnvArgCount(), List{string}())
 
 // -- Tests
 

--- a/novstd/func.nov
+++ b/novstd/func.nov
@@ -143,6 +143,38 @@ fun invert{T1, T2, T3}(function{T1, T2, T3, bool} pred)
 fun invert{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} pred)
   lambda (T1 a1, T2 a2, T3 a3, T4 a4) !pred(a1, a2, a3, a4)
 
+fun invoke{TR}(function{TR} func)
+  func()
+
+fun invoke{T1, TR}(function{T1, TR} func, T1 a1)
+  func(a1)
+
+fun invoke{T1, T2, TR}(function{T1, T2, TR} func, T1 a1, T2 a2)
+  func(a1, a2)
+
+fun invoke{T1, T2, T3, TR}(function{T1, T2, T3, TR} func, T1 a1, T2 a2, T3 a3)
+  func(a1, a2, a3)
+
+fun invoke{T1, T2, T3, T4, TR}(function{T1, T2, T3, T4, TR} func, T1 a1, T2 a2, T3 a3, T4 a4)
+  func(a1, a2, a3, a4)
+
+// -- Actions
+
+act invoke{TR}(action{TR} func)
+  func()
+
+act invoke{T1, TR}(action{T1, TR} func, T1 a1)
+  func(a1)
+
+act invoke{T1, T2, TR}(action{T1, T2, TR} func, T1 a1, T2 a2)
+  func(a1, a2)
+
+act invoke{T1, T2, T3, TR}(action{T1, T2, T3, TR} func, T1 a1, T2 a2, T3 a3)
+  func(a1, a2, a3)
+
+act invoke{T1, T2, T3, T4, TR}(action{T1, T2, T3, T4, TR} func, T1 a1, T2 a2, T3 a3, T4 a4)
+  func(a1, a2, a3, a4)
+
 // -- Tests
 
 assert(equals(1, 1) && !equals(1, 2))
@@ -284,6 +316,20 @@ assert(
   notEq = !eq;
   notEq(42, 42, 42, 1337) && !notEq(42, 42, 42, 42))
 
+assert(invoke(lambda() 42 + 1337) == 42 + 1337)
+
+assert(invoke(lambda(int x) 42 + x, 1337) == 42 + 1337)
+
+assert(invoke(lambda(int x, float y) string(x) + string(y), 1337, 42.42) == "133742.42")
+
+assert(
+  invoke(lambda(int x, float y, string z) string(x) + " " + string(y) + " " + z,
+    1337, 42.42, "hello world") == "1337 42.42 hello world")
+
+assert(
+  invoke(lambda(int x, float y, string z, long w) string(x) + " " + string(y) + " " + z + " " + string(w),
+    1337, 42.42, "hello world", -4242L) == "1337 42.42 hello world -4242")
+
 // -- Impure tests
 
 assert(
@@ -305,3 +351,17 @@ assert(
   actSum = (impure lambda (int a, int b, int c, int d) a + b + c + d);
   sumPlus42 = actSum[42];
   sumPlus42(1, 2, 3) == actSum(1, 2, 3, 42))
+
+assert(invoke(impure lambda() 42 + 1337) == 42 + 1337)
+
+assert(invoke(impure lambda(int x) 42 + x, 1337) == 42 + 1337)
+
+assert(invoke(impure lambda(int x, float y) string(x) + string(y), 1337, 42.42) == "133742.42")
+
+assert(
+  invoke(impure lambda(int x, float y, string z) string(x) + " " + string(y) + " " + z,
+    1337, 42.42, "hello world") == "1337 42.42 hello world")
+
+assert(
+  invoke(impure lambda(int x, float y, string z, long w) string(x) + " " + string(y) + " " + z + " " + string(w),
+    1337, 42.42, "hello world", -4242L) == "1337 42.42 hello world -4242")

--- a/novstd/future.nov
+++ b/novstd/future.nov
@@ -21,6 +21,6 @@ act getUntilInterupt{T}(future{T} f)
 
 // -- Tests
 
-assert(get(fork (lambda () 42)(), second()) == 42)
-assert(get(fork (lambda () 42)(), lambda () true) == 42)
-assert(get(fork (lambda () 42)(), lambda () false) == none())
+assert(get(fork invoke(lambda () 42), second()) == 42)
+assert(get(fork invoke(lambda () 42), lambda () true) == 42)
+assert(get(fork invoke(lambda () 42), lambda () false) == none())

--- a/novstd/option.nov
+++ b/novstd/option.nov
@@ -1,3 +1,5 @@
+import "func.nov"
+
 // -- Types
 
 union Option{T} = T, None
@@ -47,8 +49,8 @@ assert(Option{int}() == Option{int}())
 assert(Option{int}() ?? 42 == 42)
 assert(Option(1337) ?? 42 == 1337)
 
-assert(Option{int}() ?? lazy (lambda () 42)() == 42)
-assert(Option(1337) ?? lazy (lambda () 42)() == 1337)
+assert(Option{int}() ?? lazy invoke(lambda () 42) == 42)
+assert(Option(1337) ?? lazy invoke(lambda () 42) == 1337)
 
 assert(Option(42).string() == "42")
 assert(Option{int}().string() == "none")

--- a/novstd/stream.nov
+++ b/novstd/stream.nov
@@ -32,33 +32,33 @@ act write(sys_stream s, char c)
   s.streamWrite(c)
 
 act readToEnd(sys_stream s)
-  (
+  invoke(
     impure lambda (string result)
       read = s.streamRead(512);
       if read.length() > 0  -> self(result + read)
       else                  -> result
-  )("")
+    , "")
 
 act readChar(sys_stream s)
   s.streamRead()
 
 act readLine(sys_stream s)
-  (
+  invoke(
     impure lambda (string result)
       c = s.streamRead();
       if c == '\r'              -> self(result)
       if c == '\n' || c == '\0' -> result
       else                      -> self(result + c)
-  )("")
+  , "")
 
 act copy(sys_stream from, sys_stream to)
-  (
+  invoke(
     impure lambda(int bytesCopied)
       read        = from.streamRead(512);
       readLength  = read.length();
       if readLength > 0 -> to.streamWrite(read); self(bytesCopied + readLength)
       else              -> bytesCopied
-  )(0)
+  , 0)
 
 act readLine(StreamReadState state)
   state.readUntil("\n" :: "\r\n" :: List{string}())
@@ -67,7 +67,7 @@ act readUntil(StreamReadState state, List{string} patterns)
   state.readUntil(patterns, true)
 
 act readUntil(StreamReadState state, List{string} patterns, bool consumePattern)
-  (
+  invoke(
     impure lambda (string txt)
       p = patterns.fold(  ( lambda (Pair{int, string} best, string p)
                               idx = txt.indexOf(p);
@@ -84,4 +84,4 @@ act readUntil(StreamReadState state, List{string} patterns, bool consumePattern)
         read = state.src.streamRead(512);
         if read.isEmpty() -> Pair("", state)
         else              -> self(txt + read)
-  )(state.txt)
+  , state.txt)

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -78,52 +78,52 @@ fun startsWith(string str, string subStr)
   startsWithOffset(str, 0, subStr)
 
 fun startsWithOffset(string str, int idx, string subStr)
-  (
+  invoke(
     lambda (int subStrIdx)
       if subStrIdx >= subStr.length()               -> true
       if subStrIdx >= str.length()                  -> false
       if str[idx + subStrIdx] != subStr[subStrIdx]  -> false
       else                                          -> self(++subStrIdx)
-  )(0)
+  , 0)
 
 fun endsWith(string str, string subStr)
-  (
+  invoke(
     lambda (int revIdx)
       if revIdx >= subStr.length()                                          -> true
       if revIdx >= str.length()                                             -> false
       if str[--str.length() - revIdx] != subStr[--subStr.length() - revIdx] -> false
       else                                                                  -> self(++revIdx)
-  )(0)
+  , 0)
 
 fun any(string str, function{char, bool} pred)
-  (
+  invoke(
     lambda (int idx)
       if idx >= str.length()  -> false
       else                    -> pred(str[idx]) || self(++idx)
-  )(0)
+  , 0)
 
 fun all(string str, function{char, bool} pred)
-  (
+  invoke(
     lambda (int idx)
       if idx >= str.length()  -> true
       else                    -> pred(str[idx]) && self(++idx)
-  )(0)
+  , 0)
 
 fun none(string str, function{char, bool} pred)
-  (
+  invoke(
     lambda (int idx)
       if idx >= str.length()  -> true
       else                    -> !pred(str[idx]) && self(++idx)
-  )(0)
+  , 0)
 
 fun replace(string str, string old, string new)
-  (
+  invoke(
     lambda (string str, int startIdx)
       idx = str.indexOf(startIdx, old, 0);
       if idx < 0  ->  str
       else        ->  newStr = str[0, idx] + new + str[idx + old.length(), str.length()];
                       self(newStr, idx + new.length())
-  )(str, 0)
+  , str, 0)
 
 fun insert(string str, int idx, string val)
   if idx == 0             -> val + str
@@ -135,30 +135,30 @@ fun padLeft(string str, int length, char c)
   else                      -> str
 
 fun fold{T}(string str, function{T, char, T} func)
-  (
+  invoke(
     lambda (int idx, T result)
       idx >= str.length() ? result : self(++idx, func(result, str[idx]))
-  )(0, T())
+  , 0, T())
 
 fun transform(string str, function{char, string} func)
   str.fold(lambda (string res, char c) res + func(c))
 
 fun split(string str, function{char, bool} pred)
-  (
+  invoke(
     lambda (int startIdx, int endIdx, List{string} result)
       if startIdx < 0         -> startIdx == endIdx ? result : str[startIdx, ++endIdx] :: result
       if pred(str[startIdx])  -> startIdx == endIdx ?
         self(--startIdx, --endIdx, result) :
         self(--startIdx, --startIdx, str[++startIdx, ++endIdx] :: result)
       else                    -> self(--startIdx, endIdx, result)
-  )(--str.length(), --str.length(), List{string}())
+  , --str.length(), --str.length(), List{string}())
 
 fun toChars(string str)
-  (
+  invoke(
     lambda (int idx, List{char} result)
       if idx < 0  -> result
       else        -> self(--idx, str[idx] :: result)
-  )(--str.length(), List{char}())
+  , --str.length(), List{char}())
 
 fun join(List{string} l)
   l.sum()

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -111,11 +111,17 @@ private:
 };
 
 auto inlineCalls(const prog::Program& prog) -> prog::Program {
+  auto modified = false;
+  return inlineCalls(prog, modified);
+}
+
+auto inlineCalls(const prog::Program& prog, bool& modified) -> prog::Program {
   return internal::rewrite(
       prog,
       [](const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::ConstDeclTable* consts) {
         return std::make_unique<CallInlineRewriter>(prog, funcId, consts);
-      });
+      },
+      modified);
 }
 
 } // namespace opt

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -94,7 +94,7 @@ public:
       const auto& tgtConstDecl = tgtConsts[tgtConstId];
 
       std::ostringstream oss;
-      oss << "__inlined_" << m_consts->getCount() << '_' << tgtConstDecl.getName();
+      oss << "__inlined_" << m_consts->getNextConstId().getNum() << '_' << tgtConstDecl.getName();
 
       auto remappedConstId = m_consts->registerLocal(oss.str(), tgtConstDecl.getType());
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(novtests
   opt/call_inline_test.cpp
   opt/const_elimination_test.cpp
   opt/precompute_literals_test.cpp
+  opt/synergy_test.cpp
   opt/treeshake_test.cpp
 
   parse/comment_test.cpp

--- a/tests/opt/call_inline_test.cpp
+++ b/tests/opt/call_inline_test.cpp
@@ -20,22 +20,22 @@ TEST_CASE("Call inline", "[opt]") {
     auto inlinedProg = inlineCalls(output.getProg());
 
     // Verify that 'funcB' was inlined into 'funcA' as expected.
-    auto funcBId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
-    REQUIRE(funcBId);
+    auto funcAId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
+    REQUIRE(funcAId);
 
-    const auto& inlBDef = inlinedProg.getFuncDef(*funcBId);
-    auto inlBExprs      = std::vector<prog::expr::NodePtr>{};
+    const auto& inlADef = inlinedProg.getFuncDef(*funcAId);
+    auto inlAExprs      = std::vector<prog::expr::NodePtr>{};
 
-    inlBExprs.push_back(prog::expr::assignExprNode(
-        inlBDef.getConsts(),
-        *inlBDef.getConsts().lookup("__inlined_0_i"),
+    inlAExprs.push_back(prog::expr::assignExprNode(
+        inlADef.getConsts(),
+        *inlADef.getConsts().lookup("__inlined_0_i"),
         prog::expr::litIntNode(inlinedProg, 42))); // NOLINT: Magic numbers
 
-    inlBExprs.push_back(prog::expr::constExprNode(
-        inlBDef.getConsts(), *inlBDef.getConsts().lookup("__inlined_0_i")));
-    auto inlBGroupExpr = prog::expr::groupExprNode(std::move(inlBExprs));
+    inlAExprs.push_back(prog::expr::constExprNode(
+        inlADef.getConsts(), *inlADef.getConsts().lookup("__inlined_0_i")));
+    auto inlAGroupExpr = prog::expr::groupExprNode(std::move(inlAExprs));
 
-    CHECK(inlBDef.getExpr() == *inlBGroupExpr);
+    CHECK(inlADef.getExpr() == *inlAGroupExpr);
   }
 
   SECTION("Inline nested call") {
@@ -48,22 +48,22 @@ TEST_CASE("Call inline", "[opt]") {
     auto inlinedProg = inlineCalls(output.getProg());
 
     // Verify that 'funcB' and 'funcC' was inlined into 'funcA' as expected.
-    auto funcBId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
-    REQUIRE(funcBId);
+    auto funcAId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
+    REQUIRE(funcAId);
 
-    const auto& inlBDef = inlinedProg.getFuncDef(*funcBId);
-    auto inlBExprs      = std::vector<prog::expr::NodePtr>{};
+    const auto& inlADef = inlinedProg.getFuncDef(*funcAId);
+    auto inlAExprs      = std::vector<prog::expr::NodePtr>{};
 
-    inlBExprs.push_back(prog::expr::assignExprNode(
-        inlBDef.getConsts(),
-        *inlBDef.getConsts().lookup("__inlined_0_i"),
+    inlAExprs.push_back(prog::expr::assignExprNode(
+        inlADef.getConsts(),
+        *inlADef.getConsts().lookup("__inlined_0_i"),
         prog::expr::litIntNode(inlinedProg, 42))); // NOLINT: Magic numbers
 
-    inlBExprs.push_back(prog::expr::constExprNode(
-        inlBDef.getConsts(), *inlBDef.getConsts().lookup("__inlined_0_i")));
-    auto inlBGroupExpr = prog::expr::groupExprNode(std::move(inlBExprs));
+    inlAExprs.push_back(prog::expr::constExprNode(
+        inlADef.getConsts(), *inlADef.getConsts().lookup("__inlined_0_i")));
+    auto inlAGroupExpr = prog::expr::groupExprNode(std::move(inlAExprs));
 
-    CHECK(inlBDef.getExpr() == *inlBGroupExpr);
+    CHECK(inlADef.getExpr() == *inlAGroupExpr);
   }
 
   SECTION("Inline nested call in arg") {
@@ -76,22 +76,22 @@ TEST_CASE("Call inline", "[opt]") {
     auto inlinedProg = inlineCalls(output.getProg());
 
     // Verify that 'funcB' and 'funcC' was inlined into 'funcA' as expected.
-    auto funcBId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
-    REQUIRE(funcBId);
+    auto funcAId = inlinedProg.lookupFunc("funcA", prog::sym::TypeSet{}, prog::OvOptions{});
+    REQUIRE(funcAId);
 
-    const auto& inlBDef = inlinedProg.getFuncDef(*funcBId);
-    auto inlBExprs      = std::vector<prog::expr::NodePtr>{};
+    const auto& inlADef = inlinedProg.getFuncDef(*funcAId);
+    auto inlAExprs      = std::vector<prog::expr::NodePtr>{};
 
-    inlBExprs.push_back(prog::expr::assignExprNode(
-        inlBDef.getConsts(),
-        *inlBDef.getConsts().lookup("__inlined_0_i"),
+    inlAExprs.push_back(prog::expr::assignExprNode(
+        inlADef.getConsts(),
+        *inlADef.getConsts().lookup("__inlined_0_i"),
         prog::expr::litIntNode(inlinedProg, 42))); // NOLINT: Magic numbers
 
-    inlBExprs.push_back(prog::expr::constExprNode(
-        inlBDef.getConsts(), *inlBDef.getConsts().lookup("__inlined_0_i")));
-    auto inlBGroupExpr = prog::expr::groupExprNode(std::move(inlBExprs));
+    inlAExprs.push_back(prog::expr::constExprNode(
+        inlADef.getConsts(), *inlADef.getConsts().lookup("__inlined_0_i")));
+    auto inlAGroupExpr = prog::expr::groupExprNode(std::move(inlAExprs));
 
-    CHECK(inlBDef.getExpr() == *inlBGroupExpr);
+    CHECK(inlADef.getExpr() == *inlAGroupExpr);
   }
 }
 

--- a/tests/opt/synergy_test.cpp
+++ b/tests/opt/synergy_test.cpp
@@ -1,10 +1,6 @@
 #include "catch2/catch.hpp"
 #include "helpers.hpp"
 #include "opt/opt.hpp"
-#include "prog/expr/node_assign.hpp"
-#include "prog/expr/node_call.hpp"
-#include "prog/expr/node_const.hpp"
-#include "prog/expr/node_group.hpp"
 #include "prog/expr/node_lit_int.hpp"
 
 namespace opt {

--- a/tests/opt/synergy_test.cpp
+++ b/tests/opt/synergy_test.cpp
@@ -1,0 +1,34 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "opt/opt.hpp"
+#include "prog/expr/node_assign.hpp"
+#include "prog/expr/node_call.hpp"
+#include "prog/expr/node_const.hpp"
+#include "prog/expr/node_group.hpp"
+#include "prog/expr/node_lit_int.hpp"
+
+namespace opt {
+
+TEST_CASE("Optimization synergy", "[opt]") {
+
+  SECTION("Dynamic calls to function literals are inlined") {
+
+    const auto& output = ANALYZE("fun invoke(function{int, int} func, int arg) func(arg) "
+                                 "fun funcB(int i) i "
+                                 "act actA() invoke(funcB, 42) "
+                                 "actA()");
+    REQUIRE(output.isSuccess());
+
+    auto optimizedProg = optimize(output.getProg());
+
+    // Verify that 'funcB' and 'invoke' are both inlined into 'funcA' as expected.
+    auto actAId = optimizedProg.lookupFunc("actA", prog::sym::TypeSet{}, prog::OvOptions{});
+    REQUIRE(actAId);
+
+    const auto& inlADef = optimizedProg.getFuncDef(*actAId);
+
+    CHECK(inlADef.getExpr() == *prog::expr::litIntNode(optimizedProg, 42));
+  }
+}
+
+} // namespace opt


### PR DESCRIPTION
Adds `invoke(...)` utilities to `novstd/func.nov` can be more readable when immediately invoking a lambda.

Also contains tunings to the optimizer to make sure this pattern has exactly the same performance as just manually invoking the lambda.