### PR TITLE
Support more then 256 constants in one scope

### DIFF
--- a/include/novasm/assembler.hpp
+++ b/include/novasm/assembler.hpp
@@ -36,9 +36,9 @@ public:
   auto addLoadLitString(const std::string& val) -> void;
   auto addLoadLitIp(std::string label) -> void;
 
-  auto addStackAlloc(uint8_t amount) -> void;
-  auto addStackStore(uint8_t offset) -> void;
-  auto addStackLoad(uint8_t offset) -> void;
+  auto addStackAlloc(uint16_t amount) -> void;
+  auto addStackStore(uint16_t offset) -> void;
+  auto addStackLoad(uint16_t offset) -> void;
 
   auto addAddInt() -> void;
   auto addAddLong() -> void;
@@ -151,6 +151,7 @@ private:
 
   auto writeOpCode(OpCode opCode) -> void;
   auto writeUInt8(uint8_t val) -> void;
+  auto writeUInt16(uint16_t val) -> void;
   auto writeInt32(int32_t val) -> void;
   auto writeInt64(int64_t val) -> void;
   auto writeUInt32(uint32_t val) -> void;

--- a/include/novasm/op_code.hpp
+++ b/include/novasm/op_code.hpp
@@ -21,9 +21,12 @@ enum class OpCode : uint8_t {
 
   LoadLitIp = 20, // [uint] () -> (ip) Load an instruction-pointer on the stack.
 
-  StackAlloc = 30, // [uint8] ()    -> ()     Allocate space on the current stack-frame.
-  StackStore = 31, // [uint8] (any) -> ()     Store at a offset from the stack-frame start.
-  StackLoad  = 32, // [uint8] ()    -> (any)  Load from a offset from the stack-frame start.
+  StackAlloc      = 30, // [uint16] ()    -> ()     Allocate space on the current stack-frame.
+  StackAllocSmall = 31, // [uint8 ] ()    -> ()     Allocate space on the current stack-frame.
+  StackStore      = 32, // [uint16] (any) -> ()     Store at a offset from the stack-frame start.
+  StackStoreSmall = 33, // [uint8 ] (any) -> ()     Store at a offset from the stack-frame start.
+  StackLoad       = 34, // [uint16] ()    -> (any)  Load from a offset from the stack-frame start.
+  StackLoadSmall  = 35, // [uint8 ] ()    -> (any)  Load from a offset from the stack-frame start.
 
   AddInt        = 40, // [] (int, int)          -> (int)    Add two ints.
   AddLong       = 41, // [] (long, long)        -> (long)   Add two longs.

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -7,7 +7,7 @@ namespace novasm {
 // Version number for the binary representation of the novus assembly format.
 // Increase this when performing breaking changes to the format.
 // TODO(bastian): Add system for defining migrations.
-const uint16_t assemblyFormatVersion = 3U;
+const uint16_t assemblyFormatVersion = 4U;
 
 // Write a binary representation of the assembly file to the output iterator.
 template <typename OutputItr>

--- a/src/backend/generator.cpp
+++ b/src/backend/generator.cpp
@@ -17,10 +17,10 @@ static auto reserveConsts(novasm::Assembler* asmb, const prog::sym::ConstDeclTab
   // Allocate space for the locals, note: space for inputs is automatically allocated by the vm.
   const auto constCount = constTable.getLocalCount();
   if (constCount > 0) {
-    if (constCount > std::numeric_limits<uint8_t>::max()) {
-      throw std::logic_error{"More then 256 constants in one scope are not supported"};
+    if (constCount > std::numeric_limits<uint16_t>::max()) {
+      throw std::logic_error{"More then 65535 constants in one scope are not supported"};
     }
-    asmb->addStackAlloc(static_cast<uint8_t>(constCount));
+    asmb->addStackAlloc(static_cast<uint16_t>(constCount));
   }
 }
 

--- a/src/backend/internal/utilities.cpp
+++ b/src/backend/internal/utilities.cpp
@@ -17,12 +17,12 @@ auto getUserTypeEqLabel(const prog::Program& prog, prog::sym::TypeId typeId) -> 
   return oss.str();
 }
 
-auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId id) -> uint8_t {
+auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId id) -> uint16_t {
   const auto offset = table.getOffset(id);
-  if (offset > std::numeric_limits<uint8_t>::max()) {
-    throw std::logic_error{"More then 256 constants in one scope are not supported"};
+  if (offset > std::numeric_limits<uint16_t>::max()) {
+    throw std::logic_error{"More then 65535 constants in one scope are not supported"};
   }
-  return static_cast<uint8_t>(offset);
+  return static_cast<uint16_t>(offset);
 }
 
 auto getFieldOffset(prog::sym::FieldId fieldId) -> uint8_t {

--- a/src/backend/internal/utilities.hpp
+++ b/src/backend/internal/utilities.hpp
@@ -15,7 +15,7 @@ auto getLabel(const prog::Program& prog, prog::sym::FuncId funcId) -> std::strin
 auto getUserTypeEqLabel(const prog::Program& prog, prog::sym::TypeId typeId) -> std::string;
 
 // Get the offset in the constant-table for the constant.
-auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId id) -> uint8_t;
+auto getConstOffset(const prog::sym::ConstDeclTable& table, prog::sym::ConstId id) -> uint16_t;
 
 // Get the offset the field has in the struct.
 auto getFieldOffset(prog::sym::FieldId fieldId) -> uint8_t;

--- a/src/novasm/assembler.cpp
+++ b/src/novasm/assembler.cpp
@@ -56,19 +56,34 @@ auto Assembler::addLoadLitIp(std::string label) -> void {
   writeIpOffset(std::move(label));
 }
 
-auto Assembler::addStackAlloc(uint8_t amount) -> void {
-  writeOpCode(OpCode::StackAlloc);
-  writeUInt8(amount);
+auto Assembler::addStackAlloc(uint16_t amount) -> void {
+  if (amount <= std::numeric_limits<uint8_t>::max()) {
+    writeOpCode(OpCode::StackAllocSmall);
+    writeUInt8(static_cast<uint8_t>(amount));
+  } else {
+    writeOpCode(OpCode::StackAlloc);
+    writeUInt16(amount);
+  }
 }
 
-auto Assembler::addStackStore(uint8_t offset) -> void {
-  writeOpCode(OpCode::StackStore);
-  writeUInt8(offset);
+auto Assembler::addStackStore(uint16_t offset) -> void {
+  if (offset <= std::numeric_limits<uint8_t>::max()) {
+    writeOpCode(OpCode::StackStoreSmall);
+    writeUInt8(static_cast<uint8_t>(offset));
+  } else {
+    writeOpCode(OpCode::StackStore);
+    writeUInt16(offset);
+  }
 }
 
-auto Assembler::addStackLoad(uint8_t offset) -> void {
-  writeOpCode(OpCode::StackLoad);
-  writeUInt8(offset);
+auto Assembler::addStackLoad(uint16_t offset) -> void {
+  if (offset <= std::numeric_limits<uint8_t>::max()) {
+    writeOpCode(OpCode::StackLoadSmall);
+    writeUInt8(static_cast<uint8_t>(offset));
+  } else {
+    writeOpCode(OpCode::StackLoad);
+    writeUInt16(offset);
+  }
 }
 
 auto Assembler::addAddInt() -> void { writeOpCode(OpCode::AddInt); }
@@ -343,6 +358,12 @@ auto Assembler::writeOpCode(OpCode opCode) -> void { writeUInt8(static_cast<uint
 auto Assembler::writeUInt8(uint8_t val) -> void {
   throwIfClosed();
   m_instructions.push_back(val);
+}
+
+auto Assembler::writeUInt16(uint16_t val) -> void {
+  throwIfClosed();
+  m_instructions.push_back(val);
+  m_instructions.push_back(val >> 8U); // NOLINT: Magic number
 }
 
 auto Assembler::writeInt32(int32_t val) -> void {

--- a/src/novasm/disassembler.cpp
+++ b/src/novasm/disassembler.cpp
@@ -109,10 +109,15 @@ auto disassembleInstructions(const Assembly& assembly, const dasm::InstructionLa
     case OpCode::LoadLitFloat:
       result.push_back(Instr{opCode, offset, {Arg{readAsm<float>(&ip)}}, labels});
       continue;
-    case OpCode::LoadLitIntSmall:
     case OpCode::StackAlloc:
     case OpCode::StackLoad:
     case OpCode::StackStore:
+      result.push_back(Instr{opCode, offset, {Arg{readAsm<uint16_t>(&ip)}}, labels});
+      continue;
+    case OpCode::LoadLitIntSmall:
+    case OpCode::StackAllocSmall:
+    case OpCode::StackLoadSmall:
+    case OpCode::StackStoreSmall:
     case OpCode::MakeStruct:
     case OpCode::StructLoadField:
     case OpCode::StructStoreField:

--- a/src/novasm/op_code.cpp
+++ b/src/novasm/op_code.cpp
@@ -32,11 +32,20 @@ auto operator<<(std::ostream& out, const OpCode& rhs) noexcept -> std::ostream& 
   case OpCode::StackAlloc:
     out << "stack-alloc";
     break;
+  case OpCode::StackAllocSmall:
+    out << "stack-alloc-small";
+    break;
   case OpCode::StackStore:
     out << "stack-store";
     break;
+  case OpCode::StackStoreSmall:
+    out << "stack-store-small";
+    break;
   case OpCode::StackLoad:
     out << "stack-load";
+    break;
+  case OpCode::StackLoadSmall:
+    out << "stack-load-small";
     break;
 
   case OpCode::AddInt:

--- a/tests/vm/consts_test.cpp
+++ b/tests/vm/consts_test.cpp
@@ -5,43 +5,72 @@ namespace vm {
 
 TEST_CASE("Execute constants", "[vm]") {
 
-  CHECK_EXPR(
-      [](novasm::Assembler* asmb) -> void {
-        asmb->addStackAlloc(1);
-        asmb->addLoadLitInt(42);
-        asmb->addStackStore(0);
+  SECTION("Small stack counts") {
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addStackAlloc(1);
+          asmb->addLoadLitInt(42);
+          asmb->addStackStore(0);
 
-        asmb->addStackLoad(0);
-        asmb->addConvIntString();
-        ADD_PRINT(asmb);
-      },
-      "input",
-      "42");
+          asmb->addStackLoad(0);
+          asmb->addConvIntString();
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "42");
 
-  CHECK_EXPR(
-      [](novasm::Assembler* asmb) -> void {
-        asmb->addStackAlloc(2);
-        asmb->addLoadLitInt(42);
-        asmb->addStackStore(0);
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addStackAlloc(2);
+          asmb->addLoadLitInt(42);
+          asmb->addStackStore(0);
 
-        asmb->addLoadLitInt(1337);
-        asmb->addStackStore(1);
+          asmb->addLoadLitInt(1337);
+          asmb->addStackStore(1);
 
-        asmb->addStackLoad(0);
-        asmb->addConvIntString();
-        ADD_PRINT(asmb);
-        asmb->addPop();
+          asmb->addStackLoad(0);
+          asmb->addConvIntString();
+          ADD_PRINT(asmb);
+          asmb->addPop();
 
-        asmb->addLoadLitString(" ");
-        ADD_PRINT(asmb);
-        asmb->addPop();
+          asmb->addLoadLitString(" ");
+          ADD_PRINT(asmb);
+          asmb->addPop();
 
-        asmb->addStackLoad(1);
-        asmb->addConvIntString();
-        ADD_PRINT(asmb);
-      },
-      "input",
-      "42 1337");
+          asmb->addStackLoad(1);
+          asmb->addConvIntString();
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "42 1337");
+  }
+
+  SECTION("Big stack counts") {
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addStackAlloc(400);
+          asmb->addLoadLitInt(42);
+          asmb->addStackStore(305);
+
+          asmb->addLoadLitInt(1337);
+          asmb->addStackStore(306);
+
+          asmb->addStackLoad(305);
+          asmb->addConvIntString();
+          ADD_PRINT(asmb);
+          asmb->addPop();
+
+          asmb->addLoadLitString(" ");
+          ADD_PRINT(asmb);
+          asmb->addPop();
+
+          asmb->addStackLoad(306);
+          asmb->addConvIntString();
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "42 1337");
+  }
 }
 
 } // namespace vm


### PR DESCRIPTION
Support more then 256 constants in one scope, can be needed due to aggressive optimizer inlining. 

The new limit is `65535` (using 16 bit offsets).

The vm now has opcodes using both 8 bit and 16 bit offsets:
```
  StackAlloc      = 30, // [uint16] ()    -> ()     Allocate space on the current stack-frame.
  StackAllocSmall = 31, // [uint8 ] ()    -> ()     Allocate space on the current stack-frame.
  StackStore      = 32, // [uint16] (any) -> ()     Store at a offset from the stack-frame start.
  StackStoreSmall = 33, // [uint8 ] (any) -> ()     Store at a offset from the stack-frame start.
  StackLoad       = 34, // [uint16] ()    -> (any)  Load from a offset from the stack-frame start.
  StackLoadSmall  = 35, // [uint8 ] ()    -> (any)  Load from a offset from the stack-frame start.
```
The assembler automatically chooses the appropriate opcode based on the size of the provided offset (and the 8 and 16 bit versions can be safely mixed). 