### PR TITLE
Parse standard-library improvements

### DIFF
--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -75,14 +75,14 @@ fun subTextParser() -> Parser{string}
 // Parse the sequence number, the timing line and all text belonging to this subtitle, then
 // construct a 'Subtitle' struct.
 fun subParser() -> Parser{Subtitle}
-  seq     = txtIntParser() << lineParser(true) << whitespaceParser();
-  timing  = timingParser() << lineParser(true) << whitespaceParser();
+  seq     = txtIntParser() << lineParser(ParseFlags.Optional) << whitespaceParser();
+  timing  = timingParser() << lineParser(ParseFlags.Optional) << whitespaceParser();
   txt     = subTextParser();
   (seq & timing & txt).unwrap(lambda (int seq, Timing t, string txt) Subtitle(seq, t, txt))
 
 // Parse a list of subtitles optionally followed by whitespace.
 fun subListParser() -> Parser{List{Subtitle}}
-  manyParser(subParser() << whitespaceParser(true), true)
+  manyParser(subParser() << whitespaceParser(), true)
 
 // -- Driver code
 // Example output:

--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -70,13 +70,13 @@ fun timingParser() -> Parser{Timing}
 
 // Parse all text until a empty line is encountered.
 fun subTextParser() -> Parser{string}
-  whileParser(lambda (ParseState s) !(s == "\n\n" || s == "\r\n\r\n"))
+  untilParser(newlineParser() & newlineParser())
 
 // Parse the sequence number, the timing line and all text belonging to this subtitle, then
 // construct a 'Subtitle' struct.
 fun subParser() -> Parser{Subtitle}
-  seq     = txtIntParser() << lineParser();
-  timing  = timingParser() << lineParser();
+  seq     = txtIntParser() << lineParser(true) << whitespaceParser();
+  timing  = timingParser() << lineParser(true) << whitespaceParser();
   txt     = subTextParser();
   (seq & timing & txt).unwrap(lambda (int seq, Timing t, string txt) Subtitle(seq, t, txt))
 

--- a/examples/webserver/http_header.nov
+++ b/examples/webserver/http_header.nov
@@ -21,19 +21,19 @@ struct HttpRespHeader   =
 // -- Parsers
 
 fun httpVersionParser()
-  matchParser("HTTP/") >> whileParser(!isWhitespace)
+  matchParser("HTTP/") >> untilParser(isWhitespace)
 
 fun httpHeaderFieldParser()
   (
-    whileParser(!equals{char}[':']) << matchParser(':') & whitespaceParser() >> lineParser()
+    untilParser(matchParser(':')) << matchParser(':') & whitespaceParser() >> lineParser()
   ).unwrap(lambda (string k, string v) HttpHeaderField(k, v))
 
 fun httpReqHeaderParser()
   (
-    httpMethodParser()          << whitespaceParser() &
-    whileParser(!isWhitespace)  << whitespaceParser() &
-    httpVersionParser()         << whitespaceParser() &
-    manyParser(httpHeaderFieldParser())
+    httpMethodParser()        << whitespaceParser() &
+    untilParser(isWhitespace) << whitespaceParser() &
+    httpVersionParser()       << whitespaceParser() &
+    manyParser(httpHeaderFieldParser(), newlineParser())
   ).unwrap(lambda (HttpMethod m, string resource, string v, List{HttpHeaderField} fields)
       HttpReqHeader(m, resource, v, fields))
 

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -86,6 +86,7 @@ enum class FuncKind {
   DecrementChar, // Decrement a character.
 
   ConvIntLong,     // Convert a integer to a long.
+  ConvCharLong,    // Convert a character to a long.
   ConvIntFloat,    // Convert a int to a float.
   ConvLongInt,     // Convert a long to an integer.
   ConvLongFloat,   // Convert a long to a float.

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -383,6 +383,14 @@ fun lazyParser{T}(lazy{Parser{T}} lp)
     get(lp)(s)
   )
 
+// -- Parser modifiers
+
+fun trim(Parser{string} p)
+  p.map(lambda (string res) res.trim())
+
+fun trim(Parser{string} p, function{char, bool} pred)
+  p.map(lambda (string res) res.trim(pred))
+
 // -- Tests
 
 assert(retParser(42)("") == 42)
@@ -733,3 +741,20 @@ assert(
   p("42,1337,1,2")  == 42 :: 1337 :: 1 :: 2 :: List{int}() &&
   p("42")           == 42 :: List{int}() &&
   p("")             == List{int}())
+
+assert(
+  p = whileParser(!equals{char}['|']).trim();
+  p("") is ParseFailure &&
+  p(" ") == "" &&
+  p("\t\n\r ") == "" &&
+  p(" abc \t  | hello") == "abc" &&
+  p(" a b c \t  | hello") == "a b c" &&
+  p("\n\r a b c \t  | hello") == "a b c")
+
+assert(
+  p = whileParser(!equals{char}['|']).trim(isDigit);
+  p("") is ParseFailure &&
+  p(" ") == " " &&
+  p("123") == "" &&
+  p(" 123 ") == " 123 " &&
+  p("1abc501| hello") == "abc")

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -166,7 +166,7 @@ fun map{T, TResult}(Parser{T} p, function{T, TResult} func)
     if res as ParseFailure    fail  -> fail
   )
 
-fun mapOrErr{T, TResult}(Parser{T} p, function{T, Either{TResult, Error}} func)
+fun map{T, TResult}(Parser{T} p, function{T, Either{TResult, Error}} func)
   Parser(lambda (ParseState s) -> ParseResult{TResult}
     pR = p(s);
     if pR as ParseFailure    parseFail  -> parseFail
@@ -298,20 +298,32 @@ fun txtBoolParser()
     else            -> s.failure(Error("Expected boolean, got: '" + s[0] + "'"))
   )
 
-fun txtPosIntParser()
+fun txtPosLongParser()
   Parser(lambda (ParseState s)
     invoke(
-      lambda (ParseState s, int res, bool valid) -> ParseResult{int}
-        if s[0].isDigit() -> self(++s, res * 10 + s[0] - '0', true)
+      lambda (ParseState s, long res, bool valid) -> ParseResult{long}
+        if s[0].isDigit() -> self(++s, res * 10L + s[0] - '0', true)
         else              -> valid ?  s.success(res) :
                                       s.failure(Error("Expected integer, got: '" + s[0] + "'"))
-      , s, 0, false)
+      , s, 0L, false)
+  )
+
+fun txtLongParser()
+  matchParser('-') >> txtPosLongParser().map(negate{long})  |
+  matchParser('+') >> txtPosLongParser()                    |
+  txtPosLongParser()
+
+fun txtPosIntParser()
+   txtPosLongParser().map(lambda (long l) -> Either{int, Error}
+    l > intMax() ? Error("Integer too big") : int(l)
   )
 
 fun txtIntParser()
-  matchParser('-') >> txtPosIntParser().map(negate{int})  |
-  matchParser('+') >> txtPosIntParser()                   |
-  txtPosIntParser()
+  txtLongParser().map(lambda (long l) -> Either{int, Error}
+    if l > intMax() -> Error("Integer too big")
+    if l < intMin() -> Error("Integer too small")
+    else            -> int(l)
+  )
 
 fun txtHexParser()
   txtHexParser(1)
@@ -473,14 +485,14 @@ assert(
 assert(
   txtPosIntParser()("1")                == 1 &&
   txtPosIntParser()("1337")             == 1337 &&
-  txtPosIntParser()(intMax().string())  == intMax() &&
-  txtPosIntParser()("2147483648")       == -2147483647 - 1)
+  txtPosIntParser()(intMax().string())  == intMax())
 
 assert(
-  txtPosIntParser()("-1")   is ParseFailure &&
-  txtPosIntParser()("+1")   is ParseFailure &&
-  txtPosIntParser()("a")    is ParseFailure &&
-  txtPosIntParser()(" 123") is ParseFailure)
+  txtPosIntParser()("-1")         is ParseFailure &&
+  txtPosIntParser()("+1")         is ParseFailure &&
+  txtPosIntParser()("a")          is ParseFailure &&
+  txtPosIntParser()(" 123")       is ParseFailure &&
+  txtPosIntParser()("2147483648") is ParseFailure)
 
 assert(
   txtIntParser()("")         is ParseFailure &&
@@ -493,13 +505,33 @@ assert(
   txtIntParser()("+1")               == 1 &&
   txtIntParser()("1337")             == 1337 &&
   txtIntParser()(intMax().string())  == intMax() &&
-  txtIntParser()(intMin().string())  == intMin() &&
-  txtIntParser()("2147483648")       == -2147483647 - 1)
+  txtIntParser()(intMin().string())  == intMin())
 
 assert(
-  txtIntParser()("")         is ParseFailure &&
-  txtIntParser()("a")        is ParseFailure &&
-  txtIntParser()(" 123")     is ParseFailure)
+  txtIntParser()("")            is ParseFailure &&
+  txtIntParser()("a")           is ParseFailure &&
+  txtIntParser()(" 123")        is ParseFailure &&
+  txtIntParser()("-2147483649") is ParseFailure &&
+  txtIntParser()("2147483648")  is ParseFailure)
+
+assert(
+  txtPosLongParser()("1")                   == 1L &&
+  txtPosLongParser()("1337")                == 1337L &&
+  txtPosLongParser()(intMax().string())     == long(intMax()) &&
+  txtPosLongParser()(longMax().string())    == longMax() &&
+  txtPosLongParser()("7223372036854775807") == 7223372036854775807L &&
+  txtPosLongParser()("9223372036854775808") == -9223372036854775807L - 1L)
+
+assert(
+  txtPosLongParser()("-1") is ParseFailure &&
+  txtPosLongParser()("+1") is ParseFailure &&
+  txtPosLongParser()("a")  is ParseFailure)
+
+assert(
+  txtLongParser()("1")                == 1L &&
+  txtLongParser()("-1")               == -1L &&
+  txtLongParser()("+1")               == 1L &&
+  txtLongParser()(longMax().string()) == longMax())
 
 assert(
   txtHexParser()("0")         == 0x0 &&
@@ -670,7 +702,7 @@ assert(
 
 assert(
   err = Error("Value outside of the 100 - 200 range");
-  p = txtIntParser().mapOrErr(lambda (int i) -> Either{int, Error}
+  p = txtIntParser().map(lambda (int i) -> Either{int, Error}
     if i >= 100 && i <= 200 -> i
     else                    -> err
   );
@@ -683,7 +715,7 @@ assert(
   p("") is ParseFailure)
 
 assert(
-  p = txtIntParser().mapOrErr(lambda (int i) -> Either{string, Error}
+  p = txtIntParser().map(lambda (int i) -> Either{string, Error}
     if i == 42    -> "Meaning of life"
     if i == 1337  -> "Elite"
     else          -> Error("No signficiant meaning to: '" + i + "'")

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -234,7 +234,7 @@ fun allParser()
 fun whileParser(function{ParseState, bool} pred)
   whileParser(pred, false)
 
-fun whileParser(function{ParseState, bool} pred, bool allowEmpty)
+fun whileParser(function{ParseState, bool} pred, bool optional)
   Parser(lambda (ParseState begin)
     impl =
     (
@@ -244,14 +244,26 @@ fun whileParser(function{ParseState, bool} pred, bool allowEmpty)
                                                : cur.failure(Error(
                                                   "Unexpected character: '" + cur[0] + "'"))
     );
-    impl(begin, allowEmpty)
+    impl(begin, optional)
   )
 
 fun whileParser(function{char, bool} pred)
   whileParser(pred, false)
 
-fun whileParser(function{char, bool} pred, bool allowEmpty)
-  whileParser(lambda (ParseState s) pred(s[0]), allowEmpty)
+fun whileParser(function{char, bool} pred, bool optional)
+  whileParser(lambda (ParseState s) pred(s[0]), optional)
+
+fun untilParser(function{char, bool} pred)
+  whileParser(!pred)
+
+fun untilParser(function{char, bool} pred, bool optional)
+  whileParser(!pred, optional)
+
+fun untilParser{T}(Parser{T} endParser)
+  untilParser(endParser, false)
+
+fun untilParser{T}(Parser{T} endParser, bool optional)
+  whileParser(lambda (ParseState s) endParser(s) is ParseFailure, optional)
 
 fun whitespaceParser()
   whileParser(isWhitespace, true)
@@ -260,7 +272,13 @@ fun whitespaceParser(bool optional)
   whileParser(isWhitespace, optional)
 
 fun lineParser()
-  whileParser(lambda (ParseState s) (s - 1) != '\n', false)
+  untilParser(isNewline)
+
+fun lineParser(bool optional)
+  untilParser(isNewline, optional)
+
+fun newlineParser()
+  matchParser("\r\n") | matchParser("\n")
 
 fun txtBoolParser()
   Parser(lambda (ParseState s) -> ParseResult{bool}
@@ -394,6 +412,26 @@ assert(
   whileParser(isDigit, false)("")      is ParseFailure)
 
 assert(
+  untilParser(isDigit, true)("abc123")            == "abc" &&
+  untilParser(isDigit, true)("")                  == "" &&
+  untilParser(isDigit, false)("  hello 1 world")  == "  hello " &&
+  untilParser(isDigit, false)("1")                is ParseFailure &&
+  untilParser(isDigit, false)("")                 is ParseFailure)
+
+assert(
+  p = untilParser(matchParser('|'));
+  p("") is ParseFailure &&
+  p("|") is ParseFailure &&
+  p("|| |") is ParseFailure &&
+  p(" |") == " " &&
+  p("hello world| more?") == "hello world")
+
+assert(
+  p = untilParser(matchParser('|'), true);
+  p("") == "" &&
+  p("|") == "")
+
+assert(
   whitespaceParser()("  123")   == "  " &&
   whitespaceParser()(" a")      == " " &&
   whitespaceParser()(" \n\t ")  == " \n\t " &&
@@ -401,9 +439,21 @@ assert(
   whitespaceParser()("abc")     == "")
 
 assert(
-  lineParser()("abc sdf hello world")   == "abc sdf hello world" &&
-  lineParser()("abc sdf\nhello world")  == "abc sdf\n" &&
-  lineParser()("") is ParseFailure)
+  p = lineParser();
+  p("abc sdf hello world")     == "abc sdf hello world" &&
+  p("abc sdf\nhello world")    == "abc sdf" &&
+  p("abc sdf\r\nhello world")  == "abc sdf" &&
+  p("abc sdf\n\nhello world")  == "abc sdf" &&
+  p("") is ParseFailure)
+
+assert(
+  p = newlineParser();
+  p("\n")   == "\n" &&
+  p("\r\n") == "\r\n" &&
+  p("\n\n") == "\n" &&
+  p("\n\r") == "\n" &&
+  p("\r") is ParseFailure &&
+  p("")   is ParseFailure)
 
 assert(
   txtPosIntParser()("1")                == 1 &&

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -14,6 +14,10 @@ struct  ParseFailure    = Error err, ParseState state
 union   ParseResult{T}  = ParseSuccess{T}, ParseFailure
 struct  Parser{T}       = function{ParseState, ParseResult{T}} func
 
+enum ParseFlags =
+  None      : 0b0,
+  Optional  : 0b1
+
 // -- Operators
 
 fun (){T}(Parser{T} p, string str)
@@ -148,6 +152,9 @@ fun isEnd(ParseState s)               s.pos >= s.str.length()
 fun success{T}(ParseState s, T val)   ParseSuccess(val, s)
 fun failure(ParseState s, Error err)  ParseFailure(err, s)
 
+fun isOptional(ParseFlags flags)
+  (flags & ParseFlags.Optional) != 0
+
 fun map{T, TResult}(ParseResult{T} res, function{T, TResult} func)
   if res as ParseSuccess{T} suc   -> suc.state.success(func(suc.val))
   if res as ParseFailure    fail  -> fail
@@ -232,9 +239,9 @@ fun allParser()
   )
 
 fun whileParser(function{ParseState, bool} pred)
-  whileParser(pred, false)
+  whileParser(pred, ParseFlags.None)
 
-fun whileParser(function{ParseState, bool} pred, bool optional)
+fun whileParser(function{ParseState, bool} pred, ParseFlags flags)
   Parser(lambda (ParseState begin)
     impl =
     (
@@ -244,38 +251,38 @@ fun whileParser(function{ParseState, bool} pred, bool optional)
                                                : cur.failure(Error(
                                                   "Unexpected character: '" + cur[0] + "'"))
     );
-    impl(begin, optional)
+    impl(begin, flags.isOptional())
   )
 
 fun whileParser(function{char, bool} pred)
-  whileParser(pred, false)
+  whileParser(pred, ParseFlags.None)
 
-fun whileParser(function{char, bool} pred, bool optional)
-  whileParser(lambda (ParseState s) pred(s[0]), optional)
+fun whileParser(function{char, bool} pred, ParseFlags flags)
+  whileParser(lambda (ParseState s) pred(s[0]), flags)
 
 fun untilParser(function{char, bool} pred)
   whileParser(!pred)
 
-fun untilParser(function{char, bool} pred, bool optional)
-  whileParser(!pred, optional)
+fun untilParser(function{char, bool} pred, ParseFlags flags)
+  whileParser(!pred, flags)
 
 fun untilParser{T}(Parser{T} endParser)
-  untilParser(endParser, false)
+  untilParser(endParser, ParseFlags.None)
 
-fun untilParser{T}(Parser{T} endParser, bool optional)
-  whileParser(lambda (ParseState s) endParser(s) is ParseFailure, optional)
+fun untilParser{T}(Parser{T} endParser, ParseFlags flags)
+  whileParser(lambda (ParseState s) endParser(s) is ParseFailure, flags)
 
 fun whitespaceParser()
-  whileParser(isWhitespace, true)
+  whileParser(isWhitespace, ParseFlags.Optional)
 
-fun whitespaceParser(bool optional)
-  whileParser(isWhitespace, optional)
+fun whitespaceParser(ParseFlags flags)
+  whileParser(isWhitespace, flags)
 
 fun lineParser()
   untilParser(isNewline)
 
-fun lineParser(bool optional)
-  untilParser(isNewline, optional)
+fun lineParser(ParseFlags flags)
+  untilParser(isNewline, flags)
 
 fun newlineParser()
   matchParser("\r\n") | matchParser("\n")
@@ -412,19 +419,19 @@ assert(
   p("hello world") == "world" )
 
 assert(
-  whileParser(isDigit, false)("123 123") == "123" &&
-  whileParser(isDigit, false)("12345")   == "12345" &&
-  whileParser(isDigit, false)("1")       == "1" &&
-  whileParser(isDigit, false)("1abc")    == "1" &&
-  whileParser(isDigit, false)("abc")   is ParseFailure &&
-  whileParser(isDigit, false)("")      is ParseFailure)
+  whileParser(isDigit)("123 123") == "123" &&
+  whileParser(isDigit)("12345")   == "12345" &&
+  whileParser(isDigit)("1")       == "1" &&
+  whileParser(isDigit)("1abc")    == "1" &&
+  whileParser(isDigit)("abc")   is ParseFailure &&
+  whileParser(isDigit)("")      is ParseFailure)
 
 assert(
-  untilParser(isDigit, true)("abc123")            == "abc" &&
-  untilParser(isDigit, true)("")                  == "" &&
-  untilParser(isDigit, false)("  hello 1 world")  == "  hello " &&
-  untilParser(isDigit, false)("1")                is ParseFailure &&
-  untilParser(isDigit, false)("")                 is ParseFailure)
+  untilParser(isDigit, ParseFlags.Optional)("abc123")   == "abc" &&
+  untilParser(isDigit, ParseFlags.Optional)("")         == "" &&
+  untilParser(isDigit)("  hello 1 world")               == "  hello " &&
+  untilParser(isDigit)("1")                             is ParseFailure &&
+  untilParser(isDigit)("")                              is ParseFailure)
 
 assert(
   p = untilParser(matchParser('|'));
@@ -435,7 +442,7 @@ assert(
   p("hello world| more?") == "hello world")
 
 assert(
-  p = untilParser(matchParser('|'), true);
+  p = untilParser(matchParser('|'), ParseFlags.Optional);
   p("") == "" &&
   p("|") == "")
 

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -504,6 +504,7 @@ assert(
   txtIntParser()("-1")               == -1 &&
   txtIntParser()("+1")               == 1 &&
   txtIntParser()("1337")             == 1337 &&
+  txtIntParser()("+0200")            == 200 &&
   txtIntParser()(intMax().string())  == intMax() &&
   txtIntParser()(intMin().string())  == intMin())
 

--- a/novstd/time.nov
+++ b/novstd/time.nov
@@ -1,5 +1,6 @@
-import "std/text.nov"
 import "std/math.nov"
+import "std/parse.nov"
+import "std/text.nov"
 
 // Gregorian calendar assumed with no leap seconds.
 
@@ -255,6 +256,11 @@ fun <=(Timestamp t1, Timestamp t2)  t1.ns <= t2.ns
 fun >(Timestamp t1, Timestamp t2)   t1.ns > t2.ns
 fun >=(Timestamp t1, Timestamp t2)  t1.ns >= t2.ns
 
+// -- Parsers
+
+fun unixTimeParser()
+  txtPosLongParser().map(lambda (long l) timeEpoch() + seconds(l))
+
 // -- Actions
 
 // Get a DateTime from the current system clock.
@@ -345,3 +351,10 @@ assert(timestamp() <= timestamp())
 
 assert(approx(float(seconds(42) + milliseconds(500)), 42.5))
 assert(approx(float(seconds(1337) + millisecond()), 1337.001))
+
+// -- Parser tests
+
+assert(
+  p = unixTimeParser();
+  p("")           is ParseFailure &&
+  p("1606579701") == (DateTime(2020, Month.November, 28) + hours(16) + minutes(8) + seconds(21)))

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -361,6 +361,7 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
 
   case prog::sym::FuncKind::ConvIntLong:
+  case prog::sym::FuncKind::ConvCharLong:
     m_asmb->addConvIntLong();
     break;
   case prog::sym::FuncKind::ConvIntFloat:
@@ -758,7 +759,7 @@ auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
   m_asmb->label(endLabel);
 }
 
-auto GenExpr::visit(const prog::expr::FailNode& /*unused*/) -> void { m_asmb->addFail(); }
+auto GenExpr::visit(const prog::expr::FailNode & /*unused*/) -> void { m_asmb->addFail(); }
 
 auto GenExpr::visit(const prog::expr::LitBoolNode& n) -> void {
   m_asmb->addLoadLitInt(n.getVal() ? 1U : 0U);

--- a/src/opt/precompute_literals.cpp
+++ b/src/opt/precompute_literals.cpp
@@ -66,6 +66,7 @@ namespace opt {
   case prog::sym::FuncKind::CheckGtInt:
   case prog::sym::FuncKind::CheckGtEqInt:
   case prog::sym::FuncKind::ConvIntLong:
+  case prog::sym::FuncKind::ConvCharLong:
   case prog::sym::FuncKind::ConvIntFloat:
   case prog::sym::FuncKind::ConvIntString:
   case prog::sym::FuncKind::ConvIntChar:
@@ -441,7 +442,8 @@ private:
       assert(args.size() == 2);
       return prog::expr::litBoolNode(m_prog, getInt(*args[0]) >= getInt(*args[1]));
     }
-    case prog::sym::FuncKind::ConvIntLong: {
+    case prog::sym::FuncKind::ConvIntLong:
+    case prog::sym::FuncKind::ConvCharLong: {
       assert(args.size() == 1);
       return prog::expr::litLongNode(m_prog, static_cast<int64_t>(getInt(*args[0])));
     }

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -216,6 +216,7 @@ Program::Program() :
   // Register build-in implicit conversions.
   m_funcDecls.registerImplicitConv(*this, Fk::NoOp, m_char, m_int);
   m_funcDecls.registerImplicitConv(*this, Fk::ConvIntLong, m_int, m_long);
+  m_funcDecls.registerImplicitConv(*this, Fk::ConvCharLong, m_char, m_long);
   m_funcDecls.registerImplicitConv(*this, Fk::ConvIntFloat, m_int, m_float);
   m_funcDecls.registerImplicitConv(*this, Fk::ConvLongFloat, m_long, m_float);
 

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -464,6 +464,10 @@ TEST_CASE("Generate assembly for call expressions", "[backend]") {
       asmb->addLoadLitInt(42); // NOLINT: Magic numbers
       asmb->addConvIntLong();
     });
+    CHECK_EXPR("long('a')", [](novasm::Assembler* asmb) -> void {
+      asmb->addLoadLitInt('a');
+      asmb->addConvIntLong();
+    });
     CHECK_EXPR("string(42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(42);
       asmb->addConvIntString();


### PR DESCRIPTION
Allot of small improvements to `parse.nov`:

Changes:
* Add `untilParser` to `parse.nov`.
* Add `trim` parse modifier that can trim output of a string parser.
* Refactor the `bool optional` arguments in `parse.nov` to `ParseFlags`.
* Support `char` to `long` implicit conversion.
* Add support for parsing longs (`txtPosLongParser` and `txtLongParser`).
* Add errors when trying to parse a too small or too big integer.
* Add a unix time parser (seconds since epoch) to `time.nov`.
