### PR TITLE
Fix vm crash on abort

### DIFF
--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -889,9 +889,8 @@ End:
   // If we are backing a promise then fill-in the results and notify all waiters.
   auto endState = execHandle.getState(std::memory_order_relaxed);
 
-  // Note: During program shutdown thread can still be inside blocking system calls, when they
-  // return (and notice that they have been aborted) it is not safe to touch any memory outside
-  // their own stack.
+  // NOTE: When an executor is aborted it is unsafe to access any memory that is not local to the
+  // executor. So the registry and any references are off limits.
   if (endState == ExecState::Aborted) {
     return ExecState::Aborted;
   }
@@ -900,8 +899,8 @@ End:
     if (endState == ExecState::Success) {
       promise->setResult(POP());
     }
-      promise->setState(endState);
-    }
+    promise->setState(endState);
+  }
   execRegistry->unregisterExecutor(&execHandle);
   return endState;
 

--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -900,12 +900,8 @@ End:
     if (endState == ExecState::Success) {
       promise->setResult(POP());
     }
-    {
-      auto lk = std::lock_guard<std::mutex>{promise->getMutex()};
       promise->setState(endState);
     }
-    promise->getCondVar().notify_all();
-  }
   execRegistry->unregisterExecutor(&execHandle);
   return endState;
 

--- a/src/vm/internal/executor_handle.hpp
+++ b/src/vm/internal/executor_handle.hpp
@@ -91,11 +91,13 @@ public:
     return false;
   }
 
-  // Request the executor to abort. Returns immediately with a boolean indicating if the executor
-  // has aborted yet. Common pattern is to keep calling this function until true is returned.
-  inline auto requestAbort() noexcept -> bool {
+  // Request the executor to abort.
+  // NOTE: After requesting an abort it is unsafe to access the executor_handle anymore, as it can
+  // destroy itself at any point after that.
+  // NOTE: An aborted executor will NOT unregister itself anymore from the registry upon shutdown,
+  // it is up to the caller to unregister it.
+  inline auto requestAbort() noexcept {
     m_request.store(RequestType::Abort, std::memory_order_release);
-    return m_state.load(std::memory_order_acquire) != ExecState::Running;
   }
 
   // Request the executor to pause. Returns immediately with a boolean indicating if the executor

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -96,11 +96,13 @@ auto run(const novasm::Assembly* assembly, PlatformInterface* iface) noexcept ->
       nullptr,
       nullptr);
 
-  // Abort all executors that are still running.
-  execRegistry.abortExecutors();
-
   // Terminate the garbage-collector (finishes any ongoing collections).
   gc.terminateCollector();
+
+  // Abort all executors that are still running.
+  // NOTE: First terminate the garbage collector as that might attempt to pause / resume executors
+  // while we are trying to abort them.
+  execRegistry.abortExecutors();
 
   teardown(&settings);
 


### PR DESCRIPTION
Fixes two separate issues:
* Potential use-after-free in ref_future when its destructed when other threads are still waiting on it.
* ExecutorRegistry potentially accessing an already aborted executor,