### PR TITLE
Define '::' operator overloads to combine values into a list

### DIFF
--- a/examples/raytracer/main.nov
+++ b/examples/raytracer/main.nov
@@ -61,8 +61,8 @@ fun createScene()
   sun           = Light(DirLight(normalize(Vec3(.3, -.2, -.5)), white() * 2.0));
   redLight      = Light(PointLight(Vec3(3.0, .05, -4), Color(800, 0.0, 0.0)));
   Scene(
-    ground :: s1 :: s2 :: s3 :: s4 :: s5 :: s6 :: s7 :: List{Object}(),
-    sun :: redLight :: List{Light}())
+    ground :: s1 :: s2 :: s3 :: s4 :: s5 :: s6 :: s7,
+    sun :: redLight)
 
 act driver(int width, int height, int threads, int bounces, float fov, Path outPath, Writer{Image} writer)
   print("Begin rendering...");

--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -45,7 +45,7 @@ fun getReponse(ClientContext ctx, Resource r, HttpMethod m)
   if m == HttpMethod.Get  -> httpResp(    HttpStatusCode.Ok, txt, r.type)
   if m == HttpMethod.Head -> httpRespHead(HttpStatusCode.Ok, txt, r.type)
   else ->
-    supportedMethods = HttpMethod.Get :: HttpMethod.Head :: List{HttpMethod}();
+    supportedMethods = HttpMethod.Get :: HttpMethod.Head;
     httpRespMethodNotAllowed(supportedMethods)
 
 fun getResponse(ClientContext ctx, HttpMethod m, string url)
@@ -59,7 +59,7 @@ act writeResponse(ClientContext ctx, HttpResp resp)
     HttpHeaderField("Server",             "Novus")                ::
     HttpHeaderField("Transfer-Encoding",  "identity")             ::
     HttpHeaderField("Connection",         "keep-alive")           ::
-    HttpHeaderField("Keep-Alive",         "timeout=10, max=1000") :: List{HttpHeaderField}()
+    HttpHeaderField("Keep-Alive",         "timeout=10, max=1000")
   );
   finalResp     = resp.httpRespAddFields(extraFields);
   finalRespTxt  = ctx.respWriter(WriterState(WriterNewlineMode.CrLf), finalResp).string();
@@ -83,7 +83,7 @@ act handleConnection(ClientContext ctx)
   print("- Client connected");
 
   loop = (impure lambda(StreamReadState read)
-    r = read.readUntil("\r\n\r\n" :: "\n\n" :: List{string}());
+    r = read.readUntil("\r\n\r\n" :: "\n\n");
     if r.first.isEmpty()  -> false
     else                  -> handleRequest(ctx, r.first); self(r.second)
   );
@@ -107,8 +107,8 @@ act main(int port, Content content)
       impure lambda (TcpConnection con)
         uptime    = timeNow() - startTime;
         variables = (
-          Variable("SERVER_UPTIME", uptime.string())          ::
-          Variable("SERVER_DATE",   timeNow().httpDateStr())  :: List{Variable}()
+          Variable("SERVER_UPTIME", uptime.string()) ::
+          Variable("SERVER_DATE",   timeNow().httpDateStr())
         );
         ctx       = ClientContext(content, variables, con, respWriter, reqParser);
         handleConnection(ctx)
@@ -146,6 +146,6 @@ main(
                                           "readme.html"       ::
                                           "win.jpg"           ::
                                           "github-logo.png"   ::
-                                          "favicon.ico"       :: List{string}()).args
+                                          "favicon.ico").args
   )
 )

--- a/novstd/env.nov
+++ b/novstd/env.nov
@@ -66,26 +66,26 @@ assert(
   findEnvOpt("-d" :: List{string}(), "f") is None &&
   findEnvOpt("-df" :: List{string}(), "d") is EnvOpt &&
   findEnvOpt("-df" :: List{string}(), "f") is EnvOpt &&
-  findEnvOpt("a" :: "-b" :: "-df" :: "-c" :: List{string}(), "f") is EnvOpt &&
+  findEnvOpt("a" :: "-b" :: "-df" :: "-c", "f") is EnvOpt &&
   findEnvOpt("-f" :: List{string}(), "") is None)
 
 assert(
-  args = "b" :: "-1" :: "c" :: "d" :: List{string}();
-  in = "a" :: "-dfz" :: args :: "-t" :: List{string}();
+  args = "b" :: "-1" :: "c" :: "d";
+  in = "a" :: "-dfz" :: args :: "-t";
   findEnvOpt(in, "f") as EnvOpt o && o.args == args)
 
 assert(
   findEnvOpt("--file" :: List{string}(), "file") is EnvOpt &&
   findEnvOpt("--files" :: List{string}(), "file") is None &&
-  findEnvOpt("--hello" ::  "a" :: "--file" :: "--world" :: List{string}(), "file") is EnvOpt)
+  findEnvOpt("--hello" ::  "a" :: "--file" :: "--world", "file") is EnvOpt)
 
 assert(
-  args = "b" :: "c" :: "d" :: List{string}();
-  in = "a" :: "--file" :: args :: "-t" :: List{string}();
+  args = "b" :: "c" :: "d";
+  in = "a" :: "--file" :: args :: "-t";
   findEnvOpt(in, "file") as EnvOpt o && o.args == args)
 
 assert(
-  findEnvOpt("--test" :: "42" :: List{string}(), "test", txtIntParser()) == 42 &&
+  findEnvOpt("--test" :: "42", "test", txtIntParser()) == 42 &&
   findEnvOpt("--test" :: List{string}(), "test", txtIntParser()) is Error &&
-  findEnvOpt("--test" :: "hello" :: List{string}(), "test", txtIntParser()) is Error &&
+  findEnvOpt("--test" :: "hello", "test", txtIntParser()) is Error &&
   findEnvOpt(List{string}(), "test", txtIntParser()) is Error)

--- a/novstd/image.nov
+++ b/novstd/image.nov
@@ -124,4 +124,4 @@ assert(
 
 assert(
   g = makeColorGrid(2, 2, lambda (int x, int y) y == 0 ? red() : blue());
-  g == red() :: red() :: blue() :: blue() :: List{Color}())
+  g == red() :: red() :: blue() :: blue())

--- a/novstd/json.nov
+++ b/novstd/json.nov
@@ -310,9 +310,9 @@ assert(
   p("[1]")          == toJsonArray(toJsonVal(1.0)   :: List{JsonValue}()) &&
   p("[ 1]")         == toJsonArray(toJsonVal(1.0)   :: List{JsonValue}()) &&
   p("[ 1 ]")        == toJsonArray(toJsonVal(1.0)   :: List{JsonValue}()) &&
-  p("[1,2]")        == toJsonArray(toJsonVal(1.0)   :: toJsonVal(2.0) :: List{JsonValue}()) &&
-  p("[ 1 , 2 ]")    == toJsonArray(toJsonVal(1.0)   :: toJsonVal(2.0) :: List{JsonValue}()) &&
-  p("[ true, 2 ]")  == toJsonArray(toJsonVal(true)  :: toJsonVal(2.0) :: List{JsonValue}()) &&
+  p("[1,2]")        == toJsonArray(toJsonVal(1.0)   :: toJsonVal(2.0)) &&
+  p("[ 1 , 2 ]")    == toJsonArray(toJsonVal(1.0)   :: toJsonVal(2.0)) &&
+  p("[ true, 2 ]")  == toJsonArray(toJsonVal(true)  :: toJsonVal(2.0)) &&
   p("[ \"true\" , false, 2 ]") ==
     toJsonArray(
       toJsonVal("true") ::
@@ -320,7 +320,7 @@ assert(
       toJsonVal(2.0)    :: List{JsonValue}()) &&
   p("[ [1, 2], 2 ]") ==
     toJsonArray(
-      toJsonVal(toJsonArray(toJsonVal(1.0) :: toJsonVal(2.0) :: List{JsonValue}())) ::
+      toJsonVal(toJsonArray(toJsonVal(1.0) :: toJsonVal(2.0))) ::
       toJsonVal(2.0) :: List{JsonValue}()))
 
 assert(
@@ -396,7 +396,7 @@ assert(
   w = jsonArrayWriter(jsonValueWriter());
   w(toJsonArray(List{JsonValue}())) == "[\n]" &&
   w(toJsonArray(toJsonVal(1.0) :: List{JsonValue}())) == "[\n  1\n]" &&
-  w(toJsonArray(toJsonVal(1.0) :: toJsonVal(true) :: List{JsonValue}())) == "[\n  1,\n  true\n]")
+  w(toJsonArray(toJsonVal(1.0) :: toJsonVal(true))) == "[\n  1,\n  true\n]")
 
 assert(
   w = jsonValueWriter();

--- a/novstd/list.nov
+++ b/novstd/list.nov
@@ -22,6 +22,12 @@ fun List{T}(T val, List{T} next) -> List{T}
 
 // -- Operators
 
+fun ::{T}(T val1, T val2)
+ val1 :: List{T}(val2)
+
+fun ::{T}(List{T} l1, T val)
+  List{T}(val).push(l1)
+
 fun ::{T}(T val, List{T} l)
   l.push(val)
 
@@ -286,63 +292,63 @@ assert(List(42) == List(42))
 assert(List(42) != List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l == 1 :: 2 :: List(3) &&
-  l != 3 :: 2 :: 1 :: List{int}() &&
+  l != 3 :: 2 :: 1 &&
   l != List(42))
 
 assert(Option(42) :: List{int}() == List(42))
 assert(Option{int}() :: List{int}() == List{int}())
 
 assert(
-  l1 = 1 :: 2 :: 3 :: List{int}();
-  l2 = 10 :: 9 :: 8 :: List{int}();
-  l1 :: l2 :: l1 == 1 :: 2 :: 3 :: 10 :: 9 :: 8 :: 1 :: 2 :: 3 :: List{int}())
+  l1 = 1 :: 2 :: 3;
+  l2 = 10 :: 9 :: 8;
+  l1 :: l2 :: l1 == 1 :: 2 :: 3 :: 10 :: 9 :: 8 :: 1 :: 2 :: 3)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l[-1] == 1 && l[0] == 1 && l[1] == 2 && l[2] == 3 && l[4] == None())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l[0, -1] == List{int}() &&
   l[0, 0] == List{int}() &&
   l[0, 1] == 1 :: List{int}() &&
-  l[0, 2] == 1 :: 2 :: List{int}() &&
-  l[0, 3] == 1 :: 2 :: 3 :: List{int}() &&
-  l[0, 4] == 1 :: 2 :: 3 :: List{int}() &&
-  l[1, 4] == 2 :: 3 :: List{int}() &&
+  l[0, 2] == 1 :: 2 &&
+  l[0, 3] == 1 :: 2 :: 3 &&
+  l[0, 4] == 1 :: 2 :: 3 &&
+  l[1, 4] == 2 :: 3 &&
   l[3, 3] == List{int}() &&
   l[3, 4] == List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.string() == "[1,2,3]" && l.string("", "", "") == "123")
 assert(
-  l = "hello" :: "world" :: List{string}();
+  l = "hello" :: "world";
   l.string() == "[hello,world]" && l.string("", "", "") == "helloworld")
 assert(string(List{int}()) == "[]")
 
 assert(List{int}().isEmpty() && !List{int}(42).isEmpty() && List{int}(42).pop().isEmpty())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.front() ?? -1 == 1 && l.back() ?? -1 == 3)
 assert(
   l = List{int}();
   l.front() is None && l.back() is None)
 
 assert(push(List{int}(), 42) == List(42))
-assert(push(2 :: 3 :: List{int}(), 1) == 1 :: 2 :: 3 :: List{int}())
+assert(push(2 :: 3, 1) == 1 :: 2 :: 3)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.push(List(42)) == 42 :: 1 :: 2 :: 3 :: List{int}() &&
-  l.push(42 :: 1337 :: List{int}()) == 42 :: 1337 :: 1 :: 2 :: 3 :: List{int}() &&
-  l.push(3 :: 2 :: 1 :: List{int}()) == 3 :: 2 :: 1 :: 1 :: 2 :: 3 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.push(List(42)) == 42 :: 1 :: 2 :: 3 &&
+  l.push(42 :: 1337) == 42 :: 1337 :: 1 :: 2 :: 3 &&
+  l.push(3 :: 2 :: 1) == 3 :: 2 :: 1 :: 1 :: 2 :: 3)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.pushUnique(1) == l &&
   l.pushUnique(2) == l &&
   l.pushUnique(3) == l &&
@@ -350,209 +356,209 @@ assert(
   l.pushUnique(-1).pushUnique(2).pushUnique(4) == 4 :: -1 :: l)
 
 assert(
-  l = 42 :: 1337 :: List{int}();
-  l.pushRange(1, 3) == 1 :: 2 :: 42 :: 1337 :: List{int}())
+  l = 42 :: 1337;
+  l.pushRange(1, 3) == 1 :: 2 :: 42 :: 1337)
 
 assert(pushBack(List{int}(), 42) == List(42))
-assert(pushBack(1 :: 2 :: List{int}(), 3) == 1 :: 2 :: 3 :: List{int}())
+assert(pushBack(1 :: 2, 3) == 1 :: 2 :: 3)
 
 assert(
-  l = 1 :: 2 :: 3 :: 4 :: List{int}();
-  l.pop() == 2 :: 3 :: 4 :: List{int}() &&
+  l = 1 :: 2 :: 3 :: 4;
+  l.pop() == 2 :: 3 :: 4 &&
   l.pop(-1) == l &&
   l.pop(0) == l &&
-  l.pop(1) == 2 :: 3 :: 4 :: List{int}() &&
-  l.pop(2) == 3 :: 4 :: List{int}() &&
+  l.pop(1) == 2 :: 3 :: 4 &&
+  l.pop(2) == 3 :: 4 &&
   l.pop(3) == 4 :: List{int}() &&
   l.pop(4) == List{int}() &&
   l.pop(5) == List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: 4 :: List{int}();
+  l = 1 :: 2 :: 3 :: 4;
   l.pop(lambda (int i) i == 0) == l &&
   l.pop(lambda (int i) i > 0) == List{int}() &&
-  l.pop(lambda (int i) i == 1) == 2 :: 3 :: 4 :: List{int}() &&
-  l.pop(lambda (int i) i < 3) == 3 :: 4 :: List{int}())
+  l.pop(lambda (int i) i == 1) == 2 :: 3 :: 4 &&
+  l.pop(lambda (int i) i < 3) == 3 :: 4)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.take(-1) == List{int}() &&
   l.take(0) == List{int}() &&
   l.take(1) == 1 :: List{int}() &&
-  l.take(2) == 1 :: 2 :: List{int}() &&
-  l.take(3) == 1 :: 2 :: 3 :: List{int}() &&
-  l.take(4) == 1 :: 2 :: 3 :: List{int}())
+  l.take(2) == 1 :: 2  &&
+  l.take(3) == 1 :: 2 :: 3  &&
+  l.take(4) == 1 :: 2 :: 3 )
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3 ;
   l.take(lambda (int i) i == 0) == List{int}() &&
   l.take(lambda (int i) i > 0) == l &&
-  l.take(lambda (int i) i < 3) == 1 :: 2 :: List{int}())
+  l.take(lambda (int i) i < 3) == 1 :: 2 )
 
 assert(
-  l = 1 :: 2 :: 3 :: 4 :: List{int}();
-  l.popBack() == 1 :: 2 :: 3 :: List{int}() &&
+  l = 1 :: 2 :: 3 :: 4 ;
+  l.popBack() == 1 :: 2 :: 3  &&
   l.popBack(-1) == l &&
   l.popBack(0) == l &&
-  l.popBack(1) == 1 :: 2 :: 3 :: List{int}() &&
-  l.popBack(2) == 1 :: 2 :: List{int}() &&
+  l.popBack(1) == 1 :: 2 :: 3  &&
+  l.popBack(2) == 1 :: 2  &&
   l.popBack(3) == 1 :: List{int}() &&
   l.popBack(4) == List{int}() &&
   l.popBack(5) == List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.insert(-1, 42) == 42 :: 1 :: 2 :: 3 :: List{int}() &&
-  l.insert(0, 42) == 42 :: 1 :: 2 :: 3 :: List{int}() &&
-  l.insert(1, 42) == 1 :: 42 :: 2 :: 3 :: List{int}() &&
-  l.insert(2, 42) == 1 :: 2 :: 42 :: 3 :: List{int}() &&
-  l.insert(3, 42) == 1 :: 2 :: 3 :: 42 :: List{int}() &&
-  l.insert(4, 42) == 1 :: 2 :: 3 :: 42 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.insert(-1, 42) == 42 :: 1 :: 2 :: 3 &&
+  l.insert(0, 42) == 42 :: 1 :: 2 :: 3 &&
+  l.insert(1, 42) == 1 :: 42 :: 2 :: 3 &&
+  l.insert(2, 42) == 1 :: 2 :: 42 :: 3 &&
+  l.insert(3, 42) == 1 :: 2 :: 3 :: 42 &&
+  l.insert(4, 42) == 1 :: 2 :: 3 :: 42)
 
 assert(
-  l = 1 :: 4 :: 5 :: List{int}();
-  l.insertOrdered(0) == 0 :: 1 :: 4 :: 5 :: List{int}() &&
-  l.insertOrdered(1) == 1 :: 1 :: 4 :: 5 :: List{int}() &&
-  l.insertOrdered(2) == 1 :: 2 :: 4 :: 5 :: List{int}() &&
-  l.insertOrdered(6) == 1 :: 4 :: 5 :: 6 :: List{int}() &&
-  l.insertOrdered(99) == 1 :: 4 :: 5 :: 99 :: List{int}())
+  l = 1 :: 4 :: 5;
+  l.insertOrdered(0) == 0 :: 1 :: 4 :: 5 &&
+  l.insertOrdered(1) == 1 :: 1 :: 4 :: 5 &&
+  l.insertOrdered(2) == 1 :: 2 :: 4 :: 5 &&
+  l.insertOrdered(6) == 1 :: 4 :: 5 :: 6 &&
+  l.insertOrdered(99) == 1 :: 4 :: 5 :: 99)
 
-assert(rangeList(1, 4) == 1 :: 2 :: 3 :: List{int}())
-assert(rangeList('a', 'd') == 'a' :: 'b' :: 'c' :: List{char}())
+assert(rangeList(1, 4) == 1 :: 2 :: 3)
+assert(rangeList('a', 'd') == 'a' :: 'b' :: 'c')
 
 assert(gridList(2, 2) == Pair(0, 0) :: Pair(1, 0) ::
-                         Pair(0, 1) :: Pair(1, 1) :: List{Pair{int, int}}())
+                         Pair(0, 1) :: Pair(1, 1))
 
 assert(gridList(3, 3) == Pair(0, 0) :: Pair(1, 0) :: Pair(2, 0) ::
                          Pair(0, 1) :: Pair(1, 1) :: Pair(2, 1) ::
-                         Pair(0, 2) :: Pair(1, 2) :: Pair(2, 2) :: List{Pair{int, int}}())
+                         Pair(0, 2) :: Pair(1, 2) :: Pair(2, 2))
 
 assert(
   gridList(1, 1) == Pair(0, 0) :: List{Pair{int, int}}() &&
   gridList(0, 0) == List{Pair{int, int}}())
 
 assert(gridListReverse(2, 2) == Pair(1, 1) :: Pair(0, 1) ::
-                                Pair(1, 0) :: Pair(0, 0) :: List{Pair{int, int}}())
+                                Pair(1, 0) :: Pair(0, 0))
 
 assert(gridListReverse(3, 3) == Pair(2, 2) :: Pair(1, 2) :: Pair(0, 2) ::
                                 Pair(2, 1) :: Pair(1, 1) :: Pair(0, 1) ::
-                                Pair(2, 0) :: Pair(1, 0) :: Pair(0, 0) :: List{Pair{int, int}}())
+                                Pair(2, 0) :: Pair(1, 0) :: Pair(0, 0))
 
 assert(
   gridListReverse(1, 1) == Pair(0, 0) :: List{Pair{int, int}}() &&
   gridListReverse(0, 0) == List{Pair{int, int}}())
 
 assert(
-  l = 1 :: 2 :: 3 :: 4 :: List{int}();
-  l.filter(lambda (int v) v > 2) == 3 :: 4 :: List{int}() &&
+  l = 1 :: 2 :: 3 :: 4;
+  l.filter(lambda (int v) v > 2) == 3 :: 4 &&
   l.filter(lambda (int v) v < 0) == List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: 4 :: 5 :: List{int}();
-  l.filterReverse(lambda (int v) v > 2) == 5 :: 4 :: 3 :: List{int}() &&
+  l = 1 :: 2 :: 3 :: 4 :: 5;
+  l.filterReverse(lambda (int v) v > 2) == 5 :: 4 :: 3 &&
   l.filterReverse(lambda (int v) v < 0) == List{int}())
 
 assert(
-  l = Option(1) :: Option{int}() :: Option(2) :: Option{int}() :: List{Option{int}}();
-  l.filterNone() == 1 :: 2 :: List{int}())
+  l = Option(1) :: Option{int}() :: Option(2) :: Option{int}();
+  l.filterNone() == 1 :: 2)
 
 assert(
-  l = Option(1) :: Option{int}() :: Option(2) :: Option{int}() :: List{Option{int}}();
-  l.filterNoneReverse() == 2 :: 1 :: List{int}())
+  l = Option(1) :: Option{int}() :: Option(2) :: Option{int}();
+  l.filterNoneReverse() == 2 :: 1)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.map(lambda (int v) v * 2) == 2 :: 4 :: 6 :: List{int}() &&
-  l.map(lambda (int v) v.string()) == "1" :: "2" :: "3" :: List{string}())
+  l = 1 :: 2 :: 3;
+  l.map(lambda (int v) v * 2) == 2 :: 4 :: 6 &&
+  l.map(lambda (int v) v.string()) == "1" :: "2" :: "3")
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.mapReverse(lambda (int v) v * 2) == 6 :: 4 :: 2 :: List{int}() &&
-  l.mapReverse(lambda (int v) v.string()) == "3" :: "2" :: "1" :: List{string}())
+  l = 1 :: 2 :: 3;
+  l.mapReverse(lambda (int v) v * 2) == 6 :: 4 :: 2 &&
+  l.mapReverse(lambda (int v) v.string()) == "3" :: "2" :: "1")
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.length() == 3)
 assert(length(List{int}()) == 0)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.sum() == 6)
 assert(
-  l = 0.1 :: 1.0 :: 1.1 :: List{float}();
+  l = 0.1 :: 1.0 :: 1.1;
   l.sum() == 2.2)
 assert(
-  l = "hello" :: " " :: "world" :: List{string}();
+  l = "hello" :: " " :: "world";
   l.sum() == "hello world")
 assert(List{int}().sum() == 0)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.reverse() == 3 :: 2 :: 1 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.reverse() == 3 :: 2 :: 1)
 assert(List{int}().reverse() == List{int}())
 
 assert(
-  l = 42 :: 1337 :: -42 :: -5 :: List{int}();
-  l.sort() == -42 :: -5 :: 42 :: 1337 :: List{int}())
+  l = 42 :: 1337 :: -42 :: -5;
+  l.sort() == -42 :: -5 :: 42 :: 1337)
 assert(List{int}().sort() == List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.distinct() == l)
 assert(
-  l = 1 :: 2 :: 2 :: 3 :: List{int}();
-  l.distinct() == 1 :: 2 :: 3 :: List{int}())
+  l = 1 :: 2 :: 2 :: 3;
+  l.distinct() == 1 :: 2 :: 3)
 assert(
-  l = 3 :: 1 :: 2 :: 3 :: 2 :: 3 :: 3 :: List{int}();
-  l.distinct() == 3 :: 1 :: 2 :: List{int}())
+  l = 3 :: 1 :: 2 :: 3 :: 2 :: 3 :: 3;
+  l.distinct() == 3 :: 1 :: 2)
 assert(List{int}().distinct() == List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.distinctReverse() == 3 :: 2 :: 1 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.distinctReverse() == 3 :: 2 :: 1)
 assert(
-  l = 1 :: 2 :: 2 :: 3 :: List{int}();
-  l.distinctReverse() == 3 :: 2 :: 1 :: List{int}())
+  l = 1 :: 2 :: 2 :: 3;
+  l.distinctReverse() == 3 :: 2 :: 1)
 assert(
-  l = 1 :: 1 :: 2 :: 2 :: 3 :: 3 :: 3 :: List{int}();
-  l.distinctReverse() == 3 :: 2 :: 1 :: List{int}())
+  l = 1 :: 1 :: 2 :: 2 :: 3 :: 3 :: 3;
+  l.distinctReverse() == 3 :: 2 :: 1)
 assert(List{int}().distinctReverse() == List{int}())
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.count(lambda (int v) v > 2) == 1 &&
   l.count(lambda (int v) v == 0) == 0 &&
   l.count(lambda (int v) v > 0) == 3)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.any(lambda (int v) v > 2) && !l.any(lambda (int v) v < 0))
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.all(lambda (int v) v > 0) && !l.all(lambda (int v) v > 1))
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.none(lambda (int v) v < 0) && !l.none(lambda (int v) v > 1))
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
+  l = 1 :: 2 :: 3;
   l.contains(1) &&
   l.contains(2) &&
   l.contains(3) &&
   !l.contains(0) &&
   !l.contains(4))
 
-assert(for(1, 4, lambda (int i) i * i) == 1 :: 4 :: 9 :: List{int}())
+assert(for(1, 4, lambda (int i) i * i) == 1 :: 4 :: 9)
 
-assert(for(4, lambda (int i) i * i) == 0 :: 1 :: 4 :: 9 :: List{int}())
+assert(for(4, lambda (int i) i * i) == 0 :: 1 :: 4 :: 9)
 
 assert(
-  l1  = "hello" :: "good" :: "world" :: List{string}();
-  l2  = 42 :: 1337 :: 1 :: 2 :: 3 :: List{int}();
+  l1  = "hello" :: "good" :: "world";
+  l2  = 42 :: 1337 :: 1 :: 2 :: 3;
   z   = zip(l1, l2, lambda (List{string} result, string s, int i) (s + i.string()) :: result);
-  z == "world1" :: "good1337" :: "hello42" :: List{string}())
+  z == "world1" :: "good1337" :: "hello42")
 
 assert(
   l1  = List{string}();
@@ -562,9 +568,9 @@ assert(
 
 assert(
   l =
-    ("a1" :: "a2" :: "a3" :: "a4" :: List{string}()) ::
-    ("b1" :: "b2" :: "b3"         :: List{string}()) ::
-    ("c1" :: "c2" :: "c3" :: "d4" :: List{string}()) :: List{List{string}}();
+    ("a1" :: "a2" :: "a3" :: "a4") ::
+    ("b1" :: "b2" :: "b3"        ) ::
+    ("c1" :: "c2" :: "c3" :: "d4") :: List{List{string}}();
   l.zip(lambda (string result, List{string} cur) result + " " + cur.sum()) == " c1b1a1 c2b2a2 c3b3a3")
 
 assert(
@@ -586,18 +592,18 @@ assert(
 assert(
   eS = (lambda (string s) Either{int, string}(s));
   eI = (lambda (int i) Either{int, string}(i));
-  l = eI(1) :: eS("hello") :: eI(2) :: eS("world") :: eI(3) :: eI(4) :: List{Either{int, string}}();
-  split(l) == makePair(1 :: 2 :: 3 :: 4 :: List{int}(), "hello" :: "world" :: List{string}()))
+  l = eI(1) :: eS("hello") :: eI(2) :: eS("world") :: eI(3) :: eI(4);
+  split(l) == makePair(1 :: 2 :: 3 :: 4, "hello" :: "world"))
 
 assert(
   eS = (lambda (string s) Either{int, string}(s));
-  l = eS("hello") :: eS("good") :: eS("world") :: List{Either{int, string}}();
-  split(l) == makePair(List{int}(), "hello" :: "good" :: "world" :: List{string}()))
+  l = eS("hello") :: eS("good") :: eS("world");
+  split(l) == makePair(List{int}(), "hello" :: "good" :: "world"))
 
 assert(
   eI = (lambda (int i) Either{int, string}(i));
-  l = eI(1) :: eI(2) :: eI(3) :: List{Either{int, string}}();
-  split(l) == makePair(1 :: 2 :: 3 :: List{int}(), List{string}()))
+  l = eI(1) :: eI(2) :: eI(3);
+  split(l) == makePair(1 :: 2 :: 3, List{string}()))
 
 assert(
   l = List{Either{int, string}}();
@@ -607,30 +613,30 @@ assert(
 assert(
   eS = (lambda (string s) Either{int, string}(s));
   eI = (lambda (int i) Either{int, string}(i));
-  l = eI(1) :: eS("hello") :: eI(2) :: eS("world") :: eI(3) :: eI(4) :: List{Either{int, string}}();
-  splitReverse(l) == makePair(4 :: 3 :: 2 :: 1 :: List{int}(), "world" :: "hello" :: List{string}()))
+  l = eI(1) :: eS("hello") :: eI(2) :: eS("world") :: eI(3) :: eI(4);
+  splitReverse(l) == makePair(4 :: 3 :: 2 :: 1, "world" :: "hello"))
 
 assert(
-  l = 0 :: 1 :: 4 :: 9 :: List{int}();
+  l = 0 :: 1 :: 4 :: 9;
   listEqual(l, l) &&
-  listEqual(l, 0 :: 1 :: 4 :: 9 :: List{int}()) &&
-  !listEqual(l, 0 :: 1 :: 5 :: 9 :: List{int}()) &&
-  !listEqual(l, 0 :: 1 :: List{int}()) &&
+  listEqual(l, 0 :: 1 :: 4 :: 9) &&
+  !listEqual(l, 0 :: 1 :: 5 :: 9) &&
+  !listEqual(l, 0 :: 1) &&
   !listEqual(l, List{int}()) &&
   listEqual(List{int}(), List{int}()))
 
 // -- Impure Tests
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.map(impure lambda (int v) v * 2) == 2 :: 4 :: 6 :: List{int}() &&
-  l.map(impure lambda (int v) v.string()) == "1" :: "2" :: "3" :: List{string}())
+  l = 1 :: 2 :: 3;
+  l.map(impure lambda (int v) v * 2) == 2 :: 4 :: 6 &&
+  l.map(impure lambda (int v) v.string()) == "1" :: "2" :: "3")
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.mapReverse(impure lambda (int v) v * 2) == 6 :: 4 :: 2 :: List{int}() &&
-  l.mapReverse(impure lambda (int v) v.string()) == "3" :: "2" :: "1" :: List{string}())
+  l = 1 :: 2 :: 3;
+  l.mapReverse(impure lambda (int v) v * 2) == 6 :: 4 :: 2 &&
+  l.mapReverse(impure lambda (int v) v.string()) == "3" :: "2" :: "1")
 
-assert(for(1, 4, impure lambda (int i) i * i) == 1 :: 4 :: 9 :: List{int}())
+assert(for(1, 4, impure lambda (int i) i * i) == 1 :: 4 :: 9)
 
-assert(for(4, impure lambda (int i) i * i) == 0 :: 1 :: 4 :: 9 :: List{int}())
+assert(for(4, impure lambda (int i) i * i) == 0 :: 1 :: 4 :: 9)

--- a/novstd/parallel.nov
+++ b/novstd/parallel.nov
@@ -39,31 +39,31 @@ act parallelFor{T, TResult}(T from, T to, action{T, TResult} a)
 // -- Tests
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.parallelMap(lambda (int i) i * i) == 1 :: 4 :: 9 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.parallelMap(lambda (int i) i * i) == 1 :: 4 :: 9)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.parallelMapReverse(lambda (int i) i * i) == 9 :: 4 :: 1 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.parallelMapReverse(lambda (int i) i * i) == 9 :: 4 :: 1)
 
 assert(
-  parallelFor(1, 5, lambda (int i) i * i) == 1 :: 4 :: 9 :: 16 :: List{int}())
+  parallelFor(1, 5, lambda (int i) i * i) == 1 :: 4 :: 9 :: 16)
 
 assert(
-  parallelFor(5, lambda (int i) i * i) == 0 :: 1 :: 4 :: 9 :: 16 :: List{int}())
+  parallelFor(5, lambda (int i) i * i) == 0 :: 1 :: 4 :: 9 :: 16)
 
 // -- Impure tests
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.parallelMap(impure lambda (int i) i * i) == 1 :: 4 :: 9 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.parallelMap(impure lambda (int i) i * i) == 1 :: 4 :: 9)
 
 assert(
-  l = 1 :: 2 :: 3 :: List{int}();
-  l.parallelMapReserve(impure lambda (int i) i * i) == 9 :: 4 :: 1 :: List{int}())
+  l = 1 :: 2 :: 3;
+  l.parallelMapReserve(impure lambda (int i) i * i) == 9 :: 4 :: 1)
 
 assert(
-  parallelFor(1, 5, impure lambda (int i) i * i) == 1 :: 4 :: 9 :: 16 :: List{int}())
+  parallelFor(1, 5, impure lambda (int i) i * i) == 1 :: 4 :: 9 :: 16)
 
 assert(
-  parallelFor(5, impure lambda (int i) i * i) == 0 :: 1 :: 4 :: 9 :: 16 :: List{int}())
+  parallelFor(5, impure lambda (int i) i * i) == 0 :: 1 :: 4 :: 9 :: 16)

--- a/novstd/parse.nov
+++ b/novstd/parse.nov
@@ -844,7 +844,7 @@ assert(
 
 assert(
   p = txtBoolParser() :: txtBoolParser() :: txtBoolParser();
-  p("truefalsetrue") == true :: false :: true :: List{bool}() &&
+  p("truefalsetrue") == true :: false :: true &&
   p("truefalse")  is ParseFailure &&
   p("")           is ParseFailure)
 
@@ -883,14 +883,14 @@ assert(
 
 assert(
   p = manyParser(txtBoolParser());
-  p("truefalsetruetrue")  == true :: false :: true :: true :: List{bool}() &&
+  p("truefalsetruetrue")  == true :: false :: true :: true &&
   p("true")               == true :: List{bool}() &&
   p("true1")              == true :: List{bool}() &&
   p("")                   == List{bool}())
 
 assert(
   p = manyParser(txtIntParser(), matchParser(','));
-  p("42,1337,1,2")  == 42 :: 1337 :: 1 :: 2 :: List{int}() &&
+  p("42,1337,1,2")  == 42 :: 1337 :: 1 :: 2  &&
   p("42")           == 42 :: List{int}() &&
   p("")             == List{int}())
 
@@ -900,7 +900,7 @@ assert(
 
 assert(
   p = manyUntilParser(txtBoolParser(), newlineParser());
-  p("truefalse\ntrue")   == true :: false :: List{bool}()  &&
+  p("truefalse\ntrue")   == true :: false  &&
   p("true\n")            == true :: List{bool}()           &&
   p("false,\n")          is ParseFailure                   &&
   p("true true\n")       is ParseFailure                   &&
@@ -918,11 +918,11 @@ assert(
 
 assert(
   p = manyUntilParser(txtBoolParser(), matchParser(','), newlineParser());
-  p("true,false\ntrue")   == true :: false :: List{bool}()  &&
-  p("true\n")             == true :: List{bool}()           &&
-  p("false,\n")           is ParseFailure                   &&
-  p("true true\n")        is ParseFailure                   &&
-  p("false")              is ParseFailure                   &&
+  p("true,false\ntrue")   == true :: false          &&
+  p("true\n")             == true :: List{bool}()   &&
+  p("false,\n")           is ParseFailure           &&
+  p("true true\n")        is ParseFailure           &&
+  p("false")              is ParseFailure           &&
   p("")                   is ParseFailure)
 
 assert(

--- a/novstd/rng.nov
+++ b/novstd/rng.nov
@@ -124,6 +124,6 @@ assert(
   hellos > 450 && worlds > 450)
 
 assert(
-  l     = "hello" :: "great" :: "world" :: List{string}();
+  l     = "hello" :: "great" :: "world";
   elem  = rngInit(42).rngElem(l).val ?? "";
   l.contains(elem))

--- a/novstd/stream.nov
+++ b/novstd/stream.nov
@@ -61,7 +61,7 @@ act copy(sys_stream from, sys_stream to)
   , 0)
 
 act readLine(StreamReadState state)
-  state.readUntil("\n" :: "\r\n" :: List{string}())
+  state.readUntil("\n" :: "\r\n")
 
 act readUntil(StreamReadState state, List{string} patterns)
   state.readUntil(patterns, true)

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -385,11 +385,11 @@ assert(
   "".transform(lambda (char c) "W") == "")
 
 assert(
-  "hello world".split(equals{char}[' ']) == "hello" :: "world" :: List{string}() &&
-  "lineA\nlineB\nlineC".split(equals{char}['\n']) == "lineA" :: "lineB" :: "lineC" :: List{string}() &&
-  "   hello   world   ".split(equals{char}[' ']) == "hello" :: "world" :: List{string}() &&
+  "hello world".split(equals{char}[' ']) == "hello" :: "world" &&
+  "lineA\nlineB\nlineC".split(equals{char}['\n']) == "lineA" :: "lineB" :: "lineC" &&
+  "   hello   world   ".split(equals{char}[' ']) == "hello" :: "world" &&
   "    ".split(equals{char}[' ']).isEmpty() &&
-  " h e l l o ".split(equals{char}[' ']) == "h" :: "e" :: "l" :: "l" :: "o" :: List{string}() &&
+  " h e l l o ".split(equals{char}[' ']) == "h" :: "e" :: "l" :: "l" :: "o" &&
   "hello-world".split(equals{char}[' ']) == List("hello-world") &&
   "".split(equals{char}[' ']) == List{string}())
 
@@ -424,13 +424,13 @@ assert(
 
 assert(
   "h".toChars() == List{char}('h') &&
-  "hello".toChars() == 'h' :: 'e' :: 'l' :: 'l' :: 'o' :: List{char}() &&
+  "hello".toChars() == 'h' :: 'e' :: 'l' :: 'l' :: 'o' &&
   "1337".toChars().join() == "1337" &&
   "".toChars() == List{char}())
 
 assert(
-  join("hello" :: " " :: "world" :: List{string}()) == "hello world" &&
-  join('h' :: 'e' :: 'l' :: 'l' :: 'o' :: List{char}()) == "hello" &&
+  join("hello" :: " " :: "world") == "hello world" &&
+  join('h' :: 'e' :: 'l' :: 'l' :: 'o') == "hello" &&
   List{string}().join() == "" &&
   List{char}().join() == "")
 

--- a/novstd/version.nov
+++ b/novstd/version.nov
@@ -130,39 +130,39 @@ assert(
 assert(
   versionParser()("42.1337.123-alpha.fullmoon.wip")
   ==
-  Version(42, 1337, 123, "alpha" :: "fullmoon" :: "wip" :: List{string}())
+  Version(42, 1337, 123, "alpha" :: "fullmoon" :: "wip")
 )
 
 assert(
   versionParser()("42.1337-alpha.fullmoon.wip")
   ==
-  Version(42, 1337, 0, "alpha" :: "fullmoon" :: "wip" :: List{string}())
+  Version(42, 1337, 0, "alpha" :: "fullmoon" :: "wip")
 )
 
 assert(
   versionParser()("1.0.0-x.7.z.92")
   ==
-  Version(1, 0, 0, "x" :: "7" :: "z" :: "92" :: List{string}())
+  Version(1, 0, 0, "x" :: "7" :: "z" :: "92")
 )
 
 assert(
   versionParser()("42.1337+local-machine.europe")
   ==
-  Version(42, 1337, 0, List{string}(), "local-machine" :: "europe" :: List{string}())
+  Version(42, 1337, 0, List{string}(), "local-machine" :: "europe")
 )
 
 assert(
   versionParser()("1.0.0-beta+exp.sha.5114f85")
   ==
-  Version(1, 0, 0, "beta" :: List{string}(), "exp" :: "sha" :: "5114f85" :: List{string}())
+  Version(1, 0, 0, "beta" :: List{string}(), "exp" :: "sha" :: "5114f85")
 )
 
 assert(
   versionParser()("42.1337.123-alpha.fullmoon.wip+local-machine.europe")
   ==
   Version(42, 1337, 123,
-    "alpha" :: "fullmoon" :: "wip" :: List{string}(),
-    "local-machine" :: "europe" :: List{string}())
+    "alpha" :: "fullmoon" :: "wip",
+    "local-machine" :: "europe")
 )
 
 assert(
@@ -170,7 +170,7 @@ assert(
   ==
   Version(42, 1337, 123,
     List{string}(),
-    "alpha" :: "fullmoon" :: "wip-local-machine" :: "europe" :: List{string}())
+    "alpha" :: "fullmoon" :: "wip-local-machine" :: "europe")
 )
 
 assert(
@@ -182,7 +182,7 @@ assert(
 assert(
   versionParser()("2.29.2.windows.2")
   ==
-  Version(2, 29, 2, List{string}(), "windows" :: "2" :: List{string}())
+  Version(2, 29, 2, List{string}(), "windows" :: "2")
 )
 
 assert(
@@ -195,7 +195,7 @@ assert(
   versionWriter()(
     Version(42, 1337, 123,
       List{string}(),
-      "local-machine" :: "europe" :: List{string}()))
+      "local-machine" :: "europe"))
   ==
   "42.1337.123+local-machine.europe"
 )
@@ -203,7 +203,7 @@ assert(
 assert(
   versionWriter()(
     Version(42, 1337, 123,
-      "alpha" :: "fullmoon" :: "wip" :: List{string}()))
+      "alpha" :: "fullmoon" :: "wip"))
   ==
   "42.1337.123-alpha.fullmoon.wip"
 )
@@ -211,8 +211,8 @@ assert(
 assert(
   versionWriter()(
     Version(42, 1337, 123,
-      "alpha" :: "fullmoon" :: "wip" :: List{string}(),
-      "local-machine" :: "europe" :: List{string}()))
+      "alpha" :: "fullmoon" :: "wip",
+      "local-machine" :: "europe"))
   ==
   "42.1337.123-alpha.fullmoon.wip+local-machine.europe"
 )

--- a/novstd/writer.nov
+++ b/novstd/writer.nov
@@ -244,50 +244,50 @@ assert(
   w = listWriter(txtIntWriter());
   w(List{int}()) == "" &&
   w(42 :: List{int}()) == "42" &&
-  w(1 :: 2 :: 3 :: List{int}()) == "123")
+  w(1 :: 2 :: 3) == "123")
 
 assert(
   w = listWriter(txtIntWriter(), litWriter(','));
   w(List{int}()) == "" &&
   w(42 :: List{int}()) == "42" &&
-  w(1 :: 2 :: 3 :: List{int}()) == "1,2,3")
+  w(1 :: 2 :: 3) == "1,2,3")
 
 assert(
   w = listWriter(stringWriter(), litWriter(',') & litWriter(" "));
   w(List{string}()) == "" &&
   w("hello" :: List{string}()) == "hello" &&
-  w("hello" :: "good" :: "world" :: List{string}()) == "hello, good, world")
+  w("hello" :: "good" :: "world") == "hello, good, world")
 
 assert(
   w = listWriter(stringWriter(), newlineWriter());
   w(List{string}()) == "" &&
   w("hello" :: List{string}()) == "hello" &&
-  w("hello" :: "world" :: List{string}()) == "hello\nworld" &&
-  w("hello" :: "world" :: List{string}(), WriterNewlineMode.CrLf) == "hello\r\nworld")
+  w("hello" :: "world") == "hello\nworld" &&
+  w("hello" :: "world", WriterNewlineMode.CrLf) == "hello\r\nworld")
 
 assert(
   w = litWriter('[') & listWriter(stringWriter(), litWriter(',')) & litWriter(']');
   w(List{string}()) == "[]" &&
   w("hello" :: List{string}()) == "[hello]" &&
-  w("hello" :: "good" :: "world" :: List{string}()) == "[hello,good,world]")
+  w("hello" :: "good" :: "world") == "[hello,good,world]")
 
 assert(
   w = indentedListWriter(txtIntWriter(), litWriter(','));
   w(List{int}()) == "" &&
   w(1 :: List{int}()) == "  1\n" &&
-  w(1 :: 2 :: 3 :: List{int}()) == "  1,\n  2,\n  3\n" &&
+  w(1 :: 2 :: 3) == "  1,\n  2,\n  3\n" &&
   w(List{int}(), "", WriterNewlineMode.None) == "" &&
   w(1 :: List{int}(), "", WriterNewlineMode.None) == "1" &&
-  w(1 :: 2 :: 3 :: List{int}(), "", WriterNewlineMode.None) == "1,2,3")
+  w(1 :: 2 :: 3, "", WriterNewlineMode.None) == "1,2,3")
 
 assert(
   w = indentedListWriter(txtIntWriter());
   w(List{int}()) == "" &&
   w(1 :: List{int}()) == "  1\n" &&
-  w(1 :: 2 :: 3 :: List{int}()) == "  1\n  2\n  3\n" &&
+  w(1 :: 2 :: 3) == "  1\n  2\n  3\n" &&
   w(List{int}(), "", WriterNewlineMode.None) == "" &&
   w(1 :: List{int}(), "", WriterNewlineMode.None) == "1" &&
-  w(1 :: 2 :: 3 :: List{int}(), "", WriterNewlineMode.None) == "123")
+  w(1 :: 2 :: 3, "", WriterNewlineMode.None) == "123")
 
 assert(
   w = stringWriter() & txtIntWriter();


### PR DESCRIPTION
Define `::` operator overloads to combine values into a list.
```
1 :: 2 :: 3
```
is now equivalent to:
```
1 :: 2 :: 3 :: List{int}()
```
With the recent improvements to template type inference its still possible to define `::` overloads for other types that will take precedence over this one (either by being non-templated or being more specialized).

Its debatable if `List{T}()` should reserve this syntax for itself but its so commonly used that this cleans up allot of places that construct lists. 