### PR TITLE
Add implicit conv in func templ type inference

### DIFF
--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -105,6 +105,8 @@ public:
   [[nodiscard]] auto lookupImplicitConv(sym::TypeId from, sym::TypeId to) const
       -> std::optional<sym::FuncId>;
 
+  [[nodiscard]] auto isImplicitConvertible(sym::TypeId from, sym::TypeId to) const -> bool;
+
   [[nodiscard]] auto
   isImplicitConvertible(const sym::TypeSet& toTypes, const sym::TypeSet& fromTypes) const -> bool;
 

--- a/src/frontend/internal/typeinfer_typesub.hpp
+++ b/src/frontend/internal/typeinfer_typesub.hpp
@@ -43,7 +43,7 @@ template <typename TypeSpec>
       }
       if (!result) {
         result = inferredType;
-      } else if (result != inferredType) {
+      } else if (!ctx.getProg()->isImplicitConvertible(*inferredType, *result)) {
         return std::nullopt;
       }
     }

--- a/src/prog/internal/implicit_conv.cpp
+++ b/src/prog/internal/implicit_conv.cpp
@@ -60,6 +60,13 @@ auto findImplicitConvTypes(const Program& prog, sym::TypeId from) -> std::vector
   return result;
 }
 
+auto isImplicitConvertible(const Program& prog, sym::TypeId from, sym::TypeId to) -> bool {
+  if (from == to) {
+    return true;
+  }
+  return findImplicitConv(prog, from, to).has_value();
+}
+
 auto isImplicitConvertible(
     const Program& prog,
     const sym::TypeSet& toTypes,

--- a/src/prog/internal/implicit_conv.hpp
+++ b/src/prog/internal/implicit_conv.hpp
@@ -10,6 +10,10 @@ namespace prog::internal {
 [[nodiscard]] auto findImplicitConvTypes(const Program& prog, sym::TypeId from)
     -> std::vector<sym::TypeId>;
 
+// Is the from type implicitly convertible to the to type.
+[[nodiscard]] auto isImplicitConvertible(const Program& prog, sym::TypeId from, sym::TypeId to)
+    -> bool;
+
 // Are the fromTypes convertible to the toTypes.
 [[nodiscard]] auto isImplicitConvertible(
     const Program& prog,

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -367,6 +367,10 @@ auto Program::lookupImplicitConv(sym::TypeId from, sym::TypeId to) const
   return internal::findImplicitConv(*this, from, to);
 }
 
+auto Program::isImplicitConvertible(sym::TypeId from, sym::TypeId to) const -> bool {
+  return internal::isImplicitConvertible(*this, from, to);
+}
+
 auto Program::isImplicitConvertible(
     const sym::TypeSet& toTypes, const sym::TypeSet& fromTypes) const -> bool {
   return internal::isImplicitConvertible(*this, toTypes, fromTypes);


### PR DESCRIPTION
Allow implicit conversions in function template type inference.

For example:
```c
fun add{T}(T a, T b)
  a + b

print(add(13.337, 1))
```
Is now legal as int is implicitly convertible to float, so T is inferred as float.

Note: It only checks if further usages are compatible with the type it has inferred so far (so it checks if int is compatible with float).

It does not examine all usages to find out if there is a type that all would be compatible with. In theory this is possible and we could consider it if we find a use-case.