### PR TITLE
Add error aggregation support

### DIFF
--- a/novstd/error.nov
+++ b/novstd/error.nov
@@ -1,8 +1,11 @@
 import "std/either.nov"
+import "std/list.nov"
+import "std/option.nov"
+import "std/writer.nov"
 
 // -- Types
 
-struct Error = int code, string msg
+struct Error = int code, string msg, Option{Error} next
 
 // -- Constructors
 
@@ -12,10 +15,16 @@ fun Error()
 fun Error(string msg)
   Error(-1, msg)
 
-fun Error(int errCode)
-  Error(errCode, errCode.string())
+fun Error(int code)
+  Error(code, code.string())
+
+fun Error(int code, string msg)
+  Error(code, msg, none())
 
 // -- Operators
+
+fun ::(Error a, Error b)
+  Error(a.code, a.msg, a.next as Error n ? n :: b : b)
 
 fun ??{T}(Either{T, Error} e, T def)
   e as T val ? val : def
@@ -26,9 +35,35 @@ fun ??{T}(Either{T, Error} e, lazy{T} def)
 // -- Conversions
 
 fun string(Error err)
-  err.msg
+  err.allErrors().map(lambda (Error err) "'" + err.msg + "'").string()
 
 // -- Functions
+
+fun count(Error err)
+  err.next as Error n ? 1 + n.count() : 1
+
+fun distinct(Error err)
+  err.allErrors().distinct().combine() ?? err
+
+fun allErrors(Error err) -> List{Error}
+  err.next as Error n ? List(Error(err.code, err.msg)) :: allErrors(n) : List(err)
+
+fun combine(List{Error} err) -> Option{Error}
+  err.fold(lambda (Option{Error} result, Error err)
+    result as Error e ? some(e :: err) : some(err)
+  )
+
+fun valueOrError{T}(Pair{T, Option{Error}} p) -> Either{T, Error}
+  valueOrError(p.first, p.second)
+
+fun valueOrError{T}(Pair{T, List{Error}} p) -> Either{T, Error}
+  valueOrError(p.first, p.second)
+
+fun valueOrError{T}(T val, Option{Error} err) -> Either{T, Error}
+  err as Error e ? e : val
+
+fun valueOrError{T}(T val, List{Error} err) -> Either{T, Error}
+  valueOrError(val, combine(err))
 
 fun map{T, TResult}(Either{T, Error} v, function{T, Either{TResult, Error}} f) -> Either{TResult, Error}
   if v as T      val -> f(val)
@@ -37,6 +72,18 @@ fun map{T, TResult}(Either{T, Error} v, function{T, Either{TResult, Error}} f) -
 fun map{T, TResult}(Either{T, Error} v, function{T, TResult} f) -> Either{TResult, Error}
   if v as T      val -> f(val)
   if v as Error  err -> err
+
+// -- Writers
+
+fun errorWriter()
+  errorWriter(noneWriter(), newlineWriter())
+
+fun errorWriter(Writer{None} prefixWriter, Writer{None} sepWriter)
+  listWriter(
+    (
+      prefixWriter & litWriter('[') & txtIntWriter() & litWriter("] ") & stringWriter()
+    ).map(lambda (Error err) makePair(err.code, err.msg))
+  , sepWriter).map(lambda (Error err) err.allErrors())
 
 // -- Actions
 
@@ -50,7 +97,40 @@ act map{T, TResult}(Either{T, Error} v, action{T, TResult} f) -> Either{TResult,
 
 // -- Tests
 
-assert(Error("Hello").string() == "Hello")
+assert(Error("Hello").string() == "['Hello']")
+
+assert((Error("Hello") :: Error("World")).string() == "['Hello','World']")
+
+assert((Error("Hello") :: Error("Good") :: Error("World")).string() == "['Hello','Good','World']")
+
+assert(
+  w = errorWriter();
+  w(Error()).string() == "[-1] Unknown error" &&
+  w(Error(1337, "Hello") :: Error(42, "World")).string() == "[1337] Hello\n[42] World")
+
+assert(
+  w = errorWriter(indentWriter(), litWriter(",")).indent();
+  w(Error()).string() == "  [-1] Unknown error" &&
+  w(Error(1337, "Hello") :: Error(42, "World")).string() == "  [1337] Hello,  [42] World")
+
+assert(
+  Error("Hello").count() == 1 &&
+  (Error("Hello") :: Error("World")).count() == 2 &&
+  (Error("Good") :: Error("Hello") :: Error("World")).count() == 3)
+
+assert(
+  err = Error("Hello") :: Error("Good") :: Error("World");
+  err.allErrors() == Error("Hello") :: Error("Good") :: Error("World") :: List{Error}())
+
+assert(
+  errs = Error("Hello") :: Error("Good") :: Error("World") :: List{Error}();
+  errs.combine() == Error("Hello") :: Error("Good") :: Error("World"))
+
+assert(
+  Error("Hello").distinct() == Error("Hello") &&
+  (Error() :: Error()).distinct() == Error() &&
+  (Error("Hello") :: Error("World")).distinct() == Error("Hello") :: Error("World") &&
+  (Error("Hello") :: Error("World") :: Error("Hello")).distinct() == Error("Hello") :: Error("World"))
 
 assert(
   v = Either{int, Error}(42);
@@ -67,6 +147,15 @@ assert(
 assert(
   v = Either{int, Error}(Error());
   v.map(lambda (int val) val > 100 ? val : Error("Test")) == Error())
+
+assert(
+  valueOrError(42, none())        == 42 &&
+  valueOrError(42, Error("Test")) == Error("Test") )
+
+assert(
+  valueOrError(42, List{Error}())                                     == 42 &&
+  valueOrError(42, Error("Test") :: List{Error}())                    == Error("Test") &&
+  valueOrError(42, Error("Test") :: Error("Test2") :: List{Error}())  == Error("Test") :: Error("Test2") )
 
 // -- Impure Tests
 

--- a/novstd/list.nov
+++ b/novstd/list.nov
@@ -1,3 +1,4 @@
+import "std/either.nov"
 import "std/option.nov"
 import "std/pair.nov"
 
@@ -64,6 +65,9 @@ fun push{T}(List{T} l, T val)
 fun push{T}(List{T} l, List{T} l2)
   if l2 as LNode{T} n -> List{T}(n.val, push(l, n.next))
   if l2 is LEnd       -> l
+
+fun pushUnique{T}(List{T} l, T val)
+  l.contains(val) ? l : l.push(val)
 
 fun pushRange{T}(List{T} l, T start, T end)
   if start >= end -> l
@@ -175,6 +179,12 @@ fun reverse{T}(List{T} l)
 fun sort{T}(List{T} l)
   l.fold(insertOrdered{T})
 
+fun distinct{T}(List{T} l)
+  l.fold(pushUnique{T}).reverse()
+
+fun distinctReverse{T}(List{T} l)
+  l.fold(pushUnique{T})
+
 fun count{T}(List{T} l, function{T, bool} pred)
   l.fold(lambda (int c, T val) pred(val) ? ++c : c)
 
@@ -221,6 +231,18 @@ fun zip{T, TResult}(List{List{T}} l, function{TResult, List{T}, TResult} func, T
   if fronts.isEmpty() -> result
   else                -> nexts = l.map(lambda (List{T} cur) cur.pop(1));
                          zip(nexts, func, func(result, fronts))
+
+fun split{T1, T2}(List{Either{T1, T2}} l)
+  l.reverse().splitReverse()
+
+fun splitReverse{T1, T2}(List{Either{T1, T2}} l)
+  l.fold(
+    lambda (Pair{List{T1}, List{T2}} res, Either{T1, T2} elem)
+      makePair(
+        elem as T1 t1 ? (t1 :: res.first)   : res.first,
+        elem as T2 t2 ? (t2 :: res.second)  : res.second
+      )
+    , makePair(List{T1}(), List{T2}()))
 
 // The default equality uses stack size linear with the list length, so for large lists its
 // ineffiecient / impossible to use the default equality. This is an alternative that uses
@@ -318,6 +340,14 @@ assert(
   l.push(List(42)) == 42 :: 1 :: 2 :: 3 :: List{int}() &&
   l.push(42 :: 1337 :: List{int}()) == 42 :: 1337 :: 1 :: 2 :: 3 :: List{int}() &&
   l.push(3 :: 2 :: 1 :: List{int}()) == 3 :: 2 :: 1 :: 1 :: 2 :: 3 :: List{int}())
+
+assert(
+  l = 1 :: 2 :: 3 :: List{int}();
+  l.pushUnique(1) == l &&
+  l.pushUnique(2) == l &&
+  l.pushUnique(3) == l &&
+  l.pushUnique(4) == 4 :: l &&
+  l.pushUnique(-1).pushUnique(2).pushUnique(4) == 4 :: -1 :: l)
 
 assert(
   l = 42 :: 1337 :: List{int}();
@@ -468,6 +498,28 @@ assert(List{int}().sort() == List{int}())
 
 assert(
   l = 1 :: 2 :: 3 :: List{int}();
+  l.distinct() == l)
+assert(
+  l = 1 :: 2 :: 2 :: 3 :: List{int}();
+  l.distinct() == 1 :: 2 :: 3 :: List{int}())
+assert(
+  l = 3 :: 1 :: 2 :: 3 :: 2 :: 3 :: 3 :: List{int}();
+  l.distinct() == 3 :: 1 :: 2 :: List{int}())
+assert(List{int}().distinct() == List{int}())
+
+assert(
+  l = 1 :: 2 :: 3 :: List{int}();
+  l.distinctReverse() == 3 :: 2 :: 1 :: List{int}())
+assert(
+  l = 1 :: 2 :: 2 :: 3 :: List{int}();
+  l.distinctReverse() == 3 :: 2 :: 1 :: List{int}())
+assert(
+  l = 1 :: 1 :: 2 :: 2 :: 3 :: 3 :: 3 :: List{int}();
+  l.distinctReverse() == 3 :: 2 :: 1 :: List{int}())
+assert(List{int}().distinctReverse() == List{int}())
+
+assert(
+  l = 1 :: 2 :: 3 :: List{int}();
   l.count(lambda (int v) v > 2) == 1 &&
   l.count(lambda (int v) v == 0) == 0 &&
   l.count(lambda (int v) v > 0) == 3)
@@ -525,6 +577,38 @@ assert(
 assert(
   l = List{List{string}}();
   l.zip(lambda (string result, List{string} cur) result + " " + cur.sum()) == "")
+
+assert(
+  l = List{Either{int, string}}();
+  r = split(l);
+  r.first.isEmpty() && r.second.isEmpty())
+
+assert(
+  eS = (lambda (string s) Either{int, string}(s));
+  eI = (lambda (int i) Either{int, string}(i));
+  l = eI(1) :: eS("hello") :: eI(2) :: eS("world") :: eI(3) :: eI(4) :: List{Either{int, string}}();
+  split(l) == makePair(1 :: 2 :: 3 :: 4 :: List{int}(), "hello" :: "world" :: List{string}()))
+
+assert(
+  eS = (lambda (string s) Either{int, string}(s));
+  l = eS("hello") :: eS("good") :: eS("world") :: List{Either{int, string}}();
+  split(l) == makePair(List{int}(), "hello" :: "good" :: "world" :: List{string}()))
+
+assert(
+  eI = (lambda (int i) Either{int, string}(i));
+  l = eI(1) :: eI(2) :: eI(3) :: List{Either{int, string}}();
+  split(l) == makePair(1 :: 2 :: 3 :: List{int}(), List{string}()))
+
+assert(
+  l = List{Either{int, string}}();
+  r = splitReverse(l);
+  r.first.isEmpty() && r.second.isEmpty())
+
+assert(
+  eS = (lambda (string s) Either{int, string}(s));
+  eI = (lambda (int i) Either{int, string}(i));
+  l = eI(1) :: eS("hello") :: eI(2) :: eS("world") :: eI(3) :: eI(4) :: List{Either{int, string}}();
+  splitReverse(l) == makePair(4 :: 3 :: 2 :: 1 :: List{int}(), "world" :: "hello" :: List{string}()))
 
 assert(
   l = 0 :: 1 :: 4 :: 9 :: List{int}();

--- a/novstd/writer.nov
+++ b/novstd/writer.nov
@@ -27,7 +27,7 @@ fun WriterState(string indentStr, WriterNewlineMode newlineMode)
   WriterState("", 0, indentStr, newlineMode)
 
 fun WriterState(WriterNewlineMode newlineMode)
-  WriterState("", 0, "\t", newlineMode)
+  WriterState("", 0, "  ", newlineMode)
 
 // -- Operators
 
@@ -102,6 +102,9 @@ fun map{T, TResult}(Writer{TResult} w, function{T, TResult} func)
   )
 
 // -- Writers
+
+fun noneWriter()
+  Writer(lambda (WriterState s, None n) s)
 
 fun litWriter(string lit)
   Writer(lambda (WriterState s, None n)
@@ -192,6 +195,10 @@ fun lazyWriter{T}(lazy{Writer{T}} lw)
   )
 
 // -- Tests
+
+assert(
+  w = noneWriter();
+  w(None()) == "")
 
 assert(
   w = litWriter("hello world");


### PR DESCRIPTION
Errors can now be combined to make it easier to aggregate multiple errors.

Example:
```
import "std.nov"

fun tryGetInt(string str) -> Either{int, Error}
  txtIntParser().run(str)

fun tryGetIntList(List{string} list) -> Either{List{int}, Error}
  list.map(tryGetInt).split().valueOrError()

print(tryGetIntList("1" :: "a" :: "3" :: "c" :: List{string}()))
```
![image](https://user-images.githubusercontent.com/14230060/100483720-8ec67b00-3102-11eb-8d3b-5dff1c058df0.png)
