### PR TITLE
Typed failfast

### DIFF
--- a/examples/git-changelog.nov
+++ b/examples/git-changelog.nov
@@ -107,7 +107,7 @@ act main()
   else ->
     tagPattern    = getEnvOpt("tag", allParser()) ?? "*";
     commitsResult = getShaByTagPattern(tagPattern).map(getCommitsFrom);
-    if commitsResult as Error         err     -> printError(err); fail{bool}()
+    if commitsResult as Error         err     -> printError(err); failfast{bool}()
     if commitsResult as List{Commit}  commits -> printChangeLog(commits)
 
 main()

--- a/examples/git-changelog.nov
+++ b/examples/git-changelog.nov
@@ -107,7 +107,7 @@ act main()
   else ->
     tagPattern    = getEnvOpt("tag", allParser()) ?? "*";
     commitsResult = getShaByTagPattern(tagPattern).map(getCommitsFrom);
-    if commitsResult as Error         err     -> printError(err); fail()
+    if commitsResult as Error         err     -> printError(err); fail{bool}()
     if commitsResult as List{Commit}  commits -> printChangeLog(commits)
 
 main()

--- a/examples/json-formatter.nov
+++ b/examples/json-formatter.nov
@@ -27,6 +27,6 @@ act main()
     pathOrErr = getEnvOpt("path", pathParser());
     pretty    = hasEnvOpt("pretty");
     if pathOrErr as Path path -> formatJson(path, pretty)
-    else                      -> printErr("'path' option is required"); fail()
+    else                      -> printErr("'path' option is required"); fail{bool}()
 
 main()

--- a/examples/json-formatter.nov
+++ b/examples/json-formatter.nov
@@ -27,6 +27,6 @@ act main()
     pathOrErr = getEnvOpt("path", pathParser());
     pretty    = hasEnvOpt("pretty");
     if pathOrErr as Path path -> formatJson(path, pretty)
-    else                      -> printErr("'path' option is required"); fail{bool}()
+    else                      -> printErr("'path' option is required"); failfast{bool}()
 
 main()

--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -107,7 +107,7 @@ act parseSrt(Path path)
   print("[Parsing took: " + dur + "]\n");
 
   if res as List{Subtitle}  subs -> print(string(subs, "", "\n\n", ""))
-  if res as Error           err  -> printErr("Failed to parse: " + err); fail{bool}()
+  if res as Error           err  -> printErr("Failed to parse: " + err); failfast{bool}()
 
 act printUsage()
   print("Srt parser");
@@ -121,6 +121,6 @@ act main()
   else ->
     pathOrErr = getEnvOpt("path", pathParser());
     if pathOrErr as Path path -> parseSrt(path)
-    else                      -> printErr("'path' option is required"); fail{bool}()
+    else                      -> printErr("'path' option is required"); failfast{bool}()
 
 main()

--- a/examples/srt-parser.nov
+++ b/examples/srt-parser.nov
@@ -107,7 +107,7 @@ act parseSrt(Path path)
   print("[Parsing took: " + dur + "]\n");
 
   if res as List{Subtitle}  subs -> print(string(subs, "", "\n\n", ""))
-  if res as Error           err  -> printErr("Failed to parse: " + err); fail()
+  if res as Error           err  -> printErr("Failed to parse: " + err); fail{bool}()
 
 act printUsage()
   print("Srt parser");
@@ -121,6 +121,6 @@ act main()
   else ->
     pathOrErr = getEnvOpt("path", pathParser());
     if pathOrErr as Path path -> parseSrt(path)
-    else                      -> printErr("'path' option is required"); fail()
+    else                      -> printErr("'path' option is required"); fail{bool}()
 
 main()

--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -93,7 +93,7 @@ act handleConnection(ClientContext ctx)
 
 act main(int port, Content content)
   srvOpt  = tcpServer(port);
-  if srvOpt is None           -> printErr("Failed to start server"); fail{bool}()
+  if srvOpt is None           -> printErr("Failed to start server"); failfast{bool}()
   if srvOpt as TcpServer srv  ->
     print("Server started (port: " + port + "), press any key to stop");
 

--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -93,7 +93,7 @@ act handleConnection(ClientContext ctx)
 
 act main(int port, Content content)
   srvOpt  = tcpServer(port);
-  if srvOpt is None           -> printErr("Failed to start server"); fail()
+  if srvOpt is None           -> printErr("Failed to start server"); fail{bool}()
   if srvOpt as TcpServer srv  ->
     print("Server started (port: " + port + "), press any key to stop");
 

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -166,7 +166,15 @@ errUninitializedConst(const Source& src, const std::string& name, input::Span sp
 
 [[nodiscard]] auto errPureFuncInfRecursion(const Source& src, input::Span span) -> Diag;
 
-[[nodiscard]] auto errNoFuncFoundToInstantiate(
+[[nodiscard]] auto errNoPureFuncFoundToInstantiate(
+    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
+    -> Diag;
+
+[[nodiscard]] auto errNoActionFoundToInstantiate(
+    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
+    -> Diag;
+
+[[nodiscard]] auto errNoFuncOrActionFoundToInstantiate(
     const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
     -> Diag;
 
@@ -229,6 +237,10 @@ errUnsupportedOperator(const Source& src, const std::string& name, input::Span s
 [[nodiscard]] auto errSelfCallWithoutInferredRetType(const Source& src, input::Span span) -> Diag;
 
 [[nodiscard]] auto errIncorrectNumArgsInSelfCall(
-    const Source& src, int expectedNumArgs, int actualNumArgs, input::Span span) -> Diag;
+    const Source& src, unsigned int expectedNumArgs, unsigned int actualNumArgs, input::Span span)
+    -> Diag;
+
+[[nodiscard]] auto errInvalidFailCall(
+    const Source& src, unsigned int typeParams, unsigned int argCount, input::Span span) -> Diag;
 
 } // namespace frontend

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -143,6 +143,7 @@ public:
   auto declareLazy(std::string name) -> sym::TypeId;
   auto declarePureFunc(std::string name, sym::TypeSet input, sym::TypeId output) -> sym::FuncId;
   auto declareAction(std::string name, sym::TypeSet input, sym::TypeId output) -> sym::FuncId;
+  auto declareActionFail(std::string name, sym::TypeId output) -> sym::FuncId;
 
   auto defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void;
   auto defineUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> void;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,6 +177,7 @@ add_library(frontend STATIC
   frontend/internal/type_template_base.cpp
   frontend/internal/type_template_table.cpp
   frontend/internal/delegate_table.cpp
+  frontend/internal/fail_table.cpp
   frontend/internal/func_template_inst.cpp
   frontend/internal/func_template_table.cpp
   frontend/internal/func_template.cpp

--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -37,6 +37,7 @@ auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchP
   auto delegates     = internal::DelegateTable{};
   auto futures       = internal::FutureTable{};
   auto lazies        = internal::LazyTable{};
+  auto fails         = internal::FailTable{};
   auto typeInfos     = TypeInfoMap{};
   auto diags         = std::vector<Diag>{};
   auto makeCtx       = [&](const Source& src) {
@@ -48,6 +49,7 @@ auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchP
         &delegates,
         &futures,
         &lazies,
+        &fails,
         &typeInfos,
         &diags);
   };

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -592,7 +592,7 @@ auto errIncorrectNumArgsInSelfCall(
 auto errInvalidFailCall(
     const Source& src, unsigned int typeParams, unsigned int argCount, input::Span span) -> Diag {
   std::ostringstream oss;
-  oss << "Invalid fail action call";
+  oss << "Invalid failfast action call";
   if (typeParams != 1) {
     oss << ", requires '1' type parameter but got '" << typeParams << "'";
   }

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -394,12 +394,30 @@ auto errPureFuncInfRecursion(const Source& src, input::Span span) -> Diag {
   return error(src, oss.str(), span);
 }
 
-auto errNoFuncFoundToInstantiate(
+auto errNoPureFuncFoundToInstantiate(
     const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
     -> Diag {
   std::ostringstream oss;
-  oss << "No templated function '" << name << "' has been declared with '" << templateParamCount
+  oss << "No templated pure function '" << name << "' has been declared with '"
+      << templateParamCount << "' type parameters";
+  return error(src, oss.str(), span);
+}
+
+auto errNoActionFoundToInstantiate(
+    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
+    -> Diag {
+  std::ostringstream oss;
+  oss << "No templated action '" << name << "' has been declared with '" << templateParamCount
       << "' type parameters";
+  return error(src, oss.str(), span);
+}
+
+auto errNoFuncOrActionFoundToInstantiate(
+    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
+    -> Diag {
+  std::ostringstream oss;
+  oss << "No templated function or action '" << name << "' has been declared with '"
+      << templateParamCount << "' type parameters";
   return error(src, oss.str(), span);
 }
 
@@ -563,10 +581,24 @@ auto errSelfCallWithoutInferredRetType(const Source& src, input::Span span) -> D
 }
 
 auto errIncorrectNumArgsInSelfCall(
-    const Source& src, int expectedNumArgs, int actualNumArgs, input::Span span) -> Diag {
+    const Source& src, unsigned int expectedNumArgs, unsigned int actualNumArgs, input::Span span)
+    -> Diag {
   std::ostringstream oss;
   oss << "Self call requires '" << expectedNumArgs << "' arguments but got '" << actualNumArgs
       << "'";
+  return error(src, oss.str(), span);
+}
+
+auto errInvalidFailCall(
+    const Source& src, unsigned int typeParams, unsigned int argCount, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Invalid fail action call";
+  if (typeParams != 1) {
+    oss << ", requires '1' type parameter but got '" << typeParams << "'";
+  }
+  if (argCount != 0) {
+    oss << ", requires '0' arguments but got '" << argCount << "'";
+  }
   return error(src, oss.str(), span);
 }
 

--- a/src/frontend/internal/call_modifiers.cpp
+++ b/src/frontend/internal/call_modifiers.cpp
@@ -52,7 +52,7 @@ auto modifyCallPossibleFuncs(
 
   assert(ctx);
 
-  if (getName(nameToken) == "fail") {
+  if (getName(nameToken) == "failfast") {
     if (typeParams && typeParams->getCount() == 1 && args.first.size() == 0) {
       const auto resultType = getOrInstType(ctx, subTable, (*typeParams)[0]);
       if (resultType) {

--- a/src/frontend/internal/call_modifiers.cpp
+++ b/src/frontend/internal/call_modifiers.cpp
@@ -1,26 +1,33 @@
 #include "internal/call_modifiers.hpp"
+#include "frontend/diag_defs.hpp"
 #include "internal/utilities.hpp"
+#include <cassert>
 #include <sstream>
 
 namespace frontend::internal {
 
 static auto addArg(
     prog::expr::NodePtr arg,
-    std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>* args) {
+    std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args) {
 
-  args->second = args->second.withExtraType(arg->getType());
-  args->first.push_back(std::move(arg));
+  args.second = args.second.withExtraType(arg->getType());
+  args.first.push_back(std::move(arg));
 }
 
-auto modifyCall(
-    const Context* ctx,
+auto modifyCallArgs(
+    Context* ctx,
+    const TypeSubstitutionTable* /*unused*/,
     const lex::Token& nameToken,
+    std::optional<parse::TypeParamList> /*unused*/,
     const parse::CallExprNode& node,
-    std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>* args) -> void {
+    std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args) -> void {
 
-  // Assert has an exception where you are allowed omit the second arg (the message).
-  if (getName(nameToken) == "assert" && args->second.getCount() == 1 &&
-      args->second[0] == ctx->getProg()->getBool()) {
+  assert(ctx);
+
+  // If 'assert' is called with a single argument (the condition) then we synthesize another
+  // argument containing the message (with the source-location of the assert).
+  if (getName(nameToken) == "assert" && args.second.getCount() == 1 &&
+      args.second[0] == ctx->getProg()->getBool()) {
 
     // Construct a message containing the source position.
     auto startPos = ctx->getSrc().getTextPos(node.getSpan().getStart());
@@ -31,6 +38,33 @@ auto modifyCall(
 
     // Add the extra message arg.
     addArg(prog::expr::litStringNode(*ctx->getProg(), msgoss.str()), args);
+  }
+}
+
+auto modifyCallPossibleFuncs(
+    Context* ctx,
+    const TypeSubstitutionTable* subTable,
+    const lex::Token& nameToken,
+    std::optional<parse::TypeParamList> typeParams,
+    const parse::CallExprNode& node,
+    const std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args,
+    std::vector<prog::sym::FuncId>& possibleFuncs) -> void {
+
+  assert(ctx);
+
+  if (getName(nameToken) == "fail") {
+    if (typeParams && typeParams->getCount() == 1 && args.first.size() == 0) {
+      const auto resultType = getOrInstType(ctx, subTable, (*typeParams)[0]);
+      if (resultType) {
+        possibleFuncs.push_back(ctx->getFails()->getActionFail(ctx, *resultType));
+      }
+    } else {
+      ctx->reportDiag(
+          errInvalidFailCall,
+          typeParams ? typeParams->getCount() : 0u,
+          args.first.size(),
+          node.getSpan());
+    }
   }
 }
 

--- a/src/frontend/internal/call_modifiers.hpp
+++ b/src/frontend/internal/call_modifiers.hpp
@@ -8,10 +8,21 @@
 
 namespace frontend::internal {
 
-auto modifyCall(
-    const Context* ctx,
+auto modifyCallArgs(
+    Context* ctx,
+    const TypeSubstitutionTable* subTable,
     const lex::Token& nameToken,
+    std::optional<parse::TypeParamList> typeParams,
     const parse::CallExprNode& node,
-    std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>* args) -> void;
+    std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args) -> void;
+
+auto modifyCallPossibleFuncs(
+    Context* ctx,
+    const TypeSubstitutionTable* subTable,
+    const lex::Token& nameToken,
+    std::optional<parse::TypeParamList> typeParams,
+    const parse::CallExprNode& node,
+    const std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args,
+    std::vector<prog::sym::FuncId>& possibleFuncs) -> void;
 
 } // namespace frontend::internal

--- a/src/frontend/internal/context.cpp
+++ b/src/frontend/internal/context.cpp
@@ -11,6 +11,7 @@ Context::Context(
     DelegateTable* delegates,
     FutureTable* futures,
     LazyTable* lazies,
+    FailTable* fails,
     TypeInfoMap* typeInfos,
     std::vector<Diag>* diags) :
     m_src{src},
@@ -20,6 +21,7 @@ Context::Context(
     m_delegates{delegates},
     m_futures{futures},
     m_lazies{lazies},
+    m_fails{fails},
     m_typeInfos{typeInfos},
     m_diags{diags} {
 
@@ -40,6 +42,9 @@ Context::Context(
   }
   if (m_lazies == nullptr) {
     throw std::invalid_argument{"LazyTable cannot be null"};
+  }
+  if (m_fails == nullptr) {
+    throw std::invalid_argument{"FailTable cannot be null"};
   }
   if (m_typeInfos == nullptr) {
     throw std::invalid_argument{"TypeInfoMap cannot be null"};
@@ -64,6 +69,8 @@ auto Context::getDelegates() const noexcept -> DelegateTable* { return m_delegat
 auto Context::getFutures() const noexcept -> FutureTable* { return m_futures; }
 
 auto Context::getLazies() const noexcept -> LazyTable* { return m_lazies; }
+
+auto Context::getFails() const noexcept -> FailTable* { return m_fails; }
 
 auto Context::getTypeInfo(prog::sym::TypeId typeId) const noexcept -> std::optional<TypeInfo> {
   const auto itr = m_typeInfos->find(typeId);

--- a/src/frontend/internal/context.hpp
+++ b/src/frontend/internal/context.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "frontend/diag.hpp"
 #include "internal/delegate_table.hpp"
+#include "internal/fail_table.hpp"
 #include "internal/func_template_table.hpp"
 #include "internal/future_table.hpp"
 #include "internal/lazy_table.hpp"
@@ -26,6 +27,7 @@ public:
       DelegateTable* delegates,
       FutureTable* futures,
       LazyTable* lazies,
+      FailTable* fails,
       TypeInfoMap* typeInfos,
       std::vector<Diag>* diags);
 
@@ -38,6 +40,7 @@ public:
   [[nodiscard]] auto getDelegates() const noexcept -> DelegateTable*;
   [[nodiscard]] auto getFutures() const noexcept -> FutureTable*;
   [[nodiscard]] auto getLazies() const noexcept -> LazyTable*;
+  [[nodiscard]] auto getFails() const noexcept -> FailTable*;
 
   [[nodiscard]] auto getTypeInfo(prog::sym::TypeId typeId) const noexcept
       -> std::optional<TypeInfo>;
@@ -57,6 +60,8 @@ private:
   DelegateTable* m_delegates;
   FutureTable* m_futures;
   LazyTable* m_lazies;
+  FailTable* m_fails;
+
   TypeInfoMap* m_typeInfos;
   std::vector<Diag>* m_diags;
 };

--- a/src/frontend/internal/fail_table.cpp
+++ b/src/frontend/internal/fail_table.cpp
@@ -1,0 +1,21 @@
+#include "fail_table.hpp"
+#include "utilities.hpp"
+
+namespace frontend::internal {
+
+auto FailTable::getActionFail(Context* ctx, prog::sym::TypeId result) -> prog::sym::FuncId {
+  // Try to find an existing fail action with the same result-type.
+  auto itr = m_fails.find(result);
+  if (itr != m_fails.end()) {
+    return itr->second;
+  }
+
+  // Declare a new fail action.
+  auto name       = std::string{"__fail_"} + getName(*ctx, result);
+  auto failAction = ctx->getProg()->declareActionFail(std::move(name), result);
+
+  m_fails.insert({result, failAction});
+  return failAction;
+}
+
+} // namespace frontend::internal

--- a/src/frontend/internal/fail_table.cpp
+++ b/src/frontend/internal/fail_table.cpp
@@ -11,7 +11,7 @@ auto FailTable::getActionFail(Context* ctx, prog::sym::TypeId result) -> prog::s
   }
 
   // Declare a new fail action.
-  auto name       = std::string{"__fail_"} + getName(*ctx, result);
+  auto name       = std::string{"__failfast_"} + getName(*ctx, result);
   auto failAction = ctx->getProg()->declareActionFail(std::move(name), result);
 
   m_fails.insert({result, failAction});

--- a/src/frontend/internal/fail_table.hpp
+++ b/src/frontend/internal/fail_table.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "prog/program.hpp"
+#include <unordered_map>
+
+namespace frontend::internal {
+
+class Context;
+
+class FailTable final {
+public:
+  FailTable()                         = default;
+  FailTable(const FailTable& rhs)     = delete;
+  FailTable(FailTable&& rhs) noexcept = default;
+  ~FailTable()                        = default;
+
+  auto operator=(const FailTable& rhs) -> FailTable& = delete;
+  auto operator=(FailTable&& rhs) noexcept -> FailTable& = delete;
+
+  auto getActionFail(Context* ctx, prog::sym::TypeId result) -> prog::sym::FuncId;
+
+private:
+  std::unordered_map<prog::sym::TypeId, prog::sym::FuncId, prog::sym::TypeIdHasher> m_fails;
+};
+
+} // namespace frontend::internal

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -341,7 +341,6 @@ Program::Program() :
   m_funcDecls.registerAction(*this, Fk::ActionSleepNano, "sleepNano", sym::TypeSet{m_long}, m_long);
   m_funcDecls.registerAction(
       *this, Fk::ActionAssert, "assert", sym::TypeSet{m_bool, m_string}, m_bool);
-  m_funcDecls.registerAction(*this, Fk::ActionFail, "fail", sym::TypeSet{}, m_bool);
 }
 
 auto Program::hasType(const std::string& name) const -> bool { return m_typeDecls.exists(name); }
@@ -514,6 +513,11 @@ auto Program::declareAction(std::string name, sym::TypeSet input, sym::TypeId ou
     -> sym::FuncId {
   return m_funcDecls.registerAction(
       *this, sym::FuncKind::User, std::move(name), std::move(input), output);
+}
+
+auto Program::declareActionFail(std::string name, sym::TypeId output) -> sym::FuncId {
+  return m_funcDecls.registerAction(
+      *this, sym::FuncKind::ActionFail, std::move(name), sym::TypeSet{}, output);
 }
 
 auto Program::defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void {

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -237,7 +237,7 @@ TEST_CASE("Analyzing anonymous functions", "[frontend]") {
         "fun f() f{int}()",
         errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{23, 23}),
         errInvalidFuncInstantiation(src, input::Span{36, 36}),
-        errNoFuncFoundToInstantiate(src, "f", 1, input::Span{36, 43}));
+        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{36, 43}));
     CHECK_DIAG("fun f() lambda () b", errUndeclaredConst(src, "b", input::Span{18, 18}));
     CHECK_DIAG(
         "fun f() lambda () false ? i = 1 : i ",

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE("Analyzing user-function declarations", "[frontend]") {
         "fun f() f{int}(1)",
         errUndeclaredConst(src, "b", input::Span{14, 14}),
         errInvalidFuncInstantiation(src, input::Span{24, 24}),
-        errNoFuncFoundToInstantiate(src, "f", 1, input::Span{24, 32}));
+        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{24, 32}));
     CHECK_DIAG(
         "fun +() -> int i", errOperatorOverloadWithoutArgs(src, "operator+", input::Span{4, 4}));
     CHECK_DIAG(

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -67,34 +67,39 @@ TEST_CASE("Analyzing user-function definitions", "[frontend]") {
         "fun f() -> int int{float}()",
         errNoTypeOrConversionFoundToInstantiate(src, "int", 1, input::Span{15, 26}));
     CHECK_DIAG(
-        "fun f2() -> int f{int}(1)", errNoFuncFoundToInstantiate(src, "f", 1, input::Span{16, 24}));
+        "fun f2() -> int f{int}(1)",
+        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{16, 24}));
+    CHECK_DIAG(
+        "act a() -> int f{int}()",
+        errNoFuncOrActionFoundToInstantiate(src, "f", 1, input::Span{15, 22}));
+    CHECK_DIAG("f{int}()", errNoActionFoundToInstantiate(src, "f", 1, input::Span{0, 7}));
     CHECK_DIAG(
         "fun f1() -> int 1 "
         "fun f2() -> int f1{int}()",
-        errNoFuncFoundToInstantiate(src, "f1", 1, input::Span{34, 42}));
+        errNoPureFuncFoundToInstantiate(src, "f1", 1, input::Span{34, 42}));
     CHECK_DIAG(
         "fun f{T}(T t) t "
         "fun f2() -> int f{int, float}(1)",
-        errNoFuncFoundToInstantiate(src, "f", 2, input::Span{32, 47}));
+        errNoPureFuncFoundToInstantiate(src, "f", 2, input::Span{32, 47}));
     CHECK_DIAG(
         "fun f{T}(T T) -> T T "
         "fun f2() -> int f{int}(1)",
         errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{11, 11}),
         errInvalidFuncInstantiation(src, input::Span{37, 37}),
-        errNoFuncFoundToInstantiate(src, "f", 1, input::Span{37, 45}));
+        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{37, 45}));
     CHECK_DIAG(
         "fun f{T}(T T) -> T T "
         "fun f2() f{int}(1)",
         errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{11, 11}),
         errInvalidFuncInstantiation(src, input::Span{30, 30}),
-        errNoFuncFoundToInstantiate(src, "f", 1, input::Span{30, 38}));
+        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{30, 38}));
     CHECK_DIAG(
         "fun f{T}(T i) -> T "
         "  T = i * 2; i "
         "fun f2() -> int f{int}(1)",
         errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{21, 21}),
         errInvalidFuncInstantiation(src, input::Span{50, 50}),
-        errNoFuncFoundToInstantiate(src, "f", 1, input::Span{50, 58}));
+        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{50, 58}));
     CHECK_DIAG(
         "fun f() -> function{int} lambda () false",
         errNonMatchingFuncReturnType(

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -198,7 +198,10 @@ TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
         "fun f2() -> int op = f1{int}; op(1)",
         errAmbiguousTemplateFunction(src, "f1", 1, input::Span{75, 81}),
         errUndeclaredPureFunc(src, "op", {"int"}, input::Span{84, 88}));
-    CHECK_DIAG("fun f() f1{float}", errNoFuncFoundToInstantiate(src, "f1", 1, input::Span{8, 16}));
+    CHECK_DIAG(
+        "fun f() f1{float}", errNoPureFuncFoundToInstantiate(src, "f1", 1, input::Span{8, 16}));
+    CHECK_DIAG(
+        "act a() f1{float}", errNoFuncOrActionFoundToInstantiate(src, "f1", 1, input::Span{8, 16}));
     CHECK_DIAG(
         "fun f1{T}() -> T T() "
         "fun f2() -> int op = f1; op()",

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -215,11 +215,13 @@ TEST_CASE("Analyzing call expressions", "[frontend]") {
   }
 
   SECTION("Get fail action call") {
-    const auto& output = ANALYZE("act a() -> int fail{int}()");
+    const auto& output = ANALYZE("act a() -> int failfast{int}()");
     REQUIRE(output.isSuccess());
 
     auto callExpr = prog::expr::callExprNode(
-        output.getProg(), GET_FUNC_ID(output, "__fail_int"), std::vector<prog::expr::NodePtr>{});
+        output.getProg(),
+        GET_FUNC_ID(output, "__failfast_int"),
+        std::vector<prog::expr::NodePtr>{});
 
     CHECK(GET_FUNC_DEF(output, "a").getExpr() == *callExpr);
   }
@@ -268,20 +270,20 @@ TEST_CASE("Analyzing call expressions", "[frontend]") {
         "act f2(int i) -> int lazy i.a()",
         errLazyActionCall(src, input::Span{47, 56}));
     CHECK_DIAG(
-        "fun f() -> int fail{int}()",
-        errNoPureFuncFoundToInstantiate(src, "fail", 1, input::Span{15, 25}));
+        "fun f() -> int failfast{int}()",
+        errNoPureFuncFoundToInstantiate(src, "failfast", 1, input::Span{15, 29}));
     CHECK_DIAG(
-        "act f() -> int fail()",
-        errInvalidFailCall(src, 0, 0, input::Span{15, 20}),
-        errUndeclaredFuncOrAction(src, "fail", {}, input::Span{15, 20}));
+        "act f() -> int failfast()",
+        errInvalidFailCall(src, 0, 0, input::Span{15, 24}),
+        errUndeclaredFuncOrAction(src, "failfast", {}, input::Span{15, 24}));
     CHECK_DIAG(
-        "act f() -> int fail(1)",
-        errInvalidFailCall(src, 0, 1, input::Span{15, 21}),
-        errUndeclaredFuncOrAction(src, "fail", {"int"}, input::Span{15, 21}));
+        "act f() -> int failfast(1)",
+        errInvalidFailCall(src, 0, 1, input::Span{15, 25}),
+        errUndeclaredFuncOrAction(src, "failfast", {"int"}, input::Span{15, 25}));
     CHECK_DIAG(
-        "act f() -> int fail{int}(1.0)",
-        errInvalidFailCall(src, 1, 1, input::Span{15, 28}),
-        errNoFuncOrActionFoundToInstantiate(src, "fail", 1, input::Span{15, 28}));
+        "act f() -> int failfast{int}(1.0)",
+        errInvalidFailCall(src, 1, 1, input::Span{15, 32}),
+        errNoFuncOrActionFoundToInstantiate(src, "failfast", 1, input::Span{15, 32}));
   }
 }
 


### PR DESCRIPTION
Instead of always 'returning' a boolean we now allow the caller
to choose the return-type.

Return-type is functionally irrelevant because 'fail' actually never
returns but it can be usefull for composing fail into existing actions
(where each expression needs to be of a correct type).