### PR TITLE
Version improvements

### DIFF
--- a/novstd/func.nov
+++ b/novstd/func.nov
@@ -158,6 +158,9 @@ fun invoke{T1, T2, T3, TR}(function{T1, T2, T3, TR} func, T1 a1, T2 a2, T3 a3)
 fun invoke{T1, T2, T3, T4, TR}(function{T1, T2, T3, T4, TR} func, T1 a1, T2 a2, T3 a3, T4 a4)
   func(a1, a2, a3, a4)
 
+fun invoke{T1, T2, T3, T4, T5, TR}(function{T1, T2, T3, T4, T5, TR} func, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
+  func(a1, a2, a3, a4, a5)
+
 // -- Actions
 
 act invoke{TR}(action{TR} func)
@@ -174,6 +177,9 @@ act invoke{T1, T2, T3, TR}(action{T1, T2, T3, TR} func, T1 a1, T2 a2, T3 a3)
 
 act invoke{T1, T2, T3, T4, TR}(action{T1, T2, T3, T4, TR} func, T1 a1, T2 a2, T3 a3, T4 a4)
   func(a1, a2, a3, a4)
+
+act invoke{T1, T2, T3, T4, T5, TR}(action{T1, T2, T3, T4, T5, TR} func, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
+  func(a1, a2, a3, a4, a5)
 
 // -- Tests
 
@@ -330,6 +336,12 @@ assert(
   invoke(lambda(int x, float y, string z, long w) string(x) + " " + string(y) + " " + z + " " + string(w),
     1337, 42.42, "hello world", -4242L) == "1337 42.42 hello world -4242")
 
+assert(
+  invoke(
+    lambda(int x, float y, string z, long w, int a)
+      string(x) + " " + string(y) + " " + z + " " + string(w) + " " + string(a)
+    ,1337, 42.42, "hello world", -4242L, -1) == "1337 42.42 hello world -4242 -1")
+
 // -- Impure tests
 
 assert(
@@ -365,3 +377,9 @@ assert(
 assert(
   invoke(impure lambda(int x, float y, string z, long w) string(x) + " " + string(y) + " " + z + " " + string(w),
     1337, 42.42, "hello world", -4242L) == "1337 42.42 hello world -4242")
+
+assert(
+  invoke(
+    impure lambda(int x, float y, string z, long w, int a)
+      string(x) + " " + string(y) + " " + z + " " + string(w) + " " + string(a)
+    , 1337, 42.42, "hello world", -4242L, -1) == "1337 42.42 hello world -4242 -1")

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -268,28 +268,27 @@ fun txtBoolParser()
     else            -> s.failure(Error("Expected boolean, got: '" + s[0] + "'"))
   )
 
-fun txtIntParser()
+fun txtPosIntParser()
   Parser(lambda (ParseState s)
-    impl =
-    (
+    invoke(
       lambda (ParseState s, int res, bool valid) -> ParseResult{int}
         if s[0].isDigit() -> self(++s, res * 10 + s[0] - '0', true)
         else              -> valid ?  s.success(res) :
                                       s.failure(Error("Expected integer, got: '" + s[0] + "'"))
-    );
-    if s.isEnd() -> s.failure(Error("Expected int, got: end of input"))
-    if s == '-'  -> impl(++s, 0, false).map(negate{int})
-    if s == '+'  -> impl(++s, 0, false)
-    else         -> impl(s, 0, false)
+      , s, 0, false)
   )
+
+fun txtIntParser()
+  matchParser('-') >> txtPosIntParser().map(negate{int})  |
+  matchParser('+') >> txtPosIntParser()                   |
+  txtPosIntParser()
 
 fun txtHexParser()
   txtHexParser(1)
 
 fun txtHexParser(int minDigits)
   Parser(lambda (ParseState s)
-    impl =
-    (
+    invoke(
       lambda (ParseState s, int res, int digits) -> ParseResult{int}
         if s[0].isDigit()             -> self(++s, (res << 4) + s[0] - '0',         ++digits)
         if s[0] >= 'a' && s[0] <= 'f' -> self(++s, (res << 4) + s[0] - ('a' - 10),  ++digits)
@@ -298,32 +297,29 @@ fun txtHexParser(int minDigits)
                                           s.success(res) :
                                           s.failure(Error(
                                             "Expected hex number, got: '" + s[0] + "'"))
-    );
-    if s.isEnd() -> s.failure(Error("Expected hex number, got: end of input"))
-    else         -> impl(s, 0, 0)
+      , s, 0, 0)
   )
 
-fun txtFloatParser()
+fun txtPosFloatParser()
   intParser = txtIntParser();
   Parser(lambda (ParseState s)
-    impl =
-    (
+    invoke(
       lambda (ParseState s, float raw, float div, bool dec, bool valid) -> ParseResult{float}
         if s == '.' && !dec     -> self(++s, raw, div, true, false)
         if s[0].isDigit()       -> newRaw = raw * 10.0 + int(s[0]) - int('0');
                                    newDiv = dec ? div * 10.0 : div;
                                    self(++s, newRaw, newDiv, dec, true)
-        if s == 'e' || s == 'E' -> intParser(s + 1).map(
-                                                      lambda (int exp) raw / (div / pow(10.0, exp)))
+        if s == 'e' || s == 'E' -> intParser(s + 1).map(lambda (int exp) raw / (div / pow(10.0, exp)))
         else                    -> valid ?  s.success(raw / div) :
                                             s.failure(Error(
                                               "Expected float, got: '" + s[0] + "'"))
-    );
-    if s.isEnd() -> s.failure(Error("Expected float, got: end of input"))
-    if s == '-'  -> impl(++s, 0.0, 1.0, false, false).map(negate{float})
-    if s == '+'  -> impl(++s, 0.0, 1.0, false, false)
-    else         -> impl(s,   0.0, 1.0, false, false)
-  )
+      , s, 0.0, 1.0, false, false)
+    )
+
+fun txtFloatParser()
+  matchParser('-') >> txtPosFloatParser().map(negate{float})  |
+  matchParser('+') >> txtPosFloatParser()                     |
+  txtPosFloatParser()
 
 // -- Combination parsers
 
@@ -401,6 +397,23 @@ assert(
   lineParser()("") is ParseFailure)
 
 assert(
+  txtPosIntParser()("1")                == 1 &&
+  txtPosIntParser()("1337")             == 1337 &&
+  txtPosIntParser()(intMax().string())  == intMax() &&
+  txtPosIntParser()("2147483648")       == -2147483647 - 1)
+
+assert(
+  txtPosIntParser()("-1")   is ParseFailure &&
+  txtPosIntParser()("+1")   is ParseFailure &&
+  txtPosIntParser()("a")    is ParseFailure &&
+  txtPosIntParser()(" 123") is ParseFailure)
+
+assert(
+  txtIntParser()("")         is ParseFailure &&
+  txtIntParser()("a")        is ParseFailure &&
+  txtIntParser()(" 123")     is ParseFailure)
+
+assert(
   txtIntParser()("1")                == 1 &&
   txtIntParser()("-1")               == -1 &&
   txtIntParser()("+1")               == 1 &&
@@ -439,6 +452,33 @@ assert(
   txtHexParser()(" 123")     is ParseFailure &&
   txtHexParser(4)("123")     is ParseFailure &&
   txtHexParser(4)("123G")    is ParseFailure)
+
+assert(
+  txtPosFloatParser()("0")            == 0.0 &&
+  txtPosFloatParser()("1")            == 1.0 &&
+  txtPosFloatParser()("0001")         == 1.0 &&
+  txtPosFloatParser()("0e10")         == 0.0 &&
+  txtPosFloatParser()("0e-10")        == 0.0 &&
+  txtPosFloatParser()("42e0")         == 42.0 &&
+  txtPosFloatParser()("42e1")         == 420.0 &&
+  txtPosFloatParser()("42e2")         == 4200.0 &&
+  txtPosFloatParser()("42e+0")        == 42.0 &&
+  txtPosFloatParser()("42e+1")        == 420.0 &&
+  txtPosFloatParser()("42e+2")        == 4200.0 &&
+  txtPosFloatParser()("42e-0")        == 42.0 &&
+  txtPosFloatParser()("42e-1")        == 4.2 &&
+  txtPosFloatParser()("42e-2")        == .42 &&
+  txtPosFloatParser()("42.1337")      == 42.1337 &&
+  txtPosFloatParser()("42.1337e4")    == 421337.0 &&
+  (txtPosFloatParser()("4000000000") ?? -1.0).approx(4000000000.0))
+
+assert(
+  txtPosFloatParser()("-1")     is ParseFailure &&
+  txtPosFloatParser()("+1")     is ParseFailure &&
+  txtPosFloatParser()("--1")    is ParseFailure &&
+  txtPosFloatParser()("-+1")    is ParseFailure &&
+  txtPosFloatParser()(" 1.0")   is ParseFailure &&
+  txtPosFloatParser()("1. 0 ")  is ParseFailure)
 
 assert(
   txtFloatParser()("0")            == 0.0 &&

--- a/novstd/version.nov
+++ b/novstd/version.nov
@@ -66,7 +66,7 @@ fun string(Version v)
 fun versionParser() -> Parser{Version}
   tagParser = whileParser(lambda (char c) c.isLetter() || c.isDigit() || c == '-');
   (
-    txtIntParser() & matchParser('.') >> txtIntParser() & ?(matchParser('.') >> txtIntParser()) &
+    txtPosIntParser() & matchParser('.') >> txtPosIntParser() & ?(matchParser('.') >> txtPosIntParser()) &
     ?(matchParser('-') >> manyParser(tagParser, matchParser('.'))) &
     ?((matchParser('+') | matchParser('.')) >> manyParser(tagParser, matchParser('.')))
   ).unwrap( lambda (  int major,
@@ -101,15 +101,15 @@ assert(
 )
 
 assert(
-  Version(1, 0, 0)    >   Version(0, 1, 0)                                &&
-  Version(1, 1, 0)    >   Version(1, 0, 0)                                &&
-  Version(1, 1, 2)    >   Version(1, 1, 1)                                &&
-  Version(1, 1, 1)    >   Version(1, 1, 1, "alpha" :: List{string}())     &&
-  Version(2, 0, 0)    >   Version(1, 99, 0)                               &&
-  Version(1, 0, 0)    <   Version(2, 1, 0)                                &&
-  Version(1, 1, 0)    <   Version(1, 2, 0)                                &&
-  Version(1, 1, 2)    <   Version(1, 1, 3)                                &&
-  Version(1, 1, 1)    <   Version(1, 1, 2, "alpha" :: List{string}())
+  Version(1, 0, 0) > Version(0, 1, 0)                             &&
+  Version(1, 1, 0) > Version(1, 0, 0)                             &&
+  Version(1, 1, 2) > Version(1, 1, 1)                             &&
+  Version(1, 1, 1) > Version(1, 1, 1, "alpha" :: List{string}())  &&
+  Version(2, 0, 0) > Version(1, 99, 0)                            &&
+  Version(1, 0, 0) < Version(2, 1, 0)                             &&
+  Version(1, 1, 0) < Version(1, 2, 0)                             &&
+  Version(1, 1, 2) < Version(1, 1, 3)                             &&
+  Version(1, 1, 1) < Version(1, 1, 2, "alpha" :: List{string}())
 )
 
 assert(
@@ -118,6 +118,8 @@ assert(
   p("0")            is ParseFailure           &&
   p("0.")           is ParseFailure           &&
   p("0.a")          is ParseFailure           &&
+  p("-1.1")         is ParseFailure           &&
+  p("1.-1")         is ParseFailure           &&
   p("0.0")          == Version(0, 0)          &&
   p("42.1337")      == Version(42, 1337)      &&
   p("42.1337.123")  == Version(42, 1337, 123) &&

--- a/novstd/version.nov
+++ b/novstd/version.nov
@@ -4,6 +4,11 @@ import "std/writer.nov"
 
 // Utilities for sem-ver versions.
 // https://semver.org/
+//
+// Non-standard extensions:
+// * Omitting the patch number (assumed to be zero), example: '1.42-alpha', will equal: '1.42.0-alpha'.
+// * Using a dot to start the meta tags, example: '1.2.3.42', will equal: '1.2.3+42'.
+//
 
 // -- Types
 
@@ -63,7 +68,7 @@ fun versionParser() -> Parser{Version}
   (
     txtIntParser() & matchParser('.') >> txtIntParser() & ?(matchParser('.') >> txtIntParser()) &
     ?(matchParser('-') >> manyParser(tagParser, matchParser('.'))) &
-    ?(matchParser('+') >> manyParser(tagParser, matchParser('.')))
+    ?((matchParser('+') | matchParser('.')) >> manyParser(tagParser, matchParser('.')))
   ).unwrap( lambda (  int major,
                       int minor,
                       Option{int} patch,
@@ -164,6 +169,18 @@ assert(
   Version(42, 1337, 123,
     List{string}(),
     "alpha" :: "fullmoon" :: "wip-local-machine" :: "europe" :: List{string}())
+)
+
+assert(
+  versionParser()("1.2.3.42")
+  ==
+  Version(1, 2, 3, List{string}(), "42" :: List{string}())
+)
+
+assert(
+  versionParser()("2.29.2.windows.2")
+  ==
+  Version(2, 29, 2, List{string}(), "windows" :: "2" :: List{string}())
 )
 
 assert(


### PR DESCRIPTION
Add two non standard extensions to sem-ver (both exist in the wild unfortunately):
* Omitting the patch number (assumed to be zero), example: `1.42-alpha`, will equal: `1.42.0-alpha`.
* Using a dot to start the meta tags, example: `1.2.3.42`, will equal: `1.2.3+42`.

But both are only supported as input, output will always be written as valid semver.

Also fixes a bug of allowing negative numbers in version parts.