### PR TITLE
TcpServer refactor

### DIFF
--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -103,18 +103,19 @@ act main(int port, Content content)
   respWriter  = httpRespWriter();
   reqParser   = httpReqHeaderParser();
   handleCon   = (
-    impure lambda (TcpConnection con)
+    impure lambda (TcpConnection con, TcpServerState state)
       uptime    = timeNow() - startTime;
       variables = (
-        Variable("SERVER_UPTIME",           uptime.string())              ::
-        Variable("SERVER_DATE",             timeNow().httpDateStr())      ::
-        Variable("SERVER_PLATFORM",         getPlatform().string())       ::
-        Variable("SERVER_RUNTIME_VERSION",  getRuntimeVersion().string())
+        Variable("SERVER_UPTIME",             uptime.string())                  ::
+        Variable("SERVER_DATE",               timeNow().httpDateStr())          ::
+        Variable("SERVER_PLATFORM",           getPlatform().string())           ::
+        Variable("SERVER_RUNTIME_VERSION",    getRuntimeVersion().string())     ::
+        Variable("SERVER_CONNECTION_COUNTER", state.connectionCounter.string())
       );
       ctx       = ClientContext(content, variables, con, respWriter, reqParser);
       handleConnection(ctx)
   );
-  tcpServerLoop(IpFamily.V4, port, TcpServerLoopContext(handleCon)).failOnError();
+  tcpServer(TcpServerSettings(IpFamily.V4, port, handleCon)).failOnError();
 
   print("Server stopped")
 

--- a/examples/webserver/site/index.html
+++ b/examples/webserver/site/index.html
@@ -14,6 +14,7 @@
   <img src="win.jpg">
   <p>Running on the Novus example webserver</p>
   <p>{{SERVER_DATE}}</p>
+  <p>Visitors: {{SERVER_CONNECTION_COUNTER}}</p>
   <p>Uptime: {{SERVER_UPTIME}}</p>
   <p>Platform: {{SERVER_PLATFORM}}</p>
   <p>Runtime version: {{SERVER_RUNTIME_VERSION}}</p>

--- a/include/novasm/pcall_code.hpp
+++ b/include/novasm/pcall_code.hpp
@@ -32,8 +32,9 @@ enum class PCallCode : uint8_t {
 
   TcpOpenCon      = 40, // (int, int, string) -> (stream) Open a connect to a remote addr and port.
   TcpStartServer  = 41, // (int, int, int)    -> (stream) Start a tcp-server at port.
-  TcpAcceptCon    = 42, // ()            -> (stream) Accept a new connection from a tcp-server.
-  IpLookupAddress = 45, // (int, string) -> (string) Lookup an ip-address by host-name.
+  TcpAcceptCon    = 42, // (stream)           -> (stream) Accept a new connection from a tcp-server.
+  TcpShutdown     = 43, // (stream)           -> (int) Shutdown tcp conn or server, returns success.
+  IpLookupAddress = 45, // (int, string)      -> (string) Lookup an ip-address by host-name.
 
   ConsoleOpenStream = 50, // (int) -> (stream)  Get a stream to stdin, stdout or stderr.
 

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -148,6 +148,7 @@ enum class FuncKind {
   ActionTcpOpenCon,      // Open a tcp connection to a remote ip address and port.
   ActionTcpStartServer,  // Start a tcp server.
   ActionTcpAcceptCon,    // Accept a new connection from a tcp server stream.
+  ActionTcpShutdown,     // Shutdown a tcp connection or server.
   ActionIpLookupAddress, // Lookup an ip address by hostname for a given address family.
 
   ActionConsoleOpenStream, // Open a console stream.

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -8,22 +8,31 @@ import "std/parallel.nov"
 struct TcpConnection =
   sys_stream socket
 
-struct TcpServer =
-  int         maxBacklog,
-  sys_stream  socket,
-  int         port
+struct TcpServerState =
+  int connectionCounter
 
-struct TcpServerLoopContext =
-  action{TcpConnection, Option{Error}}  clientHandler,
-  action{bool}                          predicate
+struct TcpServerSettings =
+  IpFamily                                              family,
+  int                                                   port,
+  int                                                   maxBacklog,
+  action{TcpConnection, TcpServerState, Option{Error}}  clientHandler,
+  action{TcpServerState, bool}                          cancelPredicate
 
 // -- Constructors
 
-fun TcpServerLoopContext(action{TcpConnection, Option{Error}} clientHandler)
-  TcpServerLoopContext(
+fun TcpServerSettings(int port, action{TcpConnection, TcpServerState, Option{Error}} clientHandler)
+  TcpServerSettings(IpFamily.V4, port, clientHandler)
+
+fun TcpServerSettings(IpFamily family, int port, action{TcpConnection, TcpServerState, Option{Error}} clientHandler)
+  TcpServerSettings(family, port, 64, clientHandler)
+
+fun TcpServerSettings(IpFamily family, int port, int maxBacklog, action{TcpConnection, TcpServerState, Option{Error}} clientHandler)
+  TcpServerSettings(
+    family,
+    port,
+    maxBacklog,
     clientHandler,
-    impure lambda () !interuptIsRequested()
-  )
+    impure lambda (TcpServerState state) interuptIsRequested())
 
 // -- Connection
 
@@ -45,106 +54,73 @@ act write{T}(TcpConnection c, Writer{T} writer, T val) -> Option{Error}
 act tcpConnection(IpAddress addr) -> Either{TcpConnection, Error}
   tcpConnection(addr, 8080)
 
-act tcpConnectionAsync(IpAddress addr) -> future{Either{TcpConnection, Error}}
-  fork tcpConnection(addr)
-
 act tcpConnection(IpAddress addr, int port) -> Either{TcpConnection, Error}
   binAddr = ipBinWriter().run(addr);
   socket  = tcpOpenConnection(binAddr, IpFamily(addr).int(), port);
   if socket.streamCheckValid()  -> TcpConnection(socket)
   else                          -> Error("Failed to open connection to: '" + addr.string() + " [" + port + "]")
 
+act tcpConnectionAsync(IpAddress addr) -> future{Either{TcpConnection, Error}}
+  fork tcpConnection(addr)
+
 act tcpConnectionAsync(IpAddress addr, int port) -> future{Either{TcpConnection, Error}}
   fork tcpConnection(addr, port)
 
 // -- Server
 
-act tcpServer(IpFamily family) -> Either{TcpServer, Error}
-  tcpServer(family, 8080)
+act tcpServer(TcpServerSettings settings) -> Either{TcpServerState, Error}
+  serverSocket = tcpStartServer(settings.family.int(), settings.port, settings.maxBacklog);
+  if !serverSocket.streamCheckValid() -> Error("Failed to start tcp-server")
+  else ->
+    acceptCon = (impure lambda () -> Either{TcpConnection, Error}
+      socket = tcpAcceptConnection(serverSocket);
+      if socket.streamCheckValid()  -> TcpConnection(socket)
+      else                          -> Error("Failed to accept new connection")
+    );
+    loop = (impure lambda (
+      future{Either{TcpConnection, Error}} futureConnection,
+      List{future{Option{Error}}}          connections,
+      TcpServerState                       state)
 
-act tcpServer(IpFamily family, int port) -> Either{TcpServer, Error}
-  tcpServer(family, port, 64)
-
-act tcpServer(IpFamily family, int port, int maxBacklog) -> Either{TcpServer, Error}
-  socket = tcpStartServer(family.int(), port, maxBacklog);
-  if socket.streamCheckValid() -> TcpServer(maxBacklog, socket, port)
-  else                         -> Error("Failed to start tcp-server")
-
-act tcpAcceptConnection(TcpServer server) -> Either{TcpConnection, Error}
-  socket = tcpAcceptConnection(server.socket);
-  if socket.streamCheckValid()  -> TcpConnection(socket)
-  else                          -> Error("Failed to accept new connection")
-
-act tcpAcceptConnectionAsync(TcpServer server) -> future{Either{TcpConnection, Error}}
-  fork server.tcpAcceptConnection()
-
-act tcpServerLoop(IpFamily family, int port, TcpServerLoopContext ctx) -> Option{Error}
-  tcpServer(family, port).map(impure lambda (TcpServer svr) svr.tcpServerLoop(ctx))
-
-act tcpServerLoop(IpFamily family, int port, int maxBacklog, TcpServerLoopContext ctx) -> Option{Error}
-  tcpServer(family, port, maxBacklog).map(impure lambda (TcpServer svr) svr.tcpServerLoop(ctx))
-
-act tcpServerLoop(TcpServer svr, TcpServerLoopContext ctx) -> Option{Error}
-  loop = (impure lambda (
-    future{Either{TcpConnection, Error}} futureConnection,
-    List{future{Option{Error}}}          connections)
-
-      if futureConnection.get(milliseconds(100)) as Either{TcpConnection, Error} newConnection ->
-      (
-        if newConnection as Error          err  -> err
-        if newConnection as TcpConnection  c    ->
-          self(svr.tcpAcceptConnectionAsync(), fork ctx.clientHandler(c) :: connections)
-      )
-      else ->
-      (
-        conErrOpt = connections.map(    impure lambda (future{Option{Error}} c) c.poll().unwrap()).combine();
-        remCons   = connections.filter( impure lambda (future{Option{Error}} c) c.poll() is None);
-        if conErrOpt as Error conErr  -> conErr
-        if ctx.predicate()            -> self(futureConnection, remCons)
-        else                          -> None()
-      )
-  );
-  loop(
-    svr.tcpAcceptConnectionAsync(),
-    List{future{Option{Error}}}())
+        if futureConnection.get(milliseconds(100)) as Either{TcpConnection, Error} newConnection ->
+        (
+          if newConnection as Error          err  -> err
+          if newConnection as TcpConnection  c    ->
+            newState = TcpServerState(state.connectionCounter + 1);
+            self(fork acceptCon(), fork settings.clientHandler(c, newState) :: connections, newState)
+        )
+        else ->
+        (
+          conErrOpt = connections.map(    impure lambda (future{Option{Error}} c) c.poll().unwrap()).combine();
+          remCons   = connections.filter( impure lambda (future{Option{Error}} c) c.poll() is None);
+          if conErrOpt as Error conErr        -> conErr
+          if !settings.cancelPredicate(state) -> self(futureConnection, remCons, state)
+          else                                -> state
+        )
+    );
+    loop(fork acceptCon(), List{future{Option{Error}}}(), TcpServerState(0))
 
 // -- Tests
 
 assert(
-  tcpServer(IpFamily.V4, -1)              is Error  &&
-  tcpServer(IpFamily.V4, 65536)           is Error  &&
-  tcpServer(IpFamily.V4, intMax())        is Error  &&
-  tcpServer(IpFamily.V4, 5000, intMax())  is Error  &&
-  tcpServer(IpFamily.V6, -1)              is Error  &&
-  tcpServer(IpFamily.V6, 65536)           is Error  &&
-  tcpServer(IpFamily.V6, intMax())        is Error  &&
-  tcpServer(IpFamily.V6, 5000, intMax())  is Error
+  clientHandler = (impure lambda (TcpConnection c, TcpServerState state) Option{Error}());
+  tcpServer(TcpServerSettings(IpFamily.V4, -1, 64, clientHandler))          is Error  &&
+  tcpServer(TcpServerSettings(IpFamily.V4, 65536, 64, clientHandler))       is Error  &&
+  tcpServer(TcpServerSettings(IpFamily.V4, intMax(), 64, clientHandler))    is Error  &&
+  tcpServer(TcpServerSettings(IpFamily.V4, 5000, intMax(), clientHandler))  is Error  &&
+  tcpServer(TcpServerSettings(IpFamily.V6, -1, 64, clientHandler))          is Error  &&
+  tcpServer(TcpServerSettings(IpFamily.V6, 65536, 64, clientHandler))       is Error  &&
+  tcpServer(TcpServerSettings(IpFamily.V6, intMax(), 64, clientHandler))    is Error  &&
+  tcpServer(TcpServerSettings(IpFamily.V6, 5000, intMax(), clientHandler))  is Error
 )
 
 assert(
-  server    = tcpServer(IpFamily.V4, 5001).failOnError();
-  client    = tcpConnection(ipV4Loopback(), 5001).failOnError();
-  serverCon = server.tcpAcceptConnection().failOnError();
-
-  serverCon.write("Hello world\n").failOnError();
-  client.socket.readLine() == "Hello world"
-)
-
-assert(
-  server    = tcpServer(IpFamily.V6, 5002).failOnError();
-  client    = tcpConnection(ipV6Loopback(), 5002).failOnError();
-  serverCon = server.tcpAcceptConnection().failOnError();
-
-  serverCon.write("Hello world\n").failOnError();
-  client.socket.readLine() == "Hello world"
-)
-
-assert(
-  fork tcpServerLoop(IpFamily.V6, 5003, TcpServerLoopContext(impure lambda(TcpConnection c)
+  clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write(c.socket.readLine() + '\n')
-  ));
+  );
+  fork tcpServer(TcpServerSettings(IpFamily.V4, 5001, clientHandler));
   client = (impure lambda(string message)
-    c = tcpConnection(ipV6Loopback(), 5003).failOnError();
+    c = tcpConnection(ipV4Loopback(), 5001).failOnError();
     c.write(message + '\n').failOnError();
     c.socket.readLine()
   );
@@ -155,24 +131,50 @@ assert(
 )
 
 assert(
-  server = tcpServer(IpFamily.V6, 5004).failOnError();
-  client = tcpConnection(ipV6Loopback(), 5004).failOnError();
-
-  res = tcpServerLoop(server, TcpServerLoopContext(impure lambda(TcpConnection c)
-    Option(Error("Did not go well"))
-  ));
-  res == Error("Did not go well")
+  clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
+    c.write(c.socket.readLine() + '\n')
+  );
+  fork tcpServer(TcpServerSettings(IpFamily.V6, 5002, clientHandler));
+  client = (impure lambda(string message)
+    c = tcpConnection(ipV6Loopback(), 5002).failOnError();
+    c.write(message + '\n').failOnError();
+    c.socket.readLine()
+  );
+  parallelFor(100, impure lambda (int i)
+    msg = string("Hello from the network", i);
+    client(msg) == msg
+  ).all()
 )
 
 assert(
-  server = tcpServer(IpFamily.V6, 5005).failOnError();
-  client = tcpConnection(ipV6Loopback(), 5005).failOnError();
+  clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
+    Option(Error("Did not go well"))
+  );
+  res = fork tcpServer(TcpServerSettings(IpFamily.V6, 5003, clientHandler));
+  client = tcpConnection(ipV6Loopback(), 5003).failOnError();
+  res.get() == Error("Did not go well")
+)
 
-  clientHandler = (impure lambda (TcpConnection c)
+assert(
+  clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write("hello")
   );
-  predicate = (impure lambda ()
-    false
+  cancelPredicate = (impure lambda (TcpServerState state)
+    true
   );
-  tcpServerLoop(server, TcpServerLoopContext(clientHandler, predicate)) is None
+  tcpServer(TcpServerSettings(IpFamily.V6, 5004, 64, clientHandler, cancelPredicate)) == TcpServerState(0)
+)
+
+assert(
+  cancelPredicate = (impure lambda (TcpServerState state)
+    state.connectionCounter == 100
+  );
+  clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
+    c.write("Hello\n")
+  );
+  server = fork tcpServer(TcpServerSettings(IpFamily.V6, 5005, 64, clientHandler, cancelPredicate));
+  parallelFor(100, impure lambda (int i)
+    tcpConnection(ipV6Loopback(), 5005)
+  );
+  server.get() == TcpServerState(100)
 )

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -72,10 +72,13 @@ act tcpServer(TcpServerSettings settings) -> Either{TcpServerState, Error}
   serverSocket = tcpStartServer(settings.family.int(), settings.port, settings.maxBacklog);
   if !serverSocket.streamCheckValid() -> Error("Failed to start tcp-server")
   else ->
+    teardown = (impure lambda ()
+      serverSocket.tcpShutdown()
+    );
     acceptCon = (impure lambda () -> Either{TcpConnection, Error}
       socket = tcpAcceptConnection(serverSocket);
       if socket.streamCheckValid()  -> TcpConnection(socket)
-      else                          -> Error("Failed to accept new connection")
+      else                          -> teardown(); Error("Failed to accept new connection")
     );
     loop = (impure lambda (
       future{Either{TcpConnection, Error}} futureConnection,
@@ -84,7 +87,7 @@ act tcpServer(TcpServerSettings settings) -> Either{TcpServerState, Error}
 
         if futureConnection.get(milliseconds(100)) as Either{TcpConnection, Error} newConnection ->
         (
-          if newConnection as Error          err  -> err
+          if newConnection as Error          err  -> teardown(); err
           if newConnection as TcpConnection  c    ->
             newState = TcpServerState(state.connectionCounter + 1);
             self(fork acceptCon(), fork settings.clientHandler(c, newState) :: connections, newState)
@@ -93,9 +96,9 @@ act tcpServer(TcpServerSettings settings) -> Either{TcpServerState, Error}
         (
           conErrOpt = connections.map(    impure lambda (future{Option{Error}} c) c.poll().unwrap()).combine();
           remCons   = connections.filter( impure lambda (future{Option{Error}} c) c.poll() is None);
-          if conErrOpt as Error conErr        -> conErr
+          if conErrOpt as Error conErr        -> teardown(); conErr
           if !settings.cancelPredicate(state) -> self(futureConnection, remCons, state)
-          else                                -> state
+          else                                -> teardown(); state
         )
     );
     loop(fork acceptCon(), List{future{Option{Error}}}(), TcpServerState(0))

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -114,20 +114,20 @@ assert(
   tcpServer(TcpServerSettings(IpFamily.V6, -1, 64, clientHandler))          is Error  &&
   tcpServer(TcpServerSettings(IpFamily.V6, 65536, 64, clientHandler))       is Error  &&
   tcpServer(TcpServerSettings(IpFamily.V6, intMax(), 64, clientHandler))    is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V6, 5000, intMax(), clientHandler))  is Error
+  tcpServer(TcpServerSettings(IpFamily.V6, 5010, intMax(), clientHandler))  is Error
 )
 
 assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write(c.socket.readLine() + '\n')
   );
-  fork tcpServer(TcpServerSettings(IpFamily.V4, 5001, clientHandler));
+  fork tcpServer(TcpServerSettings(IpFamily.V4, 5011, clientHandler));
   client = (impure lambda(string message)
-    c = tcpConnection(ipV4Loopback(), 5001).failOnError();
+    c = tcpConnection(ipV4Loopback(), 5011).failOnError();
     c.write(message + '\n').failOnError();
     c.socket.readLine()
   );
-  parallelFor(100, impure lambda (int i)
+  parallelFor(25, impure lambda (int i)
     msg = string("Hello from the network", i);
     client(msg) == msg
   ).all()
@@ -137,13 +137,13 @@ assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write(c.socket.readLine() + '\n')
   );
-  fork tcpServer(TcpServerSettings(IpFamily.V6, 5002, clientHandler));
+  fork tcpServer(TcpServerSettings(IpFamily.V6, 5012, clientHandler));
   client = (impure lambda(string message)
-    c = tcpConnection(ipV6Loopback(), 5002).failOnError();
+    c = tcpConnection(ipV6Loopback(), 5012).failOnError();
     c.write(message + '\n').failOnError();
     c.socket.readLine()
   );
-  parallelFor(100, impure lambda (int i)
+  parallelFor(25, impure lambda (int i)
     msg = string("Hello from the network", i);
     client(msg) == msg
   ).all()
@@ -153,8 +153,8 @@ assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     Option(Error("Did not go well"))
   );
-  res = fork tcpServer(TcpServerSettings(IpFamily.V6, 5003, clientHandler));
-  client = tcpConnection(ipV6Loopback(), 5003).failOnError();
+  res = fork tcpServer(TcpServerSettings(IpFamily.V6, 5013, clientHandler));
+  client = tcpConnection(ipV6Loopback(), 5013).failOnError();
   res.get() == Error("Did not go well")
 )
 
@@ -165,19 +165,19 @@ assert(
   cancelPredicate = (impure lambda (TcpServerState state)
     true
   );
-  tcpServer(TcpServerSettings(IpFamily.V6, 5004, 64, clientHandler, cancelPredicate)) == TcpServerState(0)
+  tcpServer(TcpServerSettings(IpFamily.V6, 5014, 64, clientHandler, cancelPredicate)) == TcpServerState(0)
 )
 
 assert(
   cancelPredicate = (impure lambda (TcpServerState state)
-    state.connectionCounter == 100
+    state.connectionCounter == 25
   );
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write("Hello\n")
   );
-  server = fork tcpServer(TcpServerSettings(IpFamily.V6, 5005, 64, clientHandler, cancelPredicate));
-  parallelFor(100, impure lambda (int i)
-    tcpConnection(ipV6Loopback(), 5005)
+  server = fork tcpServer(TcpServerSettings(IpFamily.V6, 5015, 64, clientHandler, cancelPredicate));
+  parallelFor(25, impure lambda (int i)
+    tcpConnection(ipV6Loopback(), 5015)
   );
-  server.get() == TcpServerState(100)
+  server.get() == TcpServerState(25)
 )

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -558,6 +558,9 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::ActionTcpAcceptCon:
     m_asmb->addPCall(novasm::PCallCode::TcpAcceptCon);
     break;
+  case prog::sym::FuncKind::ActionTcpShutdown:
+    m_asmb->addPCall(novasm::PCallCode::TcpShutdown);
+    break;
   case prog::sym::FuncKind::ActionIpLookupAddress:
     m_asmb->addPCall(novasm::PCallCode::IpLookupAddress);
     break;

--- a/src/novasm/pcall_code.cpp
+++ b/src/novasm/pcall_code.cpp
@@ -65,6 +65,9 @@ auto operator<<(std::ostream& out, const PCallCode& rhs) noexcept -> std::ostrea
   case PCallCode::TcpAcceptCon:
     out << "tcp-accept-con";
     break;
+  case PCallCode::TcpShutdown:
+    out << "tcp-shutdown";
+    break;
   case PCallCode::IpLookupAddress:
     out << "ip-lookup-address";
     break;

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -323,6 +323,8 @@ Program::Program() :
   m_funcDecls.registerAction(
       *this, Fk::ActionTcpAcceptCon, "tcpAcceptConnection", sym::TypeSet{m_stream}, m_stream);
   m_funcDecls.registerAction(
+      *this, Fk::ActionTcpShutdown, "tcpShutdown", sym::TypeSet{m_stream}, m_bool);
+  m_funcDecls.registerAction(
       *this, Fk::ActionIpLookupAddress, "ipLookupAddress", sym::TypeSet{m_string, m_int}, m_string);
 
   m_funcDecls.registerAction(

--- a/src/vm/internal/pcall.hpp
+++ b/src/vm/internal/pcall.hpp
@@ -220,10 +220,13 @@ auto inline pcall(
 
     // Note: Keep the stream on the stack, reason is gc could run while we are blocked.
     auto stream  = PEEK();
-    auto* result = tcpAcceptConnection(settings, execHandle, refAlloc, stream);
+    auto* result = tcpAcceptConnection(execHandle, refAlloc, stream);
 
     POP(); // Pop the stream off the stack.
     PUSH_REF(result);
+  } break;
+  case PCallCode::TcpShutdown: {
+    PUSH_BOOL(tcpShutdown(POP()));
   } break;
   case PCallCode::IpLookupAddress: {
 

--- a/src/vm/internal/ref_stream_tcp.hpp
+++ b/src/vm/internal/ref_stream_tcp.hpp
@@ -97,8 +97,14 @@ public:
 
   auto shutdown() noexcept -> bool {
 #if defined(_WIN32)
+    switch (m_type) {
+    case TcpStreamType::Server:
+      return closesocket(m_socket) == 0;
+    case TcpStreamType::Connection:
     return ::shutdown(m_socket, SD_BOTH) == 0;
-#else  // !_WIN32
+    }
+    return false;
+#else // !_WIN32
     return ::shutdown(m_socket, SHUT_RDWR) == 0;
 #endif // !_WIN32
   }

--- a/tests/vm/io_tcp_test.cpp
+++ b/tests/vm/io_tcp_test.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Execute tcp platform-calls", "[vm]") {
 
           // Start server.
           asmb->addLoadLitInt(0);    // Address family: IpV4.
-          asmb->addLoadLitInt(8080); // Port.
+          asmb->addLoadLitInt(5000); // Port.
           asmb->addLoadLitInt(-1);   // Backlog (-1 uses the default backlog).
           asmb->addPCall(novasm::PCallCode::TcpStartServer);
           asmb->addStackStore(0); // Store the server stream.
@@ -27,7 +27,7 @@ TEST_CASE("Execute tcp platform-calls", "[vm]") {
           // Open connection to server and send message.
           asmb->addLoadLitString(loopbackAddrIpV4);
           asmb->addLoadLitInt(0);    // Address family: IpV4.
-          asmb->addLoadLitInt(8080); // Port.
+          asmb->addLoadLitInt(5000); // Port.
           asmb->addPCall(novasm::PCallCode::TcpOpenCon);
           asmb->addLoadLitString("Hello world");
           asmb->addPCall(novasm::PCallCode::StreamWriteString);
@@ -56,7 +56,7 @@ TEST_CASE("Execute tcp platform-calls", "[vm]") {
 
           // Start server.
           asmb->addLoadLitInt(1);    // Address family: IpV6.
-          asmb->addLoadLitInt(8080); // Port.
+          asmb->addLoadLitInt(5001); // Port.
           asmb->addLoadLitInt(-1);   // Backlog (-1 uses the default backlog).
           asmb->addPCall(novasm::PCallCode::TcpStartServer);
           asmb->addStackStore(0); // Store the server stream.
@@ -64,7 +64,7 @@ TEST_CASE("Execute tcp platform-calls", "[vm]") {
           // Open connection to server and send message.
           asmb->addLoadLitString(loopbackAddrIpV6);
           asmb->addLoadLitInt(1);    // Address family: IpV6.
-          asmb->addLoadLitInt(8080); // Port.
+          asmb->addLoadLitInt(5001); // Port.
           asmb->addPCall(novasm::PCallCode::TcpOpenCon);
           asmb->addLoadLitString("Hello world");
           asmb->addPCall(novasm::PCallCode::StreamWriteString);
@@ -84,38 +84,43 @@ TEST_CASE("Execute tcp platform-calls", "[vm]") {
         "Hello world");
   }
 
-  SECTION("Second accept-connection call fails") {
+  SECTION("Server shutdown cancels open-connection request") {
     CHECK_PROG(
         [&](novasm::Assembler* asmb) -> void {
           asmb->setEntrypoint("entry");
 
           // --- Main function start.
           asmb->label("entry");
+          asmb->addStackAlloc(2);
 
           // Start server.
           asmb->addLoadLitInt(0);    // Address family: IpV4.
-          asmb->addLoadLitInt(8080); // Port.
+          asmb->addLoadLitInt(5002); // Port.
           asmb->addLoadLitInt(-1);   // Backlog (-1 uses the default backlog).
           asmb->addPCall(novasm::PCallCode::TcpStartServer);
-          asmb->addDup(); // Place the server twice on the stack.
+          asmb->addStackStore(0); // Place the server on the stack at slot 0.
 
           // Start a background worker that accepts a client connection.
+          asmb->addStackLoad(0);
           asmb->addCall("worker", 1, novasm::CallMode::Forked);
+          asmb->addStackStore(1); // Place the future on the stack at slot 1.
 
           // Sleep for 100 milli-seconds to give the worker time to start.
           asmb->addLoadLitLong(100'000'000);
           asmb->addPCall(novasm::PCallCode::SleepNano);
           asmb->addPop(); // Ignore the return value of sleep.
 
-          // Attemp to accept a new connection (while the background-worker is still accepting a
-          // connection).
-          asmb->addPCall(novasm::PCallCode::TcpAcceptCon);
+          // Shutdown the server.
+          asmb->addStackLoad(0);
+          asmb->addPCall(novasm::PCallCode::TcpShutdown);
 
-          // And assert that it fails.
-          asmb->addPCall(novasm::PCallCode::StreamCheckValid);
-          asmb->addLogicInvInt();
-          asmb->addLoadLitString("Expected second accept-connection to fail");
+          // Assert that the shutdown completed successfully.
+          asmb->addLoadLitString("Shutdown failed");
           asmb->addPCall(novasm::PCallCode::Assert);
+
+          // Wait on the worker to finnish.
+          asmb->addStackLoad(1);
+          asmb->addFutureBlock();
 
           asmb->addRet();
           // --- Main function end.
@@ -124,6 +129,71 @@ TEST_CASE("Execute tcp platform-calls", "[vm]") {
           asmb->label("worker");
           asmb->addStackLoad(0); // Load arg 0.
           asmb->addPCall(novasm::PCallCode::TcpAcceptCon);
+          asmb->addRet();
+          // --- Worker function end.
+        },
+        "input",
+        "");
+  }
+
+  SECTION("Server shutdown cancels read request") {
+    CHECK_PROG(
+        [&](novasm::Assembler* asmb) -> void {
+          asmb->setEntrypoint("entry");
+
+          // --- Main function start.
+          asmb->label("entry");
+          asmb->addStackAlloc(2);
+
+          // Start server.
+          asmb->addLoadLitInt(0);    // Address family: IpV4.
+          asmb->addLoadLitInt(5003); // Port.
+          asmb->addLoadLitInt(-1);   // Backlog (-1 uses the default backlog).
+          asmb->addPCall(novasm::PCallCode::TcpStartServer);
+          asmb->addStackStore(0); // Store the server stream.
+
+          // Open connection to server and send message.
+          asmb->addLoadLitString(loopbackAddrIpV4);
+          asmb->addLoadLitInt(0);    // Address family: IpV4.
+          asmb->addLoadLitInt(5003); // Port.
+          asmb->addPCall(novasm::PCallCode::TcpOpenCon);
+          asmb->addPop(); // Ignore the stream to the opened connection.
+
+          // Accept the connection on the server.
+          asmb->addStackLoad(0);
+          asmb->addPCall(novasm::PCallCode::TcpAcceptCon);
+
+          // Start a background worker that will read a message.
+          asmb->addCall("worker", 1, novasm::CallMode::Forked);
+          asmb->addStackStore(1); // Place the future on the stack at slot 1.
+
+          // Sleep for 100 milli-seconds to give the worker time to start.
+          asmb->addLoadLitLong(100'000'000);
+          asmb->addPCall(novasm::PCallCode::SleepNano);
+          asmb->addPop(); // Ignore the return value of sleep.
+
+          // Shutdown the server.
+          asmb->addStackLoad(0);
+          asmb->addPCall(novasm::PCallCode::TcpShutdown);
+
+          // Assert that the shutdown completed successfully.
+          asmb->addLoadLitString("Shutdown failed");
+          asmb->addPCall(novasm::PCallCode::Assert);
+
+          // Wait on the worker to finnish.
+          asmb->addStackLoad(1);
+          asmb->addFutureBlock();
+
+          // Print the received message (should be empty).
+          ADD_PRINT(asmb);
+          asmb->addRet();
+          // --- Main function end.
+
+          // --- Worker function start (takes one stream arg and read a message).
+          asmb->label("worker");
+          asmb->addStackLoad(0);    // Load arg 0.
+          asmb->addLoadLitInt(512); // Max message size.
+          asmb->addPCall(novasm::PCallCode::StreamReadString);
           asmb->addRet();
           // --- Worker function end.
         },


### PR DESCRIPTION
Changes:
* Remove the tcp-server type (Was too hard to use standalone)
* Combine all server settings in `TcpServerSettings`.
* Keep track of a connection counter.
* Support properly shutting down tcp servers.