### PR TITLE
Add sem-ver utilities to novstd

### DIFF
--- a/examples/json-formatter.nov
+++ b/examples/json-formatter.nov
@@ -7,9 +7,9 @@ act formatJson(Path path, bool pretty)
   if jsonStr.isEmpty() -> printErr("Unable to read file at path: " + path); fail()
   else ->
     jParser   = jsonParser();
-    parseRes  = jParser(jsonStr);
-    if parseRes as ParseSuccess{JsonValue} s  -> printJson(s.val, pretty)
-    if parseRes as ParseFailure f             -> print("Unable to parse json: " + f)
+    parseRes  = ~jParser(jsonStr);
+    if parseRes as JsonValue v  -> printJson(v, pretty)
+    if parseRes as Error err    -> print("Unable to parse json: " + err)
 
 act printJson(JsonValue v, bool pretty)
   indent      = pretty ? "  " : "";

--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -100,11 +100,11 @@ act main(Path path)
   else ->
     p   = subListParser();
     t1  = timestamp();
-    res = p(fileRead(path));
+    res = ~p(fileRead(path));
     dur = timestamp() - t1;
     print("[Parsing took: " + dur + "]\n");
 
-    if res as ParseSuccess{List{Subtitle}} pSuc   -> print(string(pSuc.val, "", "\n\n", ""))
-    if res as ParseFailure                 pFail  -> printErr("Failed to parse: " + pFail); fail()
+    if res as List{Subtitle}  subs -> print(string(subs, "", "\n\n", ""))
+    if res as Error           err  -> printErr("Failed to parse: " + err); fail()
 
 main(Path(getEnvArg(0)))

--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -18,6 +18,9 @@ import "std.nov"
 // Parsers can be combined to create more complex parsers,
 // an overview of a few of the ways to combine parsers;
 //
+// - '?Parser{T}' -> Parser{Option{T}}
+//    Makes a parser optional, an option parser always succeeds but doesn't always produce a value.
+//
 // - 'Parser{T1} & Parser{T2}' -> Parser{Pair{T1, T2}}
 //    And combiner, excecutes parser 2 only if parser 1 succeded, both values are returned.
 //

--- a/novstd/CMakeLists.txt
+++ b/novstd/CMakeLists.txt
@@ -55,6 +55,7 @@ configure_novstd_file(text)
 configure_novstd_file(time)
 configure_novstd_file(unicode)
 configure_novstd_file(utf8)
+configure_novstd_file(version)
 configure_novstd_file(writer)
 
 # Register a test that evaluates the 'std.nov' header, usefull for detecting name conflics.

--- a/novstd/pair.nov
+++ b/novstd/pair.nov
@@ -2,6 +2,23 @@
 
 struct Pair{T1, T2} = T1 first, T2 second
 
+// -- Utilities
+
+fun makePair{T}(T a)
+  Pair(a, a)
+
+fun makePair{T1, T2}(T1 a1, T2 a2)
+  Pair(a1, a2)
+
+fun makePair{T1, T2, T3}(T1 a1, T2 a2, T3 a3)
+  Pair(Pair(a1, a2), a3)
+
+fun makePair{T1, T2, T3, T4}(T1 a1, T2 a2, T3 a3, T4 a4)
+  Pair(Pair(Pair(a1, a2), a3), a4)
+
+fun makePair{T1, T2, T3, T4, T5}(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
+  Pair(Pair(Pair(Pair(a1, a2), a3), a4), a5)
+
 // -- Conversions
 
 fun string{T1, T2}(Pair{T1, T2} p)

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -28,6 +28,10 @@ fun ??{T}(ParseResult{T} res, T def)
 fun ??{T1, T2}(ParseResult{T1} res, T2 def) -> Either{T1, T2}
   res as ParseSuccess{T1} suc ? suc.val : def
 
+fun ~{T}(ParseResult{T} res) -> Either{T, Error}
+  if res as ParseSuccess{T} suc   -> suc.val
+  if res as ParseFailure    fail  -> fail.err
+
 fun [](ParseState p, int i)
   p.str[p.pos + i]
 
@@ -483,6 +487,10 @@ assert(
   txtBoolParser()("tRuE")  is ParseFailure &&
   txtBoolParser()("fAlSe") is ParseFailure &&
   txtBoolParser()("abc")   is ParseFailure)
+
+assert(
+  ~txtBoolParser()("abc")   is Error &&
+  ~txtBoolParser()("true")  is bool)
 
 assert(
   p = ?txtIntParser();

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -143,6 +143,16 @@ fun map{T, TResult}(Parser{T} p, function{T, TResult} func)
     if res as ParseFailure    fail  -> fail
   )
 
+fun mapOrErr{T, TResult}(Parser{T} p, function{T, Either{TResult, Error}} func)
+  Parser(lambda (ParseState s) -> ParseResult{TResult}
+    pR = p(s);
+    if pR as ParseFailure    parseFail  -> parseFail
+    if pR as ParseSuccess{T} parseSuc   ->
+      mR = func(parseSuc.val);
+      if mR as Error    err -> parseSuc.state.failure(err)
+      if mR as TResult  val -> parseSuc.state.success(val)
+  )
+
 fun unwrap{T1, T2, TResult}(
   Parser{Pair{T1, T2}} p, function{T1, T2, TResult} f)
   (
@@ -483,6 +493,31 @@ assert(
   p = txtIntParser().map(lambda (int i) i == 42);
   p("123")  == false &&
   p("42")   == true &&
+  p("") is ParseFailure)
+
+assert(
+  err = Error("Value outside of the 100 - 200 range");
+  p = txtIntParser().mapOrErr(lambda (int i) -> Either{int, Error}
+    if i >= 100 && i <= 200 -> i
+    else                    -> err
+  );
+  p("123") == 123 &&
+  p("100") == 100 &&
+  p("200") == 200 &&
+  p("42") is ParseFailure &&
+  p("42") as ParseFailure pf && pf.err == err &&
+  p("201") is ParseFailure &&
+  p("") is ParseFailure)
+
+assert(
+  p = txtIntParser().mapOrErr(lambda (int i) -> Either{string, Error}
+    if i == 42    -> "Meaning of life"
+    if i == 1337  -> "Elite"
+    else          -> Error("No signficiant meaning to: '" + i + "'")
+  );
+  p("42") == "Meaning of life" &&
+  p("1337") == "Elite" &&
+  p("123") is ParseFailure &&
   p("") is ParseFailure)
 
 assert(

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -55,6 +55,13 @@ fun ++(ParseState s)
 fun --(ParseState s)
   s - 1
 
+fun ?{T}(Parser{T} p)
+  Parser(lambda (ParseState s) -> ParseResult{Option{T}}
+    r = p(s);
+    if r is ParseFailure          -> s.success(Option{T}())
+    if r as ParseSuccess{T} suc   -> suc.state.success(Option{T}(suc.val))
+  )
+
 fun &{T1, T2}(Parser{T1} p1, Parser{T2} p2)
   Parser(lambda (ParseState s) -> ParseResult{Pair{T1, T2}}
     r1 = p1(s);
@@ -457,6 +464,27 @@ assert(
   txtBoolParser()("tRuE")  is ParseFailure &&
   txtBoolParser()("fAlSe") is ParseFailure &&
   txtBoolParser()("abc")   is ParseFailure)
+
+assert(
+  p = ?txtIntParser();
+  p("")     == Option{int}() &&
+  p("abc")  == Option{int}() &&
+  p("42")   == some(42) &&
+  p("-42")  == some(-42))
+
+assert(
+  p = (?txtIntParser() & ?txtBoolParser()).unwrap(
+    lambda (Option{int} a, Option{bool} b)
+      if b ?? false -> a ?? -1
+      else          -> -42
+  );
+  p("false")      == -42  &&
+  p("")           == -42  &&
+  p("1337")       == -42  &&
+  p("1337false")  == -42  &&
+  p("true")       == -1   &&
+  p("1337true")   == 1337 &&
+  p("0true")      == 0)
 
 assert(
   p = (matchParser("Hello ") | matchParser("Greetings ")) & matchParser("World");

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -163,20 +163,39 @@ fun mapOrErr{T, TResult}(Parser{T} p, function{T, Either{TResult, Error}} func)
 fun unwrap{T1, T2, TResult}(
   Parser{Pair{T1, T2}} p, function{T1, T2, TResult} f)
   (
-    p.map(lambda (Pair{T1, T2} pair) f(pair.first, pair.second))
+    p.map(lambda (Pair{T1, T2} pair)
+      f(pair.first,
+        pair.second))
   )
 
 fun unwrap{T1, T2, T3, TResult}(
   Parser{Pair{Pair{T1, T2}, T3}} p, function{T1, T2, T3, TResult} f)
   (
-    p.map(lambda (Pair{Pair{T1, T2}, T3} pair) f(pair.first.first, pair.first.second, pair.second))
+    p.map(lambda (Pair{Pair{T1, T2}, T3} pair)
+      f(pair.first.first,
+        pair.first.second,
+        pair.second))
   )
 
 fun unwrap{T1, T2, T3, T4, TResult}(
   Parser{Pair{Pair{Pair{T1, T2}, T3}, T4}} p, function{T1, T2, T3, T4, TResult} f)
   (
     p.map(lambda (Pair{Pair{Pair{T1, T2}, T3}, T4} pair)
-      f(pair.first.first.first, pair.first.first.second, pair.first.second, pair.second))
+      f(pair.first.first.first,
+        pair.first.first.second,
+        pair.first.second,
+        pair.second))
+  )
+
+fun unwrap{T1, T2, T3, T4, T5, TResult}(
+  Parser{Pair{Pair{Pair{Pair{T1, T2}, T3}, T4}, T5}} p, function{T1, T2, T3, T4, T5, TResult} f)
+  (
+    p.map(lambda (Pair{Pair{Pair{Pair{T1, T2}, T3}, T4}, T5} pair)
+      f(pair.first.first.first.first,
+        pair.first.first.first.second,
+        pair.first.first.second,
+        pair.first.second,
+        pair.second))
   )
 
 // -- Basic parsers
@@ -576,6 +595,16 @@ assert(
   p("truetruetruetrue")   == true &&
   p("truefalsetrue")  is ParseFailure &&
   p("")               is ParseFailure)
+
+assert(
+  p = (txtBoolParser() & txtBoolParser() & txtBoolParser() & txtBoolParser() & txtBoolParser()).unwrap(
+    lambda (bool a, bool b, bool c, bool d, bool e) a && b && c && d && e);
+  p("truefalsetruetruetrue")  == false &&
+  p("truefalsetruetruetrue")  == false &&
+  p("truetruetruetruetrue")   == true &&
+  p("truefalsetruefalse") is ParseFailure &&
+  p("truefalsetrue")      is ParseFailure &&
+  p("")                   is ParseFailure)
 
 assert(
   p = manyParser(txtBoolParser(), false);

--- a/novstd/version.nov
+++ b/novstd/version.nov
@@ -1,0 +1,199 @@
+import "std/list.nov"
+import "std/parse.nov"
+import "std/writer.nov"
+
+// Utilities for sem-ver versions.
+// https://semver.org/
+
+// -- Types
+
+struct Version =
+  int           major,
+  int           minor,
+  int           patch,
+  List{string}  prereleaseTags,
+  List{string}  metaTags
+
+// -- Operators
+
+fun >(Version x, Version y)
+  x.major > y.major ||
+  (x.major == y.major && x.minor > y.minor) ||
+  (x.major == y.major && x.minor == y.minor && x.patch > y.patch) ||
+  (x.major == y.major && x.minor == y.minor && x.patch == y.patch && y.isPrerelease())
+
+fun <(Version x, Version y)
+  x.major < y.major ||
+  (x.major == y.major && x.minor < y.minor) ||
+  (x.major == y.major && x.minor == y.minor && x.patch < y.patch) ||
+  (x.major == y.major && x.minor == y.minor && x.patch == y.patch && x.isPrerelease())
+
+// -- Utilities
+
+fun bumpMajor(Version v)
+  Version(++v.major, 0, 0, v.prereleaseTags, v.metaTags)
+
+fun bumpMinor(Version v)
+  Version(v.major, ++v.minor, 0, v.prereleaseTags, v.metaTags)
+
+fun bumpPatch(Version v)
+  Version(v.major, v.minor, ++v.patch, v.prereleaseTags, v.metaTags)
+
+fun isPrerelease(Version v)
+  !v.prereleaseTags.isEmpty()
+
+// -- Conversions
+
+fun Version(int major, int minor)
+  Version(major, minor, 0)
+
+fun Version(int major, int minor, int patch)
+  Version(major, minor, patch, List{string}(), List{string}())
+
+fun Version(int major, int minor, int patch, List{string} prereleaseTags)
+  Version(major, minor, patch, prereleaseTags, List{string}())
+
+fun string(Version v)
+  versionWriter()(v).string()
+
+// -- Parsers
+
+fun versionParser() -> Parser{Version}
+  tagParser = whileParser(lambda (char c) c.isLetter() || c.isDigit() || c == '-');
+  (
+    txtIntParser() & matchParser('.') >> txtIntParser() & ?(matchParser('.') >> txtIntParser()) &
+    ?(matchParser('-') >> manyParser(tagParser, matchParser('.'))) &
+    ?(matchParser('+') >> manyParser(tagParser, matchParser('.')))
+  ).unwrap( lambda (  int major,
+                      int minor,
+                      Option{int} patch,
+                      Option{List{string}} prereleaseTags,
+                      Option{List{string}} meta)
+      Version(major, minor, patch ?? 0, prereleaseTags ?? List{string}(), meta ?? List{string}())
+    )
+
+// -- Writers
+
+fun versionWriter()
+  (
+    txtIntWriter() & litWriter('.') & txtIntWriter() & litWriter('.') & txtIntWriter() &
+    ?(litWriter("-") & listWriter(stringWriter(), litWriter("."))) &
+    ?(litWriter("+") & listWriter(stringWriter(), litWriter(".")))
+  ).map(lambda (Version v)
+      makePair(
+        v.major,
+        v.minor,
+        v.patch,
+        v.prereleaseTags.isEmpty()  ? none() : some(v.prereleaseTags),
+        v.metaTags.isEmpty()        ? none() : some(v.metaTags))
+    )
+
+// -- Tests
+
+assert(
+  isPrerelease(Version(1, 0, 0, "alpha" :: List{string}())) &&
+  !isPrerelease(Version(1, 0, 0))
+)
+
+assert(
+  Version(1, 0, 0)    >   Version(0, 1, 0)                                &&
+  Version(1, 1, 0)    >   Version(1, 0, 0)                                &&
+  Version(1, 1, 2)    >   Version(1, 1, 1)                                &&
+  Version(1, 1, 1)    >   Version(1, 1, 1, "alpha" :: List{string}())     &&
+  Version(2, 0, 0)    >   Version(1, 99, 0)                               &&
+  Version(1, 0, 0)    <   Version(2, 1, 0)                                &&
+  Version(1, 1, 0)    <   Version(1, 2, 0)                                &&
+  Version(1, 1, 2)    <   Version(1, 1, 3)                                &&
+  Version(1, 1, 1)    <   Version(1, 1, 2, "alpha" :: List{string}())
+)
+
+assert(
+  p = versionParser();
+  p("")             is ParseFailure           &&
+  p("0")            is ParseFailure           &&
+  p("0.")           is ParseFailure           &&
+  p("0.a")          is ParseFailure           &&
+  p("0.0")          == Version(0, 0)          &&
+  p("42.1337")      == Version(42, 1337)      &&
+  p("42.1337.123")  == Version(42, 1337, 123) &&
+  p("42.1337.123-") == Version(42, 1337, 123) &&
+  p("42.1337.123+") == Version(42, 1337, 123)
+)
+
+assert(
+  versionParser()("42.1337.123-alpha.fullmoon.wip")
+  ==
+  Version(42, 1337, 123, "alpha" :: "fullmoon" :: "wip" :: List{string}())
+)
+
+assert(
+  versionParser()("42.1337-alpha.fullmoon.wip")
+  ==
+  Version(42, 1337, 0, "alpha" :: "fullmoon" :: "wip" :: List{string}())
+)
+
+assert(
+  versionParser()("1.0.0-x.7.z.92")
+  ==
+  Version(1, 0, 0, "x" :: "7" :: "z" :: "92" :: List{string}())
+)
+
+assert(
+  versionParser()("42.1337+local-machine.europe")
+  ==
+  Version(42, 1337, 0, List{string}(), "local-machine" :: "europe" :: List{string}())
+)
+
+assert(
+  versionParser()("1.0.0-beta+exp.sha.5114f85")
+  ==
+  Version(1, 0, 0, "beta" :: List{string}(), "exp" :: "sha" :: "5114f85" :: List{string}())
+)
+
+assert(
+  versionParser()("42.1337.123-alpha.fullmoon.wip+local-machine.europe")
+  ==
+  Version(42, 1337, 123,
+    "alpha" :: "fullmoon" :: "wip" :: List{string}(),
+    "local-machine" :: "europe" :: List{string}())
+)
+
+assert(
+  versionParser()("42.1337.123+alpha.fullmoon.wip-local-machine.europe")
+  ==
+  Version(42, 1337, 123,
+    List{string}(),
+    "alpha" :: "fullmoon" :: "wip-local-machine" :: "europe" :: List{string}())
+)
+
+assert(
+  w = versionWriter();
+  w(Version(0, 0))          == "0.0.0" &&
+  w(Version(42, 1337, 123)) == "42.1337.123"
+)
+
+assert(
+  versionWriter()(
+    Version(42, 1337, 123,
+      List{string}(),
+      "local-machine" :: "europe" :: List{string}()))
+  ==
+  "42.1337.123+local-machine.europe"
+)
+
+assert(
+  versionWriter()(
+    Version(42, 1337, 123,
+      "alpha" :: "fullmoon" :: "wip" :: List{string}()))
+  ==
+  "42.1337.123-alpha.fullmoon.wip"
+)
+
+assert(
+  versionWriter()(
+    Version(42, 1337, 123,
+      "alpha" :: "fullmoon" :: "wip" :: List{string}(),
+      "local-machine" :: "europe" :: List{string}()))
+  ==
+  "42.1337.123-alpha.fullmoon.wip+local-machine.europe"
+)

--- a/novstd/writer.nov
+++ b/novstd/writer.nov
@@ -49,6 +49,12 @@ fun (){T}(Writer{T} w, T val)
 fun ==(WriterState s, string str)
   s.curResult == str
 
+fun ?{T}(Writer{T} p)
+  Writer(lambda (WriterState s, Option{T} optVal)
+    if optVal as T val  -> p(s, val)
+    else                -> s
+  )
+
 fun &(Writer{None} p1, Writer{None} p2)
   Writer(lambda (WriterState s, None n)
     p2(p1(s, None()), None())
@@ -211,6 +217,21 @@ assert(
   w = txtBoolWriter();
   w(true) == "true" &&
   w(false) == "false")
+
+assert(
+  w = ?txtBoolWriter();
+  w(Option{bool}(true))   == "true" &&
+  w(Option{bool}())       == "")
+
+assert(
+  w = ?(litWriter("hello: ") & stringWriter());
+  w(Option{string}("world"))   == "hello: world" &&
+  w(Option{string}())          == "")
+
+assert(
+  w = litWriter("name: ") & stringWriter() & ?(litWriter(", age: ") & txtIntWriter());
+  w(Pair("John", Option{int}()))   == "name: John" &&
+  w(Pair("Jane", Option{int}(42))) == "name: Jane, age: 42")
 
 assert(
   w = listWriter(txtIntWriter());


### PR DESCRIPTION
Adds `version.nov` to the novstd with utilities for working with sem-ver version numbers.

Example:
```
import "std.nov"

fun bumpVersionPatch(string input) -> Either{string, Error}
  res = ~versionParser()(input);
  if res as Error    err -> Error("Malformed version: " + err)
  if res as Version  ver -> ver.bumpPatch().string()

act bumpVersionPatch(Path p)
  org     = p.fileRead();
  bumped  = bumpVersionPatch(org);
  if bumped as string str -> p.fileWrite(str)
  if bumped as Error  err -> printErr("Failed to bump version: " + err)

bumpVersionPatch(Path("bin/VERSION"))
```