### PR TITLE
Tcp improvements

### DIFF
--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -63,7 +63,7 @@ act writeResponse(ClientContext ctx, HttpResp resp) -> Option{Error}
     HttpHeaderField("Server",             "Novus")                ::
     HttpHeaderField("Transfer-Encoding",  "identity")             ::
     HttpHeaderField("Connection",         "keep-alive")           ::
-    HttpHeaderField("Keep-Alive",         "timeout=10, max=1000")
+    HttpHeaderField("Keep-Alive",         "timeout=5, max=1000")
   );
   finalResp     = resp.httpRespAddFields(extraFields);
   finalRespTxt  = ctx.respWriter(WriterState(WriterNewlineMode.CrLf), finalResp).string();

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -8,6 +8,7 @@ struct TcpConnection =
   sys_stream socket
 
 struct TcpServer =
+  int         maxBacklog,
   sys_stream  socket,
   int         port
 
@@ -61,8 +62,11 @@ act tcpServer() -> Either{TcpServer, Error}
   tcpServer(8080)
 
 act tcpServer(int port) -> Either{TcpServer, Error}
-  socket = tcpStartServer(port, -1);
-  if socket.streamCheckValid() -> TcpServer(socket, port)
+  tcpServer(port, 64)
+
+act tcpServer(int port, int maxBacklog) -> Either{TcpServer, Error}
+  socket = tcpStartServer(port, maxBacklog);
+  if socket.streamCheckValid() -> TcpServer(maxBacklog, socket, port)
   else                         -> Error("Failed to start tcp-server")
 
 act tcpAcceptConnection(TcpServer server) -> Either{TcpConnection, Error}
@@ -75,6 +79,9 @@ act tcpAcceptConnectionAsync(TcpServer server) -> future{Either{TcpConnection, E
 
 act tcpServerLoop(int port, TcpServerLoopContext ctx) -> Option{Error}
   tcpServer(port).map(impure lambda (TcpServer svr) svr.tcpServerLoop(ctx))
+
+act tcpServerLoop(int port, int maxBacklog, TcpServerLoopContext ctx) -> Option{Error}
+  tcpServer(port, maxBacklog).map(impure lambda (TcpServer svr) svr.tcpServerLoop(ctx))
 
 act tcpServerLoop(TcpServer svr, TcpServerLoopContext ctx) -> Option{Error}
   loop = (impure lambda (
@@ -103,8 +110,19 @@ act tcpServerLoop(TcpServer svr, TcpServerLoopContext ctx) -> Option{Error}
 // -- Tests
 
 assert(
-  server    = tcpServer(5000).failOnError();
-  client    = tcpConnection("127.0.0.1", 5000).failOnError();
+  tcpServer(-1)       is Error  &&
+  tcpServer(65536)    is Error  &&
+  tcpServer(intMax()) is Error
+)
+
+assert(
+  maxBacklog  = intMax();
+  tcpServer(5000, maxBacklog) is TcpServer
+)
+
+assert(
+  server    = tcpServer(5001).failOnError();
+  client    = tcpConnection("127.0.0.1", 5001).failOnError();
   serverCon = server.tcpAcceptConnection().failOnError();
 
   serverCon.write("Hello world\n").failOnError();
@@ -112,16 +130,11 @@ assert(
 )
 
 assert(
-  tcpServer(-1) is Error &&
-  tcpServer(65536) is Error
-)
-
-assert(
-  fork tcpServerLoop(5001, TcpServerLoopContext(impure lambda(TcpConnection c)
+  fork tcpServerLoop(5002, TcpServerLoopContext(impure lambda(TcpConnection c)
     c.write(c.socket.readLine() + '\n')
   ));
   client = (impure lambda(string message)
-    c = tcpConnection("127.0.0.1", 5001).failOnError();
+    c = tcpConnection("127.0.0.1", 5002).failOnError();
     c.write(message + '\n').failOnError();
     c.socket.readLine()
   );
@@ -132,8 +145,8 @@ assert(
 )
 
 assert(
-  server = tcpServer(5002).failOnError();
-  client = tcpConnection("127.0.0.1", 5002).failOnError();
+  server = tcpServer(5003).failOnError();
+  client = tcpConnection("127.0.0.1", 5003).failOnError();
 
   res = tcpServerLoop(server, TcpServerLoopContext(impure lambda(TcpConnection c)
     some(Error("Did not go well"))
@@ -142,8 +155,8 @@ assert(
 )
 
 assert(
-  server = tcpServer(5003).failOnError();
-  client = tcpConnection("127.0.0.1", 5003).failOnError();
+  server = tcpServer(5004).failOnError();
+  client = tcpConnection("127.0.0.1", 5004).failOnError();
 
   clientHandler = (impure lambda (TcpConnection c)
     c.write("hello")

--- a/src/vm/internal/fd_utilities.hpp
+++ b/src/vm/internal/fd_utilities.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "internal/stream_opts.hpp"
 #include "internal/os_include.hpp"
+#include "internal/stream_opts.hpp"
 #include <cstdio>
 
 namespace vm::internal {
@@ -11,22 +11,26 @@ namespace vm::internal {
 
 // Set file-descriptor options.
 inline auto setFileOpts(int fd, StreamOpts opts) noexcept -> bool {
+
   // Get the current options of the file descriptor.
   int fileOpts = fcntl(fd, F_GETFL);
   if (fileOpts < 0) {
     return false;
   }
 
+  auto updatedOptions = false;
+
   // Update the options.
   if (static_cast<int32_t>(opts) & static_cast<int32_t>(StreamOpts::NoBlock)) {
     fileOpts |= O_NONBLOCK;
+    updatedOptions = true;
   }
 
   // Set the file options.
   if (fcntl(fd, F_SETFL, fileOpts) < 0) {
     return false;
   }
-  return true;
+  return updatedOptions;
 }
 
 // Set file-descriptor options.
@@ -43,16 +47,19 @@ inline auto unsetFileOpts(int fd, StreamOpts opts) noexcept -> bool {
     return false;
   }
 
+  auto updatedOptions = false;
+
   // Update the options.
   if (static_cast<int32_t>(opts) & static_cast<int32_t>(StreamOpts::NoBlock)) {
     fileOpts &= ~O_NONBLOCK;
+    updatedOptions = true;
   }
 
   // Set the file options.
   if (fcntl(fd, F_SETFL, fileOpts) < 0) {
     return false;
   }
-  return true;
+  return updatedOptions;
 }
 
 // Unset file-descriptor options.

--- a/src/vm/internal/ref_stream_console.hpp
+++ b/src/vm/internal/ref_stream_console.hpp
@@ -137,8 +137,9 @@ public:
         return false;
       }
       m_nonblockWinTerm = true;
+      return true;
     }
-    return true;
+    return false;
 #else //!_WIN32
     return setFileOpts(m_filePtr, opts);
 #endif
@@ -148,8 +149,9 @@ public:
 #if defined(_WIN32)
     if (static_cast<int32_t>(opts) & static_cast<int32_t>(StreamOpts::NoBlock)) {
       m_nonblockWinTerm = false;
+      return true;
     }
-    return true;
+    return false;
 #else //!_WIN32
     return unsetFileOpts(m_filePtr, opts);
 #endif

--- a/src/vm/internal/ref_stream_tcp.hpp
+++ b/src/vm/internal/ref_stream_tcp.hpp
@@ -47,7 +47,7 @@ public:
       if (shutdown(m_socket, SD_BOTH) == 0) {
         closesocket(m_socket);
       }
-#else // !_WIN32
+#else  // !_WIN32
       if (shutdown(m_socket, SHUT_RDWR) == 0) {
         close(m_socket);
       }
@@ -175,12 +175,12 @@ public:
 
   auto setOpts(StreamOpts /*unused*/) noexcept -> bool {
     // TODO(bastian): Support non-blocking sockets.
-    return true;
+    return false;
   }
 
   auto unsetOpts(StreamOpts /*unused*/) noexcept -> bool {
     // TODO(bastian): Support non-blocking sockets.
-    return true;
+    return false;
   }
 
   auto acceptConnection(ExecutorHandle* execHandle, RefAllocator* alloc) -> TcpStreamRef* {

--- a/src/vm/internal/ref_stream_tcp.hpp
+++ b/src/vm/internal/ref_stream_tcp.hpp
@@ -26,11 +26,14 @@
 namespace vm::internal {
 
 constexpr int32_t defaultConnectionBacklog = 64;
+constexpr int32_t receiveTimeoutSeconds    = 15;
 
 enum class TcpStreamType : uint8_t {
   Server     = 0, // Server cannot be used for sending or receiving but can accept new connections.
   Connection = 1, // Connections are be used for sending and receiving.
 };
+
+auto configureSocket(SOCKET sock) noexcept -> void;
 
 // Tcp implementation of the 'stream' interface.
 // Note: To avoid needing a vtable there is no abstract 'Stream' class but instead there are wrapper
@@ -47,7 +50,7 @@ public:
       if (shutdown(m_socket, SD_BOTH) == 0) {
         closesocket(m_socket);
       }
-#else  // !_WIN32
+#else // !_WIN32
       if (shutdown(m_socket, SHUT_RDWR) == 0) {
         close(m_socket);
       }
@@ -191,8 +194,26 @@ public:
     // 'accept' call blocks so we mark ourselves as paused so the gc can trigger in the mean time.
     execHandle->setState(ExecState::Paused);
 
-    // Accept a new connection from the socket.
-    const auto sock = accept(m_socket, nullptr, nullptr);
+    SOCKET sock;
+    while (true) {
+      // Accept a new connection from the socket.
+      sock = accept(m_socket, nullptr, nullptr);
+
+      // Retry the accept for certain errors.
+      if (!SOCKET_VALID(sock)) {
+#if defined(_WIN32)
+        if (SOCKET_ERR == WSAEWOULDBLOCK || SOCKET_ERR == WSAECONNRESET) {
+          continue; // Retry.
+        }
+#else // !_WIN32
+        if (SOCKET_ERR == EAGAIN || SOCKET_ERR == EWOULDBLOCK || SOCKET_ERR == ECONNABORTED) {
+          continue; // Retry.
+        }
+#endif // !_WIN32
+      }
+
+      break; // Stop trying to accept a new connection.
+    }
 
     // After resuming check if we should wait for gc (or if we are aborted).
     execHandle->setState(ExecState::Running);
@@ -203,6 +224,8 @@ public:
     if (!SOCKET_VALID(sock)) {
       return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Connection, sock, SOCKET_ERR);
     }
+
+    configureSocket(sock);
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Connection, sock);
   }
 
@@ -218,12 +241,30 @@ private:
       Ref{getKind()}, m_type{type}, m_socket{sock}, m_err{err} {}
 };
 
+inline auto configureSocket(SOCKET sock) noexcept -> void {
+  // Allow reusing the address, allows stopping and restarting the server without waiting for the
+  // socket's wait-time to expire.
+  int optVal = 1;
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&optVal), sizeof(int));
+
+  // Configure the receive timeout;
+#if defined(_WIN32)
+  int timeout = receiveTimeoutSeconds * 1'000;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char*>(&timeout), sizeof(timeout));
+#else // !_WIN32
+  auto timeout = timeval{};
+  timeout.tv_sec = receiveTimeoutSeconds;
+  timeout.tv_usec = 0;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char*>(&timeout), sizeof(timeout));
+#endif // !_WIN32
+}
+
 inline auto tcpOpenConnection(
     const Settings& settings,
     ExecutorHandle* execHandle,
     RefAllocator* alloc,
     StringRef* address,
-    int32_t port) -> TcpStreamRef* {
+    int32_t port) noexcept -> TcpStreamRef* {
 
   if (!settings.socketsEnabled) {
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Connection, INVALID_SOCKET);
@@ -239,6 +280,8 @@ inline auto tcpOpenConnection(
   if (!SOCKET_VALID(sock)) {
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Connection, sock, SOCKET_ERR);
   }
+
+  configureSocket(sock);
 
   sockaddr_in addr = {};
   addr.sin_family  = AF_INET;
@@ -269,8 +312,8 @@ inline auto tcpOpenConnection(
   return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Connection, sock);
 }
 
-inline auto
-tcpStartServer(const Settings& settings, RefAllocator* alloc, int32_t port, int32_t backlog)
+inline auto tcpStartServer(
+    const Settings& settings, RefAllocator* alloc, int32_t port, int32_t backlog) noexcept
     -> TcpStreamRef* {
 
   if (!settings.socketsEnabled) {
@@ -278,7 +321,7 @@ tcpStartServer(const Settings& settings, RefAllocator* alloc, int32_t port, int3
   }
 
   if (port < 0 || port > std::numeric_limits<uint16_t>::max()) {
-    // TODO: Add error code that user code call query.
+    // TODO: Add error code that user code can query.
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Server, INVALID_SOCKET);
   }
 
@@ -288,11 +331,7 @@ tcpStartServer(const Settings& settings, RefAllocator* alloc, int32_t port, int3
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Server, sock, SOCKET_ERR);
   }
 
-  // Allow reusing the address, allows stopping and restarting the server without waiting for the
-  // socket's wait-time to expire.
-  int optVal = 1;
-  setsockopt(
-      sock, SOL_SOCKET, SO_REUSEADDR, static_cast<char*>(static_cast<void*>(&optVal)), sizeof(int));
+  configureSocket(sock);
 
   // Bind the socket to any ip address at the given port.
   sockaddr_in addr;
@@ -313,8 +352,10 @@ tcpStartServer(const Settings& settings, RefAllocator* alloc, int32_t port, int3
 }
 
 inline auto tcpAcceptConnection(
-    const Settings& settings, ExecutorHandle* execHandle, RefAllocator* alloc, Value stream)
-    -> TcpStreamRef* {
+    const Settings& settings,
+    ExecutorHandle* execHandle,
+    RefAllocator* alloc,
+    Value stream) noexcept -> TcpStreamRef* {
 
   if (!settings.socketsEnabled) {
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Connection, INVALID_SOCKET);
@@ -334,8 +375,10 @@ inline auto tcpAcceptConnection(
 }
 
 inline auto ipLookupAddress(
-    const Settings& settings, ExecutorHandle* execHandle, RefAllocator* alloc, StringRef* hostName)
-    -> StringRef* {
+    const Settings& settings,
+    ExecutorHandle* execHandle,
+    RefAllocator* alloc,
+    StringRef* hostName) noexcept -> StringRef* {
 
   if (!settings.socketsEnabled) {
     return alloc->allocStr(0);
@@ -369,18 +412,16 @@ inline auto ipLookupAddress(
   // Note: 'getaddrinfo' returns a linked list of addresses sorted by priority, atm we just use the
   // first one.
 
-  // Note: We only request ipv4 addresses so the following code is technically not required but is
-  // slightly more correct.
   unsigned int maxSize;
   void* addr;
   switch (res->ai_family) {
   case AF_INET:
     maxSize = INET_ADDRSTRLEN;
-    addr    = &static_cast<sockaddr_in*>(static_cast<void*>(res->ai_addr))->sin_addr;
+    addr    = &reinterpret_cast<sockaddr_in*>(res->ai_addr)->sin_addr;
     break;
   case AF_INET6:
     maxSize = INET6_ADDRSTRLEN;
-    addr    = &static_cast<sockaddr_in6*>(static_cast<void*>(res->ai_addr))->sin6_addr;
+    addr    = &reinterpret_cast<sockaddr_in6*>(res->ai_addr)->sin6_addr;
     break;
   default:
     assert(false);


### PR DESCRIPTION
Changes:
* Add 15 second receive timeout (avoids 'stuck' connections).
* Expose the connection backlog setting to `std/tcp.nov`.
* Cleanup inconsistent return values of set / unset stream options (now returns `true` if the option was applied, in all other cases: returns `false`).