### PR TITLE
Improve error output of the parser library

### DIFF
--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -37,7 +37,10 @@ import "std.nov"
 //    Excecutes both parsers, return a list containing both values.
 //
 // - 'Parser{T} ! Error' -> Parser{T}'
-//    Add a more descriptive error when the given parser fails.
+//    Append a more descriptive error when the given parser fails.
+//
+// - 'Parser{T} !! Error' -> Parser{T}'
+//    Replace the error with a more descriptive error when the given parser fails.
 
 // -- Types
 
@@ -85,7 +88,7 @@ fun subParser() -> Parser{Subtitle}
 
 // Parse a list of subtitles optionally followed by whitespace.
 fun subListParser() -> Parser{List{Subtitle}}
-  manyParser(subParser() << whitespaceParser(), true)
+  manyUntilParser(subParser() << whitespaceParser(), endParser())
 
 // -- Driver code
 // Example output:

--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -35,6 +35,9 @@ import "std.nov"
 //
 // - 'Parser{T} :: Parser{T}' -> Parser{List{T}}'
 //    Excecutes both parsers, return a list containing both values.
+//
+// - 'Parser{T} ! Error' -> Parser{T}'
+//    Add a more descriptive error when the given parser fails.
 
 // -- Types
 
@@ -59,14 +62,14 @@ fun timecodeParser() -> Parser{Duration}
     (matchParser(':') >> durationParser(minute()))      ::
     (matchParser(':') >> durationParser(second()))      ::
     (matchParser(',') >> durationParser(millisecond()))
-  ).map(sum{Duration})
+  ).map(sum{Duration}) ! Error("Invalid srt timecode")
 
 // Format of timing: '00:13:59,380 --> 00:14:01,257'
 // Parse two timecodes and construct a 'Timing' struct.
 fun timingParser() -> Parser{Timing}
   (
     timecodeParser() & (matchParser(" --> ") >> timecodeParser())
-  ).unwrap(lambda (Duration a, Duration b) Timing(a, b))
+  ).unwrap(lambda (Duration a, Duration b) Timing(a, b)) ! Error("Invalid srt timing specification")
 
 // Parse all text until a empty line is encountered.
 fun subTextParser() -> Parser{string}
@@ -75,7 +78,7 @@ fun subTextParser() -> Parser{string}
 // Parse the sequence number, the timing line and all text belonging to this subtitle, then
 // construct a 'Subtitle' struct.
 fun subParser() -> Parser{Subtitle}
-  seq     = txtIntParser() << lineParser(ParseFlags.Optional) << whitespaceParser();
+  seq     = txtIntParser() << lineParser(ParseFlags.Optional) << whitespaceParser() ! Error("Invalid sequence number");
   timing  = timingParser() << lineParser(ParseFlags.Optional) << whitespaceParser();
   txt     = subTextParser();
   (seq & timing & txt).unwrap(lambda (int seq, Timing t, string txt) Subtitle(seq, t, txt))

--- a/examples/webserver/http_header.nov
+++ b/examples/webserver/http_header.nov
@@ -35,7 +35,7 @@ fun httpReqHeaderParser()
     httpVersionParser()       << whitespaceParser() &
     manyParser(httpHeaderFieldParser(), newlineParser())
   ).unwrap(lambda (HttpMethod m, string resource, string v, List{HttpHeaderField} fields)
-      HttpReqHeader(m, resource, v, fields))
+      HttpReqHeader(m, resource, v, fields)) ! Error("Invalid http request header")
 
 // -- Writers
 

--- a/examples/webserver/http_method.nov
+++ b/examples/webserver/http_method.nov
@@ -29,4 +29,4 @@ fun httpMethodParser()
   (matchParser("TRACE")   >> retParser(HttpMethod.Trace))   |
   (matchParser("OPTIONS") >> retParser(HttpMethod.Options)) |
   (matchParser("CONNECT") >> retParser(HttpMethod.Connect)) |
-  (matchParser("PATH")    >> retParser(HttpMethod.Patch))
+  (matchParser("PATH")    >> retParser(HttpMethod.Patch))   !! Error("Invalid http method")

--- a/include/lex/token_kind.hpp
+++ b/include/lex/token_kind.hpp
@@ -23,6 +23,7 @@ enum class TokenKind {
   OpEq,           // =
   OpEqEq,         // ==
   OpBang,         // !
+  OpBangBang,     // !!
   OpBangEq,       // !=
   OpLe,           // <
   OpLeEq,         // <=

--- a/include/prog/operator.hpp
+++ b/include/prog/operator.hpp
@@ -22,6 +22,7 @@ enum class Operator {
   Tilde,
   EqEq,
   Bang,
+  BangBang,
   BangEq,
   Le,
   LeEq,

--- a/novstd/ascii.nov
+++ b/novstd/ascii.nov
@@ -1,4 +1,5 @@
 import "std/list.nov"
+import "std/text.nov"
 
 // -- Functions
 
@@ -35,12 +36,23 @@ fun toUpper(char c)
 fun toLower(char c)
   c.isUpper() ? char(c ^ 0x20) : c
 
+fun isPrintable(char c)
+  !c.isControl() && c < 127
+
 fun escapeForPrinting(char c)
-  if c == '\n'                -> "\\n"
-  if c == '\r'                -> "\\r"
-  if c == '\t'                -> "\\t"
-  if c.isControl() || c > 127 -> "\\" + int(c).string()
-  else                        -> c.string()
+  if c == '\n'        -> "\\n"
+  if c == '\r'        -> "\\r"
+  if c == '\t'        -> "\\t"
+  if c.isPrintable()  -> c.string()
+  else                -> "\\" + int(c).string()
+
+fun escapeForPrinting(string str)
+  invoke(lambda (int idx, string str)
+    if idx >= str.length()      -> str
+    if !str[idx].isPrintable()  -> replace = str[idx].escapeForPrinting();
+                                   self(idx + replace.length(), str.remove(idx).insert(idx, replace))
+    else                        -> self(++idx, str)
+  , 0, str)
 
 // -- Tests
 
@@ -105,3 +117,12 @@ assert(
   '+'.escapeForPrinting()       == "+"      &&
   char(127).escapeForPrinting() == "\\127"  &&
   char(189).escapeForPrinting() == "\\189")
+
+assert(
+  "".escapeForPrinting()                  == ""                     &&
+  "hello world".escapeForPrinting()       == "hello world"          &&
+  "hello\nworld".escapeForPrinting()      == "hello\\nworld"        &&
+  "\thello\nworld\r".escapeForPrinting()  == "\\thello\\nworld\\r"  &&
+  "\0".escapeForPrinting()                == "\\0"                  &&
+  "\0\0\0".escapeForPrinting()            == "\\0\\0\\0"            &&
+  "\a\n\t\b".escapeForPrinting()          == "\\7\\n\\t\\8")

--- a/novstd/error.nov
+++ b/novstd/error.nov
@@ -32,6 +32,12 @@ fun ??{T}(Either{T, Error} e, T def)
 fun ??{T}(Either{T, Error} e, lazy{T} def)
   e as T val ? val : def.get()
 
+fun !{T}(Either{T, Error} e, Error newError)
+  e as Error oldError ? Either{T, Error}(newError :: oldError) : e
+
+fun !{T}(Either{T, Error} e, function{Error, Error} errorMutation)
+  e as Error oldError ? Either{T, Error}(errorMutation(oldError)) : e
+
 // -- Conversions
 
 fun string(Error err)
@@ -147,6 +153,30 @@ assert(
 assert(
   v = Either{int, Error}(Error());
   v.map(lambda (int val) val > 100 ? val : Error("Test")) == Error())
+
+assert(
+  v = Either{int, Error}(Error("Low level error"));
+  (v ! Error("Better error")) == Error("Better error") :: Error("Low level error"))
+
+assert(
+  v = Either{int, Error}(42);
+  (v ! Error("Better error")) == 42)
+
+assert(
+  v = Either{int, Error}(Error("Low level error"));
+  (v ! lambda (Error oldErr) Error("Better error")) == Error("Better error"))
+
+assert(
+  v = Either{int, Error}(Error("Low level error"));
+  (v ! lambda (Error e) e) == Error("Low level error"))
+
+assert(
+  v = Either{int, Error}(Error("Low level error"));
+  (v ! lambda (Error e) Error("Better error") :: e) == Error("Better error") :: Error("Low level error"))
+
+assert(
+  v = Either{int, Error}(42);
+  (v ! lambda (Error e) Error("Better error")) == 42)
 
 assert(
   valueOrError(42, none())        == 42 &&

--- a/novstd/error.nov
+++ b/novstd/error.nov
@@ -33,9 +33,12 @@ fun ??{T}(Either{T, Error} e, lazy{T} def)
   e as T val ? val : def.get()
 
 fun !{T}(Either{T, Error} e, Error newError)
-  e as Error oldError ? Either{T, Error}(newError :: oldError) : e
+  e !! (lambda (Error oldError) newError :: oldError)
 
-fun !{T}(Either{T, Error} e, function{Error, Error} errorMutation)
+fun !!{T}(Either{T, Error} e, Error newError)
+  e !! (lambda (Error oldError) newError)
+
+fun !!{T}(Either{T, Error} e, function{Error, Error} errorMutation)
   e as Error oldError ? Either{T, Error}(errorMutation(oldError)) : e
 
 // -- Conversions
@@ -164,19 +167,27 @@ assert(
 
 assert(
   v = Either{int, Error}(Error("Low level error"));
-  (v ! lambda (Error oldErr) Error("Better error")) == Error("Better error"))
-
-assert(
-  v = Either{int, Error}(Error("Low level error"));
-  (v ! lambda (Error e) e) == Error("Low level error"))
-
-assert(
-  v = Either{int, Error}(Error("Low level error"));
-  (v ! lambda (Error e) Error("Better error") :: e) == Error("Better error") :: Error("Low level error"))
+  (v !! Error("Better error")) == Error("Better error"))
 
 assert(
   v = Either{int, Error}(42);
-  (v ! lambda (Error e) Error("Better error")) == 42)
+  (v !! Error("Better error")) == 42)
+
+assert(
+  v = Either{int, Error}(Error("Low level error"));
+  (v !! lambda (Error oldErr) Error("Better error")) == Error("Better error"))
+
+assert(
+  v = Either{int, Error}(Error("Low level error"));
+  (v !! lambda (Error e) e) == Error("Low level error"))
+
+assert(
+  v = Either{int, Error}(Error("Low level error"));
+  (v !! lambda (Error e) Error("Better error") :: e) == Error("Better error") :: Error("Low level error"))
+
+assert(
+  v = Either{int, Error}(42);
+  (v !! lambda (Error e) Error("Better error")) == 42)
 
 assert(
   valueOrError(42, none())        == 42 &&

--- a/novstd/json.nov
+++ b/novstd/json.nov
@@ -77,6 +77,9 @@ fun string(JsonValue v, string indent, WriterNewlineMode newlineMode)
   w = jsonValueWriter();
   w(v, indent, newlineMode).string()
 
+fun string(JsonNull n)
+  "null"
+
 // -- Parsers
 
 fun jsonNullParser()
@@ -86,8 +89,8 @@ fun jsonNumberParser()
   txtFloatParser()
 
 fun jsonBoolParser()
-  (matchParser("true")  >> retParser(true)) |
-  (matchParser("false") >> retParser(false))
+  (matchParser("true")  >> retParser(true))  |
+  (matchParser("false") >> retParser(false)) !! Error("Invalid json boolean")
 
 fun jsonUtf8EscapedCharParser()
   hexParser = txtHexParser(4);
@@ -101,14 +104,14 @@ fun jsonUtf8EscapedCharParser()
     if s[0] == 'r'  -> (s + 1).success("\r")
     if s[0] == 't'  -> (s + 1).success("\t")
     if s[0] == 'u'  -> hexParser(s + 1).map(lambda (int unicode) toUtf8(UnicodePoint(unicode)))
-    else            -> s.failure(Error("Invalid escape sequence"))
+    else            -> s.failure(Error("Invalid json character escape sequence"))
   )
 
 fun jsonUtf8CharParser()
   escapedChar = jsonUtf8EscapedCharParser();
   Parser(lambda (ParseState s)
-    if s[0].isControl()                   -> s.failure(Error("Unexpected control character"))
-    if s[0] == '"'                        -> s.failure(Error("End of string"))
+    if s[0].isControl()                   -> s.failure(Error("Unexpected character: '" + s[0].escapeForPrinting() + "'"))
+    if s[0] == '"'                        -> s.failure(Error("Unexpected end of string"))
     if s[0] == '\\'                       -> escapedChar(s + 1)
     if utf8Validate(s.str, s.pos, false)  -> cc = s[0].utf8GetCharCount();
                                              (s + cc).success(s.str[s.pos, s.pos + cc])
@@ -116,32 +119,48 @@ fun jsonUtf8CharParser()
   )
 
 fun jsonStringParser()
-  matchParser('"') >> manyParser(jsonUtf8CharParser()).map(sum{string}) << matchParser('"')
+  quote = matchParser('"');
+  (
+    quote >> manyUntilParser(jsonUtf8CharParser(), quote).map(sum{string}) << quote
+  ) ! Error("Invalid json string")
 
 fun jsonObjectParser(Parser{JsonValue} valParser)
   open      = matchParser('{')    << whitespaceParser();
-  key       = jsonStringParser()  << whitespaceParser();
+  key       = jsonStringParser()  << whitespaceParser() ! Error("Invalid object key");
   colon     = matchParser(':')    << whitespaceParser();
   value     = valParser           << whitespaceParser();
-  comma     = matchParser(',')    << whitespaceParser();
+  comma     = matchParser(',')    << whitespaceParser() !! Error("Expected comma or end of object");
   close     = matchParser('}')    << whitespaceParser();
   keyValue  = (key << colon) & value;
-  (open >> manyParser(keyValue, comma) << close).map(toJsonObj)
+  (open >> manyUntilParser(keyValue, comma, close) << close).map(toJsonObj)
 
 fun jsonArrayParser(Parser{JsonValue} valParser)
   open  = matchParser('[')    << whitespaceParser();
   value = valParser           << whitespaceParser();
-  comma = matchParser(',')    << whitespaceParser();
+  comma = matchParser(',')    << whitespaceParser() !! Error("Expected comma or end of array");
   close = matchParser(']')    << whitespaceParser();
-  (open >> manyParser(value, comma) << close).map(toJsonArray)
+  (open >> manyUntilParser(value, comma, close) << close).map(toJsonArray)
 
-fun jsonValueParser() -> Parser{JsonValue}
-  jsonNullParser().                                       map(toJsonVal{JsonNull})    |
-  jsonNumberParser().                                     map(toJsonVal{float})       |
-  jsonBoolParser().                                       map(toJsonVal{bool})        |
-  jsonStringParser().                                     map(toJsonVal{string})      |
-  jsonObjectParser(lazyParser(lazy jsonValueParser())).   map(toJsonVal{JsonObject})  |
-  jsonArrayParser(lazyParser(lazy jsonValueParser())).    map(toJsonVal{JsonArray})
+fun jsonValueParser()
+  objectP = jsonObjectParser(lazyParser(lazy jsonValueParser()));
+  arrayP  = jsonArrayParser(lazyParser(lazy jsonValueParser()));
+  stringP = jsonStringParser();
+  nullP   = jsonNullParser();
+  boolP   = jsonBoolParser();
+  numberP = jsonNumberParser();
+  Parser(lambda (ParseState s)
+    if s[0] == '{'    -> objectP(s) .map(toJsonVal{JsonObject})
+    if s[0] == '['    -> arrayP(s)  .map(toJsonVal{JsonArray})
+    if s[0] == '"'    -> stringP(s) .map(toJsonVal{string})
+    if s[0] == 'n'    -> nullP(s)   .map(toJsonVal{JsonNull})
+    if s[0] == 't'    -> boolP(s)   .map(toJsonVal{bool})
+    if s[0] == 'f'    -> boolP(s)   .map(toJsonVal{bool})
+    if s[0].isDigit() -> numberP(s) .map(toJsonVal{float})
+    if s[0] == '-'    -> numberP(s) .map(toJsonVal{float})
+    if s[0] == '\0'   -> s.failure(Error("Missing json value"))
+    else              -> s.failure(
+      Error("Invalid start of json value: '" + s[0].escapeForPrinting() + "'"))
+  )
 
 fun jsonParser()
   jsonValueParser()

--- a/novstd/option.nov
+++ b/novstd/option.nov
@@ -26,9 +26,9 @@ fun string{T}(Option{T} opt)
 
 // -- Functions
 
-fun some{T}(T t) Option(t)
-
-fun none() None()
+fun some{T}(T t)  Option(t)
+fun none{T}()     Option{T}(None())
+fun none()        None()
 
 fun map{T, TResult}(Option{T} opt, function{T, TResult} func) -> Option{TResult}
   opt as T val ? func(val) : none()

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -253,6 +253,12 @@ fun allParser()
     s.success(s.str[s.pos, s.str.length()])
   )
 
+fun endParser()
+  Parser(lambda (ParseState s) -> ParseResult{string}
+    s.isEnd() ? s.success("")
+              : s.failure(Error("Expected end of input, got '" + s[0].escapeForPrinting() + "'"))
+  )
+
 fun whileParser(function{ParseState, bool} pred)
   whileParser(pred, ParseFlags.None)
 
@@ -482,6 +488,16 @@ assert(
   p("|") == "")
 
 assert(
+  p = untilParser(endParser(), ParseFlags.Optional);
+  p("Hello world")  == "Hello world" &&
+  p("")             == "")
+
+assert(
+  p = untilParser(endParser());
+  p("Hello world") == "Hello world" &&
+  p("") is ParseFailure)
+
+assert(
   whitespaceParser()("  123")   == "  " &&
   whitespaceParser()(" a")      == " " &&
   whitespaceParser()(" \n\t ")  == " \n\t " &&
@@ -504,6 +520,12 @@ assert(
   p("\n\r") == "\n" &&
   p("\r") is ParseFailure &&
   p("")   is ParseFailure)
+
+assert(
+  p = endParser();
+  p("") == ""               &&
+  p("a") is ParseFailure    &&
+  p(" ") is ParseFailure)
 
 assert(
   txtPosIntParser()("1")                == 1 &&

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -28,8 +28,10 @@ fun (){T}(Parser{T} p, ParseState s)
 
 fun run{T}(Parser{T} p, string str) -> Either{T, Error}
   res = p(str);
-  if res as ParseSuccess{T} suc   -> suc.val
-  if res as ParseFailure    fail  -> fail.err
+  if res as ParseSuccess{T} suc  -> suc.val
+  if res as ParseFailure    fail ->
+    txtPos = getTextPos(fail.state.str[0, fail.state.pos]);
+    Error("Parsing failed, line: " + (txtPos.line + 1) + ", column: " + (txtPos.column + 1)) :: fail.err
 
 fun build{T}(Parser{T} p) -> function{string, Either{T, Error}}
   lambda (string str)
@@ -483,9 +485,10 @@ assert(retParser(42)("") == 42)
 assert(nopParser()("") == true)
 
 assert(
-  failParser(Error("Hello world"))  .run("")            == Error("Hello world")   &&
-  failParser()                      .run("Hello world") == Error()                &&
-  failParser()                      .run("")            == Error())
+  parseErr = Error("Parsing failed, line: 1, column: 1");
+  failParser(Error("Hello world")).run("")  == parseErr :: Error("Hello world") &&
+  failParser().run("Hello world")           == parseErr :: Error()              &&
+  failParser().run("")                      == parseErr :: Error())
 
 assert(
   matchParser('a')("a") == 'a' &&
@@ -780,24 +783,28 @@ assert(
   p("abc")    is ParseFailure)
 
 assert(
+  parseErr = Error("Parsing failed, line: 1, column: 1");
   p = matchParser("Hello") ! Error("Did not greet");
   p("Hello") == "Hello" &&
-  p.run("Hell") == Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
+  p.run("Hell") == parseErr :: Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
 
 assert(
+  parseErr = Error("Parsing failed, line: 1, column: 1");
   p = matchParser("Hello") !! Error("Did not greet");
   p("Hello") == "Hello" &&
-  p.run("Hell") == Error("Did not greet"))
+  p.run("Hell") == parseErr :: Error("Did not greet"))
 
 assert(
+  parseErr = Error("Parsing failed, line: 1, column: 1");
   p = (matchParser("Hello") !! lambda (Error err) Error("Did not greet"));
   p("Hello") == "Hello" &&
-  p.run("Hell") == Error("Did not greet"))
+  p.run("Hell") == parseErr :: Error("Did not greet"))
 
 assert(
+  parseErr = Error("Parsing failed, line: 1, column: 1");
   p = (matchParser("Hello") !! lambda (Error err) Error("Did not greet") :: err);
   p("Hello") == "Hello" &&
-  p.run("Hell") == Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
+  p.run("Hell") == parseErr :: Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
 
 assert(
   p = txtIntParser().map(lambda (int i) i * i);

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -234,14 +234,17 @@ fun retParser{T}(T val)
 fun matchParser(char c)
   Parser(lambda (ParseState s) -> ParseResult{char}
     if s == c -> (s + 1).success(c)
-    else      -> s.failure(Error("Expected: '" + c + "', got: '" + s[0] + "'"))
+    else      -> s.failure(
+      Error("Expected: '" + c.escapeForPrinting() + "', got: '" + s[0].escapeForPrinting() + "'"))
   )
 
 fun matchParser(string str)
   Parser(lambda (ParseState s) -> ParseResult{string}
     if s == str -> (s + str.length()).success(str)
     else        -> s.failure(
-      Error("Expected: '" + str + "', got: '" + s.str[s.pos, s.pos + str.length()] + "'"))
+      expected = str.escapeForPrinting();
+      got      = s.str[s.pos, s.pos + str.length()].escapeForPrinting();
+      Error("Expected: '" + expected + "', got: '" + got + "'"))
   )
 
 fun allParser()
@@ -296,7 +299,12 @@ fun lineParser(ParseFlags flags)
   untilParser(isNewline, flags)
 
 fun newlineParser()
-  matchParser("\r\n") | matchParser("\n")
+  Parser(lambda (ParseState s)
+    if s == "\n"    -> (s + 1).success("\n")
+    if s == "\r\n"  -> (s + 2).success("\r\n")
+    else            -> s.failure(
+      Error("Expected a newline, got: '" + s[0].escapeForPrinting() + "'"))
+  )
 
 fun txtBoolParser()
   Parser(lambda (ParseState s) -> ParseResult{bool}
@@ -306,7 +314,8 @@ fun txtBoolParser()
     if s == "false" -> (s + 5).success(false)
     if s == "FALSE" -> (s + 5).success(false)
     if s == "False" -> (s + 5).success(false)
-    else            -> s.failure(Error("Expected boolean, got: '" + s[0] + "'"))
+    else            -> s.failure(
+      Error("Expected a boolean, got: '" + s[0].escapeForPrinting() + "'"))
   )
 
 fun txtPosLongParser()
@@ -315,7 +324,8 @@ fun txtPosLongParser()
       lambda (ParseState s, long res, bool valid) -> ParseResult{long}
         if s[0].isDigit() -> self(++s, res * 10L + s[0] - '0', true)
         else              -> valid ?  s.success(res) :
-                                      s.failure(Error("Expected integer, got: '" + s[0] + "'"))
+                                      s.failure(
+          Error("Expected an integer, got: '" + s[0].escapeForPrinting() + "'"))
       , s, 0L, false)
   )
 
@@ -348,13 +358,14 @@ fun txtHexParser(int minDigits)
         if s[0] >= 'A' && s[0] <= 'F' -> self(++s, (res << 4) + s[0] - ('A' - 10),  ++digits)
         else                          -> digits >= minDigits ?
                                           s.success(res) :
-                                          s.failure(Error(
-                                            "Expected hex number, got: '" + s[0] + "'"))
+                                          s.failure(digits > 0 && digits < minDigits
+            ? Error("Expected '" + minDigits + "' hex digits, got only '" + digits + "'")
+            : Error("Expected hex number, got: '" + s[0].escapeForPrinting() + "'"))
       , s, 0, 0)
   )
 
 fun txtPosFloatParser()
-  intParser = txtIntParser();
+  expParser = txtIntParser() ! Error("Invalid exponent");
   Parser(lambda (ParseState s)
     invoke(
       lambda (ParseState s, float raw, float div, bool dec, bool valid) -> ParseResult{float}
@@ -362,10 +373,10 @@ fun txtPosFloatParser()
         if s[0].isDigit()       -> newRaw = raw * 10.0 + int(s[0]) - int('0');
                                    newDiv = dec ? div * 10.0 : div;
                                    self(++s, newRaw, newDiv, dec, true)
-        if s == 'e' || s == 'E' -> intParser(s + 1).map(lambda (int exp) raw / (div / pow(10.0, exp)))
+        if s == 'e' || s == 'E' -> expParser(s + 1).map(lambda (int exp) raw / (div / pow(10.0, exp)))
         else                    -> valid ?  s.success(raw / div) :
-                                            s.failure(Error(
-                                              "Expected float, got: '" + s[0] + "'"))
+                                            s.failure(
+          Error("Expected a floating point number, got: '" + s[0].escapeForPrinting() + "'"))
       , s, 0.0, 1.0, false, false)
     )
 

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -132,11 +132,12 @@ fun =={T1, T2}(ParseResult{Either{T1, T2}} result, T2 val)
   result as ParseSuccess{Either{T1, T2}} suc && suc.val == val
 
 fun !{T}(Parser{T} p, Error newError)
-  Parser(lambda (ParseState s) -> ParseResult{T}
-    pR = p(s);
-    pR as ParseFailure parseFail ? parseFail.state.failure(newError :: parseFail.err) : pR)
+  p !! (lambda (Error oldError) newError :: oldError)
 
-fun !{T}(Parser{T} p, function{Error, Error} errorMutation)
+fun !!{T}(Parser{T} p, Error newError)
+  p !! (lambda (Error oldError) newError)
+
+fun !!{T}(Parser{T} p, function{Error, Error} errorMutation)
   Parser(lambda (ParseState s) -> ParseResult{T}
     pR = p(s);
     pR as ParseFailure parseFail ? parseFail.state.failure(errorMutation(parseFail.err)) : pR)
@@ -718,12 +719,17 @@ assert(
   p.run("Hell") == Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
 
 assert(
-  p = (matchParser("Hello") ! lambda (Error err) Error("Did not greet"));
+  p = matchParser("Hello") !! Error("Did not greet");
   p("Hello") == "Hello" &&
   p.run("Hell") == Error("Did not greet"))
 
 assert(
-  p = (matchParser("Hello") ! lambda (Error err) Error("Did not greet") :: err);
+  p = (matchParser("Hello") !! lambda (Error err) Error("Did not greet"));
+  p("Hello") == "Hello" &&
+  p.run("Hell") == Error("Did not greet"))
+
+assert(
+  p = (matchParser("Hello") !! lambda (Error err) Error("Did not greet") :: err);
   p("Hello") == "Hello" &&
   p.run("Hell") == Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
 

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -131,6 +131,16 @@ fun =={T1, T2}(ParseResult{Either{T1, T2}} result, T1 val)
 fun =={T1, T2}(ParseResult{Either{T1, T2}} result, T2 val)
   result as ParseSuccess{Either{T1, T2}} suc && suc.val == val
 
+fun !{T}(Parser{T} p, Error newError)
+  Parser(lambda (ParseState s) -> ParseResult{T}
+    pR = p(s);
+    pR as ParseFailure parseFail ? parseFail.state.failure(newError :: parseFail.err) : pR)
+
+fun !{T}(Parser{T} p, function{Error, Error} errorMutation)
+  Parser(lambda (ParseState s) -> ParseResult{T}
+    pR = p(s);
+    pR as ParseFailure parseFail ? parseFail.state.failure(errorMutation(parseFail.err)) : pR)
+
 // -- Conversions
 
 fun string(ParseState s)
@@ -230,7 +240,8 @@ fun matchParser(char c)
 fun matchParser(string str)
   Parser(lambda (ParseState s) -> ParseResult{string}
     if s == str -> (s + str.length()).success(str)
-    else        -> s.failure(Error("Expected: '" + str + "', got: '" + s[0] + "'"))
+    else        -> s.failure(
+      Error("Expected: '" + str + "', got: '" + s.str[s.pos, s.pos + str.length()] + "'"))
   )
 
 fun allParser()
@@ -689,6 +700,21 @@ assert(
   p("Hello")  is ParseFailure &&
   p(" World") is ParseFailure &&
   p("abc")    is ParseFailure)
+
+assert(
+  p = matchParser("Hello") ! Error("Did not greet");
+  p("Hello") == "Hello" &&
+  p.run("Hell") == Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
+
+assert(
+  p = (matchParser("Hello") ! lambda (Error err) Error("Did not greet"));
+  p("Hello") == "Hello" &&
+  p.run("Hell") == Error("Did not greet"))
+
+assert(
+  p = (matchParser("Hello") ! lambda (Error err) Error("Did not greet") :: err);
+  p("Hello") == "Hello" &&
+  p.run("Hell") == Error("Did not greet") :: Error("Expected: 'Hello', got: 'Hell'"))
 
 assert(
   p = txtIntParser().map(lambda (int i) i * i);

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -235,6 +235,14 @@ fun retParser{T}(T val)
 fun nopParser()
   retParser(true)
 
+fun failParser()
+  failParser(Error())
+
+fun failParser(Error error)
+  Parser(lambda (ParseState s) -> ParseResult{bool}
+    s.failure(error)
+  )
+
 fun matchParser(char c)
   Parser(lambda (ParseState s) -> ParseResult{char}
     if s == c -> (s + 1).success(c)
@@ -398,35 +406,61 @@ fun txtFloatParser()
 // -- Combination parsers
 
 fun manyParser{T}(Parser{T} p)
-  manyParser(p, false)
-
-fun manyParser{T}(Parser{T} p, bool toEnd)
   Parser(lambda (ParseState begin)
-    impl =
+    invoke(lambda (ParseState cur, List{T} result) -> ParseResult{List{T}}
     (
-      lambda (ParseState cur, List{T} result) -> ParseResult{List{T}}
         if cur.isEnd() -> cur.success(result)
         else ->
           res = p(cur);
           if res as ParseSuccess{T} suc   -> self(suc.state, suc.val :: result)
-          if res as ParseFailure    fail  -> toEnd ? fail : cur.success(result)
-    );
-    impl(begin, List{T}()).map(reverse{T})
+          if res as ParseFailure    fail  -> cur.success(result)
+    ), begin, List{T}()).map(reverse{T})
   )
 
-fun manyParser{T1, T2}(Parser{T1} p, Parser{T2} seperator)
+fun manyParser{T, SepT}(Parser{T} p, Parser{SepT} seperator)
   Parser(lambda (ParseState begin)
-    impl =
+    invoke(lambda (ParseState cur, List{T} result, bool required) -> ParseResult{List{T}}
     (
-      lambda (ParseState cur, List{T1} result, bool required) -> ParseResult{List{T1}}
-        res1 = p(cur);
-        if res1 as ParseFailure     fail1  -> required ? fail1 : cur.success(result)
-        if res1 as ParseSuccess{T1} suc1   ->
-          res2 = seperator(suc1.state);
-          if res2 as ParseSuccess{T2} suc2  -> self(suc2.state, suc1.val :: result, true)
-          if res2 is ParseFailure           -> suc1.state.success(suc1.val :: result)
-    );
-    impl(begin, List{T1}(), false).map(reverse{T1})
+      res = p(cur);
+      if res as ParseFailure     fail  -> required ? fail : cur.success(result)
+      if res as ParseSuccess{T}  suc   ->
+        sepRes = seperator(suc.state);
+        if sepRes as ParseSuccess{SepT} sepSuc  -> self(sepSuc.state, suc.val :: result, true)
+        if sepRes is ParseFailure               -> suc.state.success(suc.val :: result)
+    ), begin, List{T}(), false).map(reverse{T})
+  )
+
+fun manyUntilParser{T, UntilT}(Parser{T} p, Parser{UntilT} until)
+  Parser(lambda (ParseState begin)
+    invoke(lambda (ParseState cur, List{T} result) -> ParseResult{List{T}}
+    (
+      if until(cur) is ParseSuccess{UntilT} -> cur.success(result)
+      if cur.isEnd()                        -> cur.failure(Error("Unexpected end of input"))
+      else ->
+        res = p(cur);
+        if res as ParseSuccess{T} suc   -> self(suc.state, suc.val :: result)
+        if res as ParseFailure    fail  -> fail
+    ), begin, List{T}()).map(reverse{T})
+  )
+
+fun manyUntilParser{T, SepT, UntilT}(Parser{T} p, Parser{SepT} seperator, Parser{UntilT} until)
+  reachedUntil = (lambda (ParseState s) until(s) is ParseSuccess{UntilT});
+  Parser(lambda (ParseState begin)
+    if reachedUntil(begin) -> begin.success(List{T}())
+    else ->
+      invoke(lambda (ParseState cur, List{T} result) -> ParseResult{List{T}}
+      (
+        if cur.isEnd()  -> cur.failure(Error("Unexpected end of input"))
+        else            ->
+          res = p(cur);
+          if res as ParseFailure    fail  -> fail
+          if res as ParseSuccess{T} suc   ->
+            sepRes = seperator(suc.state);
+            if sepRes as ParseSuccess{SepT} sepSuc  -> self(sepSuc.state, suc.val :: result)
+            if sepRes as ParseFailure       sepFail -> reachedUntil(suc.state)
+                                                          ? suc.state.success(suc.val :: result)
+                                                          : sepFail
+      ), begin, List{T}()).map(reverse{T})
   )
 
 fun lazyParser{T}(lazy{Parser{T}} lp)
@@ -447,6 +481,11 @@ fun trim(Parser{string} p, function{char, bool} pred)
 assert(retParser(42)("") == 42)
 
 assert(nopParser()("") == true)
+
+assert(
+  failParser(Error("Hello world"))  .run("")            == Error("Hello world")   &&
+  failParser()                      .run("Hello world") == Error()                &&
+  failParser()                      .run("")            == Error())
 
 assert(
   matchParser('a')("a") == 'a' &&
@@ -836,21 +875,48 @@ assert(
   p("")                   is ParseFailure)
 
 assert(
-  p = manyParser(txtBoolParser(), false);
+  p = manyParser(txtBoolParser());
   p("truefalsetruetrue")  == true :: false :: true :: true :: List{bool}() &&
   p("true")               == true :: List{bool}() &&
   p("true1")              == true :: List{bool}() &&
   p("")                   == List{bool}())
 
 assert(
-  p = manyParser(txtBoolParser(), true);
-  p("true1true") is ParseFailure)
-
-assert(
   p = manyParser(txtIntParser(), matchParser(','));
   p("42,1337,1,2")  == 42 :: 1337 :: 1 :: 2 :: List{int}() &&
   p("42")           == 42 :: List{int}() &&
   p("")             == List{int}())
+
+assert(
+  p = manyUntilParser(txtBoolParser(), endParser());
+  p("true1true") is ParseFailure)
+
+assert(
+  p = manyUntilParser(txtBoolParser(), newlineParser());
+  p("truefalse\ntrue")   == true :: false :: List{bool}()  &&
+  p("true\n")            == true :: List{bool}()           &&
+  p("false,\n")          is ParseFailure                   &&
+  p("true true\n")       is ParseFailure                   &&
+  p("false")             is ParseFailure                   &&
+  p("")                  is ParseFailure)
+
+assert(
+  p = manyUntilParser(txtIntParser(), matchParser(','), newlineParser());
+  p("42,1337\n1,2")   == 42 :: 1337 :: List{int}()  &&
+  p("42\n")           == 42 :: List{int}()          &&
+  p("42,\n")          is ParseFailure               &&
+  p("42 42\n")        is ParseFailure               &&
+  p("42")             is ParseFailure               &&
+  p("")               is ParseFailure)
+
+assert(
+  p = manyUntilParser(txtBoolParser(), matchParser(','), newlineParser());
+  p("true,false\ntrue")   == true :: false :: List{bool}()  &&
+  p("true\n")             == true :: List{bool}()           &&
+  p("false,\n")           is ParseFailure                   &&
+  p("true true\n")        is ParseFailure                   &&
+  p("false")              is ParseFailure                   &&
+  p("")                   is ParseFailure)
 
 assert(
   p = whileParser(!equals{char}['|']).trim();

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -232,6 +232,9 @@ fun retParser{T}(T val)
     s.success(val)
   )
 
+fun nopParser()
+  retParser(true)
+
 fun matchParser(char c)
   Parser(lambda (ParseState s) -> ParseResult{char}
     if s == c -> (s + 1).success(c)
@@ -442,6 +445,8 @@ fun trim(Parser{string} p, function{char, bool} pred)
 // -- Tests
 
 assert(retParser(42)("") == 42)
+
+assert(nopParser()("") == true)
 
 assert(
   matchParser('a')("a") == 'a' &&

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -131,6 +131,15 @@ fun insert(string str, int idx, string val)
   if idx >= str.length()  -> str + val
   else                    -> str[0, idx] + val + str[idx, str.length()]
 
+fun remove(string str, int idx)
+  str.remove(idx, 1)
+
+fun remove(string str, int idx, int amount)
+  if amount <= 0                  -> str
+  if idx == 0                     -> str[amount, str.length()]
+  if idx == str.length() - amount -> str[0, str.length() - amount]
+  else                            -> str[0, idx] + str[idx + amount, str.length()]
+
 fun padLeft(string str, int length, char c)
   if str.length() < length  -> padLeft(c.string() + str, length, c)
   else                      -> str
@@ -316,6 +325,32 @@ assert(
   "helloworld".insert("helloworld".length(), "_") == "helloworld_" &&
   "helloworld".insert(1, "_") == "h_elloworld" &&
   "helloworld".insert(5, "_") == "hello_world")
+
+assert(
+  "".remove(0)            == "" &&
+  "h".remove(0)           == "" &&
+  "helloworld".remove(0)  == "elloworld" &&
+  "helloworld".remove(1)  == "hlloworld" &&
+  "helloworld".remove(2)  == "heloworld" &&
+  "helloworld".remove(8)  == "helloword" &&
+  "helloworld".remove(9)  == "helloworl" &&
+  "helloworld".remove(-1) == "helloworld" &&
+  "helloworld".remove(10) == "helloworld")
+
+assert(
+  "".remove(0, 0)             == ""   &&
+  "".remove(0, 2)             == ""   &&
+  "h".remove(0, 0)            == "h"  &&
+  "h".remove(0, 2)            == ""   &&
+  "helloworld".remove(0, 2)   == "lloworld" &&
+  "helloworld".remove(1, 2)   == "hloworld" &&
+  "helloworld".remove(2, 2)   == "heoworld" &&
+  "helloworld".remove(8, 2)   == "hellowor" &&
+  "helloworld".remove(9, 2)   == "helloworl" &&
+  "helloworld".remove(0, 9)   == "d" &&
+  "helloworld".remove(0, 10)  == "" &&
+  "helloworld".remove(0, -1)  == "helloworld" &&
+  "helloworld".remove(2, -1)  == "helloworld")
 
 assert(
   "1".padLeft(-1, '0') == "1" &&

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -104,18 +104,17 @@ fun any(string str, function{char, bool} pred)
   , 0)
 
 fun all(string str, function{char, bool} pred)
-  invoke(
-    lambda (int idx)
-      if idx >= str.length()  -> true
-      else                    -> pred(str[idx]) && self(++idx)
-  , 0)
+  str.count(pred) == str.length()
 
 fun none(string str, function{char, bool} pred)
+  str.count(pred) == 0
+
+fun count(string str, function{char, bool} pred)
   invoke(
-    lambda (int idx)
-      if idx >= str.length()  -> true
-      else                    -> !pred(str[idx]) && self(++idx)
-  , 0)
+    lambda (int idx, int res)
+      if idx >= str.length()  -> res
+      else                    -> self(++idx, pred(str[idx]) ? ++res : res)
+  , 0, 0)
 
 fun replace(string str, string old, string new)
   invoke(
@@ -307,6 +306,13 @@ assert(
 assert(
   "hello world".none(equals{char}['1']) &&
   !"hello world".none(equals{char}[' ']))
+
+assert(
+  "".count(equals{char}[' ']) == 0 &&
+  " ".count(equals{char}[' ']) == 1 &&
+  " hello ".count(equals{char}[' ']) == 2 &&
+  "hello world".count(equals{char}[' ']) == 1 &&
+  "1234567890".count(isDigit) == 10)
 
 assert(
   "hello world".replace("hello", "world") == "world world" &&

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -2,12 +2,21 @@ import "std/ascii.nov"
 import "std/func.nov"
 import "std/list.nov"
 
+// -- Types
+
+struct TextPos =
+  int line,
+  int column
+
 // -- Operators
 
 fun +{T}(string s, T v)
   s + v.string()
 
 // -- Conversions
+
+fun string(TextPos p)
+  "[ln " + (p.line + 1) + ", c " + (p.column + 1) + "]"
 
 fun string(int i, int minDigits)
   i.string().padLeft(minDigits, '0')
@@ -203,6 +212,11 @@ fun join(List{string} l)
 fun join(List{char} l)
   l.fold(appendChar)
 
+fun getTextPos(string str)
+  line    = str.count(equals{char}['\n']);
+  column  = str.length() - (str.indexOfLast("\n") + 1);
+  TextPos(line, column)
+
 // -- Tests
 
 assert(
@@ -264,7 +278,8 @@ assert(
   "wasd wasd".indexOfLast(" ") == 4 &&
   "wasd wasd".indexOfLast("d w") == 3 &&
   "wasd wasd".indexOfLast("wasdz") == -1 &&
-  "wasd wasd".indexOfLast("") == -1)
+  "wasd wasd".indexOfLast("") == -1 &&
+  "".indexOfLast("d") == -1)
 
 assert(
   "hello world".indexOf(equals{char}[' ']) == 5 &&
@@ -418,3 +433,11 @@ assert(
   join('h' :: 'e' :: 'l' :: 'l' :: 'o' :: List{char}()) == "hello" &&
   List{string}().join() == "" &&
   List{char}().join() == "")
+
+assert(
+  "".getTextPos()           == TextPos(0, 0) &&
+  "a".getTextPos()          == TextPos(0, 1) &&
+  "abc".getTextPos()        == TextPos(0, 3) &&
+  "abc\n".getTextPos()      == TextPos(1, 0) &&
+  "abc\ndef".getTextPos()   == TextPos(1, 3) &&
+  "abc\ndef\n".getTextPos() == TextPos(2, 0))

--- a/novstd/time.nov
+++ b/novstd/time.nov
@@ -259,7 +259,7 @@ fun >=(Timestamp t1, Timestamp t2)  t1.ns >= t2.ns
 // -- Parsers
 
 fun unixTimeParser()
-  txtPosLongParser().map(lambda (long l) timeEpoch() + seconds(l))
+  txtPosLongParser().map(lambda (long l) timeEpoch() + seconds(l)) ! Error("Invalid unix timestamp")
 
 // -- Actions
 

--- a/novstd/version.nov
+++ b/novstd/version.nov
@@ -75,7 +75,7 @@ fun versionParser() -> Parser{Version}
                       Option{List{string}} prereleaseTags,
                       Option{List{string}} meta)
       Version(major, minor, patch ?? 0, prereleaseTags ?? List{string}(), meta ?? List{string}())
-    )
+    ) ! Error("Invalid sem-ver version")
 
 // -- Writers
 

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -92,6 +92,8 @@ auto getOperator(const lex::Token& token) -> std::optional<prog::Operator> {
     return prog::Operator::EqEq;
   case lex::TokenKind::OpBang:
     return prog::Operator::Bang;
+  case lex::TokenKind::OpBangBang:
+    return prog::Operator::BangBang;
   case lex::TokenKind::OpBangEq:
     return prog::Operator::BangEq;
   case lex::TokenKind::OpLe:
@@ -149,6 +151,8 @@ auto getText(const prog::Operator& op) -> std::string {
     return "==";
   case prog::Operator::Bang:
     return "!";
+  case prog::Operator::BangBang:
+    return "!!";
   case prog::Operator::BangEq:
     return "!=";
   case prog::Operator::Le:

--- a/src/lex/lexer.cpp
+++ b/src/lex/lexer.cpp
@@ -122,6 +122,10 @@ auto LexerImpl::next() -> Token {
       }
       return basicToken(TokenKind::OpEq, input::Span{m_inputPos});
     case '!':
+      if (peekChar(0) == '!') {
+        consumeChar();
+        return basicToken(TokenKind::OpBangBang, input::Span{m_inputPos - 1, m_inputPos});
+      }
       if (peekChar(0) == '=') {
         consumeChar();
         return basicToken(TokenKind::OpBangEq, input::Span{m_inputPos - 1, m_inputPos});

--- a/src/lex/token_cat.cpp
+++ b/src/lex/token_cat.cpp
@@ -52,6 +52,7 @@ auto lookupCat(const TokenKind kind) -> TokenCat {
   case TokenKind::OpEq:
   case TokenKind::OpEqEq:
   case TokenKind::OpBang:
+  case TokenKind::OpBangBang:
   case TokenKind::OpBangEq:
   case TokenKind::OpLe:
   case TokenKind::OpLeEq:

--- a/src/lex/token_kind.cpp
+++ b/src/lex/token_kind.cpp
@@ -58,6 +58,9 @@ auto operator<<(std::ostream& out, const TokenKind& rhs) -> std::ostream& {
   case TokenKind::OpBang:
     out << "!";
     break;
+  case TokenKind::OpBangBang:
+    out << "!!";
+    break;
   case TokenKind::OpBangEq:
     out << "!=";
     break;

--- a/src/parse/op_precedence.cpp
+++ b/src/parse/op_precedence.cpp
@@ -57,6 +57,7 @@ auto getRhsOpPrecedence(const lex::Token& token) -> int {
   case lex::TokenKind::OpPipePipe:
     return orPrecedence;
   case lex::TokenKind::OpBang:
+  case lex::TokenKind::OpBangBang:
     return bangPrecedence;
   case lex::TokenKind::OpQMark:
     return conditionalPrecedence;

--- a/src/parse/op_precedence.cpp
+++ b/src/parse/op_precedence.cpp
@@ -56,6 +56,8 @@ auto getRhsOpPrecedence(const lex::Token& token) -> int {
   case lex::TokenKind::OpPipe:
   case lex::TokenKind::OpPipePipe:
     return orPrecedence;
+  case lex::TokenKind::OpBang:
+    return bangPrecedence;
   case lex::TokenKind::OpQMark:
     return conditionalPrecedence;
   case lex::TokenKind::OpSemi:

--- a/src/parse/op_precedence.hpp
+++ b/src/parse/op_precedence.hpp
@@ -3,19 +3,20 @@
 
 namespace parse {
 
-const int callPrecedence           = 16;
-const int doubleQmarkPrecedence    = 15;
-const int fieldPrecedence          = 14;
-const int unaryPrecedence          = 13;
-const int multiplicativePrecedence = 12;
-const int additivePrecedence       = 11;
-const int shiftPrecedence          = 10;
-const int typeTestPrecedence       = 9;
-const int relationalPrecedence     = 8;
-const int equalityPrecedence       = 7;
-const int andPrecedence            = 6;
-const int xorPrecedence            = 5;
-const int orPrecedence             = 4;
+const int callPrecedence           = 17;
+const int doubleQmarkPrecedence    = 16;
+const int fieldPrecedence          = 15;
+const int unaryPrecedence          = 14;
+const int multiplicativePrecedence = 13;
+const int additivePrecedence       = 12;
+const int shiftPrecedence          = 11;
+const int typeTestPrecedence       = 10;
+const int relationalPrecedence     = 9;
+const int equalityPrecedence       = 8;
+const int andPrecedence            = 7;
+const int xorPrecedence            = 6;
+const int orPrecedence             = 5;
+const int bangPrecedence           = 4;
 const int conditionalPrecedence    = 3;
 const int assignmentPrecedence     = 2;
 const int groupingPrecedence       = 1;

--- a/src/prog/operator.cpp
+++ b/src/prog/operator.cpp
@@ -35,6 +35,8 @@ auto getFuncName(Operator op) -> std::string {
     return "__op_eqeq";
   case Operator::Bang:
     return "__op_bang";
+  case Operator::BangBang:
+    return "__op_bangbang";
   case Operator::BangEq:
     return "__op_bangeq";
   case Operator::Le:

--- a/tests/lex/operators_test.cpp
+++ b/tests/lex/operators_test.cpp
@@ -22,6 +22,7 @@ TEST_CASE("Lexing operators", "[lex]") {
   CHECK_TOKENS("=", basicToken(TokenKind::OpEq));
   CHECK_TOKENS("==", basicToken(TokenKind::OpEqEq));
   CHECK_TOKENS("!", basicToken(TokenKind::OpBang));
+  CHECK_TOKENS("!!", basicToken(TokenKind::OpBangBang));
   CHECK_TOKENS("!=", basicToken(TokenKind::OpBangEq));
   CHECK_TOKENS("<", basicToken(TokenKind::OpLe));
   CHECK_TOKENS("<=", basicToken(TokenKind::OpLeEq));

--- a/tests/parse/expr_binary_test.cpp
+++ b/tests/parse/expr_binary_test.cpp
@@ -16,6 +16,8 @@ TEST_CASE("Parsing binary operators", "[parse]") {
   CHECK_EXPR("1 ! !3", binaryExprNode(INT(1), BANG, unaryExprNode(BANG, INT(3))));
   CHECK_EXPR(
       "!1 ! !3", binaryExprNode(unaryExprNode(BANG, INT(1)), BANG, unaryExprNode(BANG, INT(3))));
+  CHECK_EXPR("1 !! 3", binaryExprNode(INT(1), BANGBANG, INT(3)));
+  CHECK_EXPR("1 !!!3", binaryExprNode(INT(1), BANGBANG, unaryExprNode(BANG, INT(3))));
 
   SECTION("Precedence") {
     CHECK_EXPR("1 + 2 * 5", binaryExprNode(INT(1), PLUS, binaryExprNode(INT(2), STAR, INT(5))));

--- a/tests/parse/expr_binary_test.cpp
+++ b/tests/parse/expr_binary_test.cpp
@@ -11,6 +11,11 @@ TEST_CASE("Parsing binary operators", "[parse]") {
   CHECK_EXPR("1 + 2 + 3", binaryExprNode(binaryExprNode(INT(1), PLUS, INT(2)), PLUS, INT(3)));
   CHECK_EXPR(
       "1 + 3 1 * 2", binaryExprNode(INT(1), PLUS, INT(3)), binaryExprNode(INT(1), STAR, INT(2)));
+  CHECK_EXPR(
+      "1 ! 3 1 * 2", binaryExprNode(INT(1), BANG, INT(3)), binaryExprNode(INT(1), STAR, INT(2)));
+  CHECK_EXPR("1 ! !3", binaryExprNode(INT(1), BANG, unaryExprNode(BANG, INT(3))));
+  CHECK_EXPR(
+      "!1 ! !3", binaryExprNode(unaryExprNode(BANG, INT(1)), BANG, unaryExprNode(BANG, INT(3))));
 
   SECTION("Precedence") {
     CHECK_EXPR("1 + 2 * 5", binaryExprNode(INT(1), PLUS, binaryExprNode(INT(2), STAR, INT(5))));

--- a/tests/parse/expr_unary_test.cpp
+++ b/tests/parse/expr_unary_test.cpp
@@ -16,7 +16,7 @@ TEST_CASE("Parsing unary operators", "[parse]") {
   CHECK_EXPR("-+-1", unaryExprNode(MINUS, unaryExprNode(PLUS, unaryExprNode(MINUS, INT(1)))));
   CHECK_EXPR("+-!1", unaryExprNode(PLUS, unaryExprNode(MINUS, unaryExprNode(BANG, INT(1)))));
   CHECK_EXPR("+?!1", unaryExprNode(PLUS, unaryExprNode(QMARK, unaryExprNode(BANG, INT(1)))));
-  CHECK_EXPR("!42 !true", unaryExprNode(BANG, INT(42)), unaryExprNode(BANG, BOOL(true)));
+  CHECK_EXPR("!42", unaryExprNode(BANG, INT(42)));
 
   SECTION("Errors") {
     CHECK_EXPR("&1", errInvalidUnaryOp(AMP, INT(1)));

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -23,6 +23,7 @@ namespace parse {
 #define MINUSMINUS lex::basicToken(lex::TokenKind::OpMinusMinus)
 #define STAR lex::basicToken(lex::TokenKind::OpStar)
 #define BANG lex::basicToken(lex::TokenKind::OpBang)
+#define BANGBANG lex::basicToken(lex::TokenKind::OpBangBang)
 #define AMP lex::basicToken(lex::TokenKind::OpAmp)
 #define AMPAMP lex::basicToken(lex::TokenKind::OpAmpAmp)
 #define PIPE lex::basicToken(lex::TokenKind::OpPipe)


### PR DESCRIPTION
Improve error reporting of the parse library and the parsers that ship with the standard library.

Also adds support for user-overloadable binary ! and !! operators.

Parser library uses these operators as a way to allow tuning error output of parsers:
* `Parser{T} ! Error -> Parser{T}`
    Append a more descriptive error when the given parser fails.
* `Parser{T} !! Error -> Parser{T}`
    Replace the error with a more descriptive error when the given parser fails.