### PR TITLE
Interupt api improvements

### DIFF
--- a/examples/perlin.nov
+++ b/examples/perlin.nov
@@ -48,7 +48,7 @@ act draw(I2 pos, sys_stream out, Settings s, Duration t)
   out.streamFlush()
 
 act loop(sys_stream in, sys_stream out, Settings s, Timestamp begin, int frame)
-  if in.readToEnd().length() != 0 || isInteruptRequested() -> false
+  if in.readToEnd().length() != 0 || interuptIsRequested() -> false
   else ->
     now     = timestamp();
     elapsed = now - begin;

--- a/examples/snake.nov
+++ b/examples/snake.nov
@@ -178,7 +178,7 @@ act loop(sys_stream in, sys_stream out, Duration prevFrameDur, GameState state)
   t1      = timestamp();
   window  = getWindow();
   input   = getInput(in.readToEnd());
-  if input is InputQuit || isInteruptRequested()  -> false
+  if input is InputQuit || interuptIsRequested()  -> false
   if input is InputRestart                        -> loop(in, out)
   else ->
     newState  = simulateGame(state, window, input);

--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -114,7 +114,7 @@ act main(int port, Content content)
         handleConnection(ctx)
     );
     stopCond    = (
-      impure lambda () inStream.readChar() != '\0' || isInteruptRequested()
+      impure lambda () inStream.readChar() != '\0' || interuptIsRequested()
     );
     srv.acceptLoop(handleCon, stopCond);
 

--- a/include/novasm/pcall_code.hpp
+++ b/include/novasm/pcall_code.hpp
@@ -34,10 +34,11 @@ enum class PCallCode : uint8_t {
   TermGetWidth     = 62, // ()    -> (int)  Get the width (num columns) of the terminal.
   TermGetHeight    = 63, // ()    -> (int)  Get the height (num rows) of the terminal.
 
-  GetEnvArg      = 70, // (int)     -> (string) Get an environment argument by index.
-  GetEnvArgCount = 71, // ()        -> (int)    Get the amount of environment arguments provided.
-  GetEnvVar      = 72, // (string)  -> (string) Get a environment variable by name.
-  IsInteruptReq  = 73, // ()        -> (int)    Check if an interupt has been requested.
+  GetEnvArg        = 70, // (int)     -> (string) Get an environment argument by index.
+  GetEnvArgCount   = 71, // ()        -> (int)    Get the amount of environment arguments provided.
+  GetEnvVar        = 72, // (string)  -> (string) Get a environment variable by name.
+  InteruptIsReq    = 73, // ()        -> (int)    Check if an interupt has been requested.
+  InteruptResetReq = 74, // ()        -> (int)    Reset the 'is requested' flag, returns success.
 
   ClockMicroSinceEpoch = 80, // () -> (long) Get the elapsed microseconds since unix epoch.
   ClockNanoSteady      = 81, // () -> (long) Get process steady clock in nanoseconds.

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -141,10 +141,11 @@ enum class FuncKind {
   ActionTermGetWidth,     // Get the width of the terminal device.
   ActionTermGetHeight,    // Get the height of the terminal device.
 
-  ActionGetEnvArgCount, // Get the amount of environment arguments passed to the application.
-  ActionGetEnvArg,      // Get a environment argument string at a specific index.
-  ActionGetEnvVar,      // Get a environment variable by name.
-  ActionIsInteruptReq,  // Check if an interupt has been requested.
+  ActionGetEnvArgCount,   // Get the amount of environment arguments passed to the application.
+  ActionGetEnvArg,        // Get a environment argument string at a specific index.
+  ActionGetEnvVar,        // Get a environment variable by name.
+  ActionInteruptIsReq,    // Check if an interupt has been requested.
+  ActionInteruptResetReq, // Reset the interupt requested flag.
 
   ActionClockMicroSinceEpoch, // Return a long of the amount of microseconds since epoch
                               // (01-01-1970).

--- a/novstd/future.nov
+++ b/novstd/future.nov
@@ -17,7 +17,7 @@ act get{T}(future{T} f, action{bool} predicate, Duration checkInternal)
   else           -> none()
 
 act getUntilInterupt{T}(future{T} f)
-  f.get(impure lambda() !isInteruptRequested())
+  f.get(impure lambda() !interuptIsRequested())
 
 // -- Tests
 

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -544,8 +544,11 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::ActionGetEnvVar:
     m_asmb->addPCall(novasm::PCallCode::GetEnvVar);
     break;
-  case prog::sym::FuncKind::ActionIsInteruptReq:
-    m_asmb->addPCall(novasm::PCallCode::IsInteruptReq);
+  case prog::sym::FuncKind::ActionInteruptIsReq:
+    m_asmb->addPCall(novasm::PCallCode::InteruptIsReq);
+    break;
+  case prog::sym::FuncKind::ActionInteruptResetReq:
+    m_asmb->addPCall(novasm::PCallCode::InteruptResetReq);
     break;
 
   case prog::sym::FuncKind::ActionClockMicroSinceEpoch:
@@ -755,7 +758,7 @@ auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
   m_asmb->label(endLabel);
 }
 
-auto GenExpr::visit(const prog::expr::FailNode & /*unused*/) -> void { m_asmb->addFail(); }
+auto GenExpr::visit(const prog::expr::FailNode& /*unused*/) -> void { m_asmb->addFail(); }
 
 auto GenExpr::visit(const prog::expr::LitBoolNode& n) -> void {
   m_asmb->addLoadLitInt(n.getVal() ? 1U : 0U);

--- a/src/novasm/pcall_code.cpp
+++ b/src/novasm/pcall_code.cpp
@@ -75,8 +75,11 @@ auto operator<<(std::ostream& out, const PCallCode& rhs) noexcept -> std::ostrea
   case PCallCode::GetEnvVar:
     out << "get-env-var";
     break;
-  case PCallCode::IsInteruptReq:
-    out << "is-interupt-req";
+  case PCallCode::InteruptIsReq:
+    out << "interupt-is-req";
+    break;
+  case PCallCode::InteruptResetReq:
+    out << "interupt-reset-req";
     break;
 
   case PCallCode::ClockMicroSinceEpoch:

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -295,7 +295,9 @@ Program::Program() :
   m_funcDecls.registerAction(
       *this, Fk::ActionGetEnvVar, "getEnvVar", sym::TypeSet{m_string}, m_string);
   m_funcDecls.registerAction(
-      *this, Fk::ActionIsInteruptReq, "isInteruptRequested", sym::TypeSet{}, m_bool);
+      *this, Fk::ActionInteruptIsReq, "interuptIsRequested", sym::TypeSet{}, m_bool);
+  m_funcDecls.registerAction(
+      *this, Fk::ActionInteruptResetReq, "interuptResetRequested", sym::TypeSet{}, m_bool);
 
   m_funcDecls.registerAction(
       *this, Fk::ActionClockMicroSinceEpoch, "clockMicroSinceEpoch", sym::TypeSet{}, m_long);

--- a/src/vm/internal/interupt.cpp
+++ b/src/vm/internal/interupt.cpp
@@ -21,8 +21,9 @@ auto interuptResetRequested() noexcept -> bool {
 auto interruptHandler(DWORD dwCtrlType) noexcept -> int {
   switch (dwCtrlType) {
   case CTRL_C_EVENT:
+    // NOTE: We are treating 'BREAK' also as an interupt because in win32 'CTRL_C' (aka interupt),
+    // is pretty weird and cannot for example be send to other processes.
   case CTRL_BREAK_EVENT:
-  case CTRL_CLOSE_EVENT:
     g_interruptRequested.store(true, std::memory_order_release);
     return true; // Indicate that we have handled the event.
   default:

--- a/src/vm/internal/interupt.cpp
+++ b/src/vm/internal/interupt.cpp
@@ -7,8 +7,13 @@ namespace vm::internal {
 
 static std::atomic_bool g_interruptRequested = false;
 
-auto isInterruptRequested() noexcept -> bool {
+auto interuptIsRequested() noexcept -> bool {
   return g_interruptRequested.load(std::memory_order_acquire);
+}
+
+auto interuptResetRequested() noexcept -> bool {
+  g_interruptRequested.store(false, std::memory_order_release);
+  return true; // Atm this cannot fail.
 }
 
 #if defined(_WIN32)
@@ -25,7 +30,7 @@ auto interruptHandler(DWORD dwCtrlType) noexcept -> int {
   }
 }
 
-auto setupInterruptHandler() noexcept -> bool {
+auto interruptSetupHandler() noexcept -> bool {
   return SetConsoleCtrlHandler(interruptHandler, true);
 }
 
@@ -35,7 +40,7 @@ auto interruptHandler(int /*unused*/) noexcept -> void {
   g_interruptRequested.store(true, std::memory_order_release);
 }
 
-auto setupInterruptHandler() noexcept -> bool {
+auto interruptSetupHandler() noexcept -> bool {
 
   struct sigaction actionInfo = {};
   actionInfo.sa_handler       = interruptHandler;

--- a/src/vm/internal/interupt.hpp
+++ b/src/vm/internal/interupt.hpp
@@ -2,8 +2,10 @@
 
 namespace vm::internal {
 
-auto setupInterruptHandler() noexcept -> bool;
+auto interruptSetupHandler() noexcept -> bool;
 
-[[nodiscard]] auto isInterruptRequested() noexcept -> bool;
+[[nodiscard]] auto interuptIsRequested() noexcept -> bool;
+
+[[nodiscard]] auto interuptResetRequested() noexcept -> bool;
 
 } // namespace vm::internal

--- a/src/vm/internal/pcall.hpp
+++ b/src/vm/internal/pcall.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "internal/executor_handle.hpp"
+#include "internal/interupt.hpp"
 #include "internal/ref_long.hpp"
 #include "internal/ref_stream_console.hpp"
 #include "internal/ref_stream_file.hpp"
@@ -9,7 +10,6 @@
 #include "internal/stream_utilities.hpp"
 #include "internal/string_utilities.hpp"
 #include "internal/terminal.hpp"
-#include "internal/interupt.hpp"
 #include "novasm/pcall_code.hpp"
 #include "vm/exec_state.hpp"
 #include "vm/platform_interface.hpp"
@@ -221,8 +221,11 @@ auto inline pcall(
     auto* res = std::getenv(nameStrRef->getCharDataPtr());
     PUSH_REF(res == nullptr ? refAlloc->allocStr(0) : toStringRef(refAlloc, res));
   } break;
-  case PCallCode::IsInteruptReq: {
-    PUSH_INT(isInterruptRequested());
+  case PCallCode::InteruptIsReq: {
+    PUSH_BOOL(interuptIsRequested());
+  } break;
+  case PCallCode::InteruptResetReq: {
+    PUSH_BOOL(interuptResetRequested());
   } break;
 
   case PCallCode::ClockMicroSinceEpoch: {

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -64,7 +64,7 @@ static auto setup(internal::Settings* settings) noexcept {
   signal(SIGPIPE, SIG_IGN);
 
   if (settings->interceptInterupt) {
-    settings->interceptInterupt = internal::setupInterruptHandler();
+    settings->interceptInterupt = internal::interruptSetupHandler();
   }
 }
 

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -44,7 +44,7 @@ static auto setup(internal::Settings* settings) noexcept {
   enableVTConsoleMode();
 
   if (settings->interceptInterupt) {
-    settings->interceptInterupt = internal::setupInterruptHandler();
+    settings->interceptInterupt = internal::interruptSetupHandler();
   }
 }
 


### PR DESCRIPTION
Changes:
- `isInteruptRequested` renamed to `interuptIsRequested`
- Add new `interuptResetRequested` api to reset the `interuptIsRequested` flag.
- No longer handle `CTRL_CLOSE_EVENT` on windows (we should not let programs ignore that).

Example that uses `interuptResetRequested` to listen for interupt multiple times.
```
import "std.nov"

act shouldStop()
  if !interuptIsRequested() -> false
  else ->
    interuptResetRequested();
    print("Do you want to stop? (y/n)");
    readLine() == "y"

act main()
  if shouldStop() -> print("Goodbye")
  else ->
    print("Running...");
    sleep(milliseconds(100));
    self()

main()
```
Example output:
![image](https://user-images.githubusercontent.com/14230060/99879672-f9654b80-2c16-11eb-9b30-3afab6229160.png)
