### PR TITLE
Support overloading unary question-mark operator

### DIFF
--- a/include/prog/operator.hpp
+++ b/include/prog/operator.hpp
@@ -30,6 +30,7 @@ enum class Operator {
   ColonColon,
   SquareSquare,
   ParenParen,
+  QMark,
   QMarkQMark,
 };
 

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -108,6 +108,8 @@ auto getOperator(const lex::Token& token) -> std::optional<prog::Operator> {
     return prog::Operator::SquareSquare;
   case lex::TokenKind::OpParenParen:
     return prog::Operator::ParenParen;
+  case lex::TokenKind::OpQMark:
+    return prog::Operator::QMark;
   case lex::TokenKind::OpQMarkQMark:
     return prog::Operator::QMarkQMark;
   default:
@@ -163,6 +165,8 @@ auto getText(const prog::Operator& op) -> std::string {
     return "[]";
   case prog::Operator::ParenParen:
     return "()";
+  case prog::Operator::QMark:
+    return "?";
   case prog::Operator::QMarkQMark:
     return "??";
   }

--- a/src/parse/op_precedence.cpp
+++ b/src/parse/op_precedence.cpp
@@ -11,6 +11,7 @@ auto getLhsOpPrecedence(const lex::Token& token) -> int {
   case lex::TokenKind::OpMinusMinus:
   case lex::TokenKind::OpBang:
   case lex::TokenKind::OpTilde:
+  case lex::TokenKind::OpQMark:
     return unaryPrecedence;
   default:
     return 0;

--- a/src/prog/operator.cpp
+++ b/src/prog/operator.cpp
@@ -51,6 +51,8 @@ auto getFuncName(Operator op) -> std::string {
     return "__op_squaresquare";
   case Operator::ParenParen:
     return "__op_parenparen";
+  case Operator::QMark:
+    return "__op_qmark";
   case Operator::QMarkQMark:
     return "__op_qmarkqmark";
   }

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -152,7 +152,7 @@ TEST_CASE("Analyzing user-function declarations", "[frontend]") {
         errNoTypeOrConversionFoundToInstantiate(src, "s", 1, input::Span{59, 67}));
     CHECK_DIAG(
         "fun -(int i) -> int 1", errDuplicateFuncDeclaration(src, "operator-", input::Span{0, 20}));
-    CHECK_DIAG("fun ?() -> int 1", errNonOverloadableOperator(src, "?", input::Span{4, 4}));
+    CHECK_DIAG("fun &&() -> int 1", errNonOverloadableOperator(src, "&&", input::Span{4, 5}));
     CHECK_DIAG(
         "fun f{int}() -> int 1", errTypeParamNameConflictsWithType(src, "int", input::Span{6, 8}));
     CHECK_DIAG(

--- a/tests/parse/expr_unary_test.cpp
+++ b/tests/parse/expr_unary_test.cpp
@@ -6,18 +6,21 @@ namespace parse {
 
 TEST_CASE("Parsing unary operators", "[parse]") {
 
-  CHECK_EXPR("-1", unaryExprNode(MINUS, INT(1)))
-  CHECK_EXPR("+1", unaryExprNode(PLUS, INT(1)))
-  CHECK_EXPR("!1", unaryExprNode(BANG, INT(1)))
-  CHECK_EXPR("!x", unaryExprNode(BANG, ID_EXPR("x")))
+  CHECK_EXPR("-1", unaryExprNode(MINUS, INT(1)));
+  CHECK_EXPR("+1", unaryExprNode(PLUS, INT(1)));
+  CHECK_EXPR("!1", unaryExprNode(BANG, INT(1)));
+  CHECK_EXPR("!x", unaryExprNode(BANG, ID_EXPR("x")));
+  CHECK_EXPR("?1", unaryExprNode(QMARK, INT(1)));
   CHECK_EXPR("--1", unaryExprNode(MINUSMINUS, INT(1)));
   CHECK_EXPR("++1", unaryExprNode(PLUSPLUS, INT(1)));
   CHECK_EXPR("-+-1", unaryExprNode(MINUS, unaryExprNode(PLUS, unaryExprNode(MINUS, INT(1)))));
   CHECK_EXPR("+-!1", unaryExprNode(PLUS, unaryExprNode(MINUS, unaryExprNode(BANG, INT(1)))));
+  CHECK_EXPR("+?!1", unaryExprNode(PLUS, unaryExprNode(QMARK, unaryExprNode(BANG, INT(1)))));
   CHECK_EXPR("!42 !true", unaryExprNode(BANG, INT(42)), unaryExprNode(BANG, BOOL(true)));
 
   SECTION("Errors") {
     CHECK_EXPR("&1", errInvalidUnaryOp(AMP, INT(1)));
+    CHECK_EXPR("??1", errInvalidUnaryOp(QMARKQMARK, INT(1)));
     CHECK_EXPR("&+1", errInvalidUnaryOp(AMP, unaryExprNode(PLUS, INT(1))));
     CHECK_EXPR("&1 + 2", errInvalidUnaryOp(AMP, binaryExprNode(INT(1), PLUS, INT(2))));
     CHECK_EXPR("&", errInvalidUnaryOp(AMP, errInvalidPrimaryExpr(END)));

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -32,6 +32,7 @@ namespace parse {
 #define EQEQ lex::basicToken(lex::TokenKind::OpEqEq)
 #define SEMI lex::basicToken(lex::TokenKind::OpSemi)
 #define QMARK lex::basicToken(lex::TokenKind::OpQMark)
+#define QMARKQMARK lex::basicToken(lex::TokenKind::OpQMarkQMark)
 #define DOT lex::basicToken(lex::TokenKind::OpDot)
 #define COLONCOLON lex::basicToken(lex::TokenKind::OpColonColon)
 #define SQUARESQUARE lex::basicToken(lex::TokenKind::OpSquareSquare)


### PR DESCRIPTION
Support overloading the unary question mark operator.

Example:
```
import "std.nov"

fun ?(int i)
  if i == 0 -> none()
  else      -> some(i)

print(?42)
print(?0)
```
Output:
![image](https://user-images.githubusercontent.com/14230060/99914043-9bfaf880-2d03-11eb-9813-175b4d56f4d3.png)
