### PR TITLE
Improved function templated type param inference

### DIFF
--- a/novstd/error.nov
+++ b/novstd/error.nov
@@ -6,6 +6,9 @@ struct Error = int code, string msg
 
 // -- Constructors
 
+fun Error()
+  Error(-1, "Unknown error")
+
 fun Error(string msg)
   Error(-1, msg)
 
@@ -25,6 +28,60 @@ fun ??{T}(Either{T, Error} e, lazy{T} def)
 fun string(Error err)
   err.msg
 
+// -- Functions
+
+fun map{T, TResult}(Either{T, Error} v, function{T, Either{TResult, Error}} f) -> Either{TResult, Error}
+  if v as T      val -> f(val)
+  if v as Error  err -> err
+
+fun map{T, TResult}(Either{T, Error} v, function{T, TResult} f) -> Either{TResult, Error}
+  if v as T      val -> f(val)
+  if v as Error  err -> err
+
+// -- Actions
+
+act map{T, TResult}(Either{T, Error} v, action{T, Either{TResult, Error}} f) -> Either{TResult, Error}
+  if v as T      val -> f(val)
+  if v as Error  err -> err
+
+act map{T, TResult}(Either{T, Error} v, action{T, TResult} f) -> Either{TResult, Error}
+  if v as T      val -> f(val)
+  if v as Error  err -> err
+
 // -- Tests
 
 assert(Error("Hello").string() == "Hello")
+
+assert(
+  v = Either{int, Error}(42);
+  v.map(lambda (int val) val * 2) == 84)
+
+assert(
+  v = Either{int, Error}(Error());
+  v.map(lambda (int val) 42) == Error())
+
+assert(
+  v = Either{int, Error}(42);
+  v.map(lambda (int val) val > 100 ? val : Error("Test")) == Error("Test"))
+
+assert(
+  v = Either{int, Error}(Error());
+  v.map(lambda (int val) val > 100 ? val : Error("Test")) == Error())
+
+// -- Impure Tests
+
+assert(
+  v = Either{int, Error}(42);
+  v.map(impure lambda (int val) val * 2) == 84)
+
+assert(
+  v = Either{int, Error}(Error("Test"));
+  v.map(impure lambda (int val) val) == Error("Test"))
+
+assert(
+  v = Either{int, Error}(42);
+  v.map(impure lambda (int val) val > 100 ? val : Error("Test")) == Error("Test"))
+
+assert(
+  v = Either{int, Error}(Error());
+  v.map(impure lambda (int val) val > 100 ? val : Error("Test")) == Error())

--- a/novstd/option.nov
+++ b/novstd/option.nov
@@ -30,14 +30,22 @@ fun some{T}(T t) Option(t)
 
 fun none() None()
 
-fun map{T, TResult}(Option{T} opt, function{T, TResult} func)
-  opt as T val ? func(val) : None()
+fun map{T, TResult}(Option{T} opt, function{T, TResult} func) -> Option{TResult}
+  opt as T val ? func(val) : none()
 
-fun map{T, TResult}(Option{T} opt, function{T, Option{TResult}} func)
-  opt as T val ? func(val) : None()
+fun map{T, TResult}(Option{T} opt, function{T, Option{TResult}} func) -> Option{TResult}
+  opt as T val ? func(val) : none()
 
 fun unwrap{T}(Option{Option{T}} opt) -> Option{T}
   opt as Option{T} o ? o : none()
+
+// -- Actions
+
+act map{T, TResult}(Option{T} opt, action{T, TResult} func) -> Option{TResult}
+  opt as T val ? func(val) : none()
+
+act map{T, TResult}(Option{T} opt, action{T, Option{TResult}} func) -> Option{TResult}
+  opt as T val ? func(val) : none()
 
 // -- Tests
 
@@ -62,7 +70,20 @@ assert(
   func = (lambda (int val) val > 0 ? Option(val) : None());
   Option(42).map(func) == 42 &&
   Option(-42).map(func) is None &&
+  Option(-42).map(func) == Option{int}() &&
   Option{int}().map(func) is None)
 
-assert( Option{Option{int}}().unwrap() == Option{int}() )
-assert( Option(Option(42)).unwrap() == Option(42) )
+assert(Option{Option{int}}().unwrap() == Option{int}())
+assert(Option(Option(42)).unwrap() == Option(42))
+
+// -- Impure Tests
+
+assert(Option(42).map(impure lambda (int val) val * 2) == 84)
+assert(Option{int}().map(impure lambda (int val) val * 2) == None())
+
+assert(
+  func = (impure lambda (int val) val > 0 ? Option(val) : None());
+  Option(42).map(func) == 42 &&
+  Option(-42).map(func) is None &&
+  Option(-42).map(func) == Option{int}() &&
+  Option{int}().map(func) is None)

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -83,7 +83,7 @@ auto FuncTemplate::getRetType(const prog::sym::TypeSet& typeParams)
 }
 
 auto FuncTemplate::inferTypeParams(const prog::sym::TypeSet& argTypes)
-    -> std::optional<prog::sym::TypeSet> {
+    -> std::optional<InferResult> {
   if (argTypes.getCount() != m_parseNode->getArgList().getCount()) {
     return std::nullopt;
   }
@@ -96,7 +96,11 @@ auto FuncTemplate::inferTypeParams(const prog::sym::TypeSet& argTypes)
     }
     typeParams.push_back(*inferredType);
   }
-  return prog::sym::TypeSet{std::move(typeParams)};
+
+  InferResult result;
+  result.types      = prog::sym::TypeSet{std::move(typeParams)};
+  result.complexity = getComplexity(*m_ctx, result.types);
+  return result;
 }
 
 auto FuncTemplate::isCallable(

--- a/src/frontend/internal/func_template.hpp
+++ b/src/frontend/internal/func_template.hpp
@@ -13,6 +13,11 @@ class FuncTemplate final {
   friend class FuncTemplateTable;
 
 public:
+  struct InferResult {
+    prog::sym::TypeSet types;
+    int complexity;
+  };
+
   FuncTemplate(const FuncTemplate& rhs) = delete;
   FuncTemplate(FuncTemplate&& rhs)      = default;
   ~FuncTemplate()                       = default;
@@ -28,7 +33,7 @@ public:
       -> std::optional<prog::sym::TypeId>;
 
   [[nodiscard]] auto inferTypeParams(const prog::sym::TypeSet& argTypes)
-      -> std::optional<prog::sym::TypeSet>;
+      -> std::optional<InferResult>;
 
   [[nodiscard]] auto
   isCallable(const prog::sym::TypeSet& typeParams, const prog::sym::TypeSet& argTypes) -> bool;

--- a/src/frontend/internal/typeinfer_typesub.cpp
+++ b/src/frontend/internal/typeinfer_typesub.cpp
@@ -46,4 +46,20 @@ auto resolvePathToTypeSub(
   return resolvePathToTypeSub(ctx, ++begin, end, params[targetIndex]);
 }
 
+auto getComplexity(const Context& ctx, prog::sym::TypeId type) noexcept -> int {
+  const auto typeInfo = ctx.getTypeInfo(type);
+  if (!typeInfo || !typeInfo->hasParams()) {
+    return 1; // Simple type without type-parameters has a complexity of 1.
+  }
+  return 1 + getComplexity(ctx, *typeInfo->getParams());
+}
+
+auto getComplexity(const Context& ctx, const prog::sym::TypeSet& types) noexcept -> int {
+  auto result = 0;
+  for (const auto& type : types) {
+    result += getComplexity(ctx, type);
+  }
+  return result;
+}
+
 } // namespace frontend::internal

--- a/src/frontend/internal/typeinfer_typesub.hpp
+++ b/src/frontend/internal/typeinfer_typesub.hpp
@@ -51,4 +51,14 @@ template <typename TypeSpec>
   return result;
 }
 
+/* Calculate the complexity of a type, used to prefer simpler types for type inference.
+ * Note: Currently this is based on the amount of type-parameters and their complexity.
+ */
+auto getComplexity(const Context& ctx, prog::sym::TypeId type) noexcept -> int;
+
+/* Calculate the complexity of a set of types, used to prefer simpler types for type inference.
+ * Note: Currently this a sum of the complexity of the types.
+ */
+auto getComplexity(const Context& ctx, const prog::sym::TypeSet& types) noexcept -> int;
+
 } // namespace frontend::internal


### PR DESCRIPTION
Prefer matches with simpler types (with less type parameters, so prefer `int` over `Option{int}`. This makes it possible to overload templated functions with more specialized matches.

Before this pr in the following example both overloads of map would be instantiated (and overload resolution would pick one at random as they have an identical signature). With this change only the one with a simpler match would be instantated so `int` instead of `Option{int}` for the `TResult` param.
```
union Option{T} = T, None
struct None

fun map{T, TResult}(Option{T} opt, function{T, TResult} func) -> Option{TResult}
  opt as T val ? func(val) : None()

fun map{T, TResult}(Option{T} opt, function{T, Option{TResult}} func) -> Option{TResult}
  opt as T val ? func(val) : None()

assert( Option{int}(42)       .map(lambda (int i) i * 2               ) == 84 )
assert( Option{int}(None())   .map(lambda (int i) i * 2               ) == None() )
assert( Option{int}(42)       .map(lambda (int i) Option{int}(None()) ) == None() )
assert( Option{int}(None())   .map(lambda (int i) Option{int}(None()) ) == None() )
```