### PR TITLE
LibFuzzer based lexer and parser fuzz tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,25 @@ jobs:
         sudo ln -s /usr/bin/llvm-profdata-10 /usr/bin/llvm-profdata
 
     - name: configure
-      run: ./scripts/configure.sh --type Debug --sanitize --coverage --tests --lint
+      run: ./scripts/configure.sh --type Debug --sanitize --coverage --tests --fuzz --lint
 
     - name: build
       run: ./scripts/build.sh
 
     - name: test
       run: ./scripts/test.sh
+
+    - name: fuzz-corpus-cache
+      uses: actions/cache@v2
+      with:
+        path: ./fuzz/corpus
+        key: fuzz-corpus
+
+    - name: fuzz-lex
+      run: ./scripts/fuzz.sh --path bin/novfuzz-lex --duration 60
+
+    - name: fuzz-parse
+      run: ./scripts/fuzz.sh --path bin/novfuzz-parse --duration 60
 
     - name: upload-coverage
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /compile_commands.json
 /test_coverage.lcov
 
+# Logs
+/*.log
+
 # User settings (Except portable common settings).
 /.vscode/*
 !/.vscode/settings.json
@@ -21,3 +24,14 @@
 # Ide caches.
 /.clangd/index/*
 /.cache/
+
+# Coverage files
+**/*.profraw
+**/*.profdata
+
+# Analyzer crash reports
+/crash-*
+
+# Fuzz corpus
+/fuzz/corpus
+/fuzz_rawcoverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(
 
 # Custom options options.
 set(BUILD_TESTING "Off" CACHE BOOL "Should test targets be build")
+set(BUILD_FUZZING "Off" CACHE BOOL "Should fuzzing targets be build")
 set(LINTING       "Off" CACHE BOOL "Should source linting be enabled")
 set(SANITIZE      "Off" CACHE BOOL "Should santiser instrumentation be included in targets")
 set(COVERAGE      "Off" CACHE BOOL "Should coverage instrumentation be included in targets")
@@ -18,6 +19,7 @@ message(STATUS "* Host processor: ${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS "* CMake version: ${CMAKE_VERSION}")
 message(STATUS "* Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "* Build tests: ${BUILD_TESTING}")
+message(STATUS "* Build fuzzing: ${BUILD_FUZZING}")
 message(STATUS "* Linting: ${LINTING}")
 message(STATUS "* Sanitize: ${SANITIZE}")
 message(STATUS "* Coverage: ${COVERAGE}")
@@ -127,6 +129,10 @@ add_subdirectory(apps)
 
 if(BUILD_TESTING)
   add_subdirectory(tests)
+endif()
+
+if(BUILD_FUZZING)
+  add_subdirectory(fuzz)
 endif()
 
 add_subdirectory(novstd)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Configure fuzz executables using llvm libfuzzer (https://llvm.org/docs/LibFuzzer.html).
+
+if(NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+  message(FATAL_ERROR "Fuzzing is only supported with the clang compiler")
+endif()
+
+# 'novfuzz-lex' executable.
+message(STATUS "Configuring novfuzz-lex executable")
+add_executable(novfuzz-lex fuzz_lex.cpp)
+target_compile_features(novfuzz-lex PUBLIC cxx_std_17)
+target_compile_options(novfuzz-lex PUBLIC -g -fexceptions -fsanitize=fuzzer)
+target_link_options(novfuzz-lex PUBLIC -fsanitize=fuzzer)
+target_link_libraries(novfuzz-lex PRIVATE lex)
+
+# 'novfuzz-parse' executable.
+message(STATUS "Configuring novfuzz-parse executable")
+add_executable(novfuzz-parse fuzz_parse.cpp)
+target_compile_features(novfuzz-parse PUBLIC cxx_std_17)
+target_compile_options(novfuzz-parse PUBLIC -g -fexceptions -fsanitize=fuzzer)
+target_link_options(novfuzz-parse PUBLIC -fsanitize=fuzzer)
+target_link_libraries(novfuzz-parse PRIVATE parse)

--- a/fuzz/fuzz_lex.cpp
+++ b/fuzz/fuzz_lex.cpp
@@ -1,0 +1,11 @@
+#include "lex/lexer.hpp"
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) -> int {
+  static_assert(sizeof(uint8_t) == sizeof(char), "Unexpected char size");
+
+  const char* inputBegin = reinterpret_cast<const char*>(data);
+  const char* inputEnd   = inputBegin + size;
+
+  lex::lexAll(inputBegin, inputEnd);
+  return 0;
+}

--- a/fuzz/fuzz_parse.cpp
+++ b/fuzz/fuzz_parse.cpp
@@ -1,0 +1,96 @@
+#include "lex/token_itr.hpp"
+#include "parse/parser.hpp"
+#include <array>
+
+namespace {
+
+const std::array<lex::Token, 65> fuzzTokens = {
+    lex::basicToken(lex::TokenKind::OpPlus),
+    lex::basicToken(lex::TokenKind::OpPlusPlus),
+    lex::basicToken(lex::TokenKind::OpMinus),
+    lex::basicToken(lex::TokenKind::OpMinusMinus),
+    lex::basicToken(lex::TokenKind::OpStar),
+    lex::basicToken(lex::TokenKind::OpSlash),
+    lex::basicToken(lex::TokenKind::OpRem),
+    lex::basicToken(lex::TokenKind::OpAmp),
+    lex::basicToken(lex::TokenKind::OpAmpAmp),
+    lex::basicToken(lex::TokenKind::OpPipe),
+    lex::basicToken(lex::TokenKind::OpPipePipe),
+    lex::basicToken(lex::TokenKind::OpHat),
+    lex::basicToken(lex::TokenKind::OpTilde),
+    lex::basicToken(lex::TokenKind::OpShiftL),
+    lex::basicToken(lex::TokenKind::OpShiftR),
+    lex::basicToken(lex::TokenKind::OpEq),
+    lex::basicToken(lex::TokenKind::OpEqEq),
+    lex::basicToken(lex::TokenKind::OpBang),
+    lex::basicToken(lex::TokenKind::OpBangBang),
+    lex::basicToken(lex::TokenKind::OpBangEq),
+    lex::basicToken(lex::TokenKind::OpLe),
+    lex::basicToken(lex::TokenKind::OpLeEq),
+    lex::basicToken(lex::TokenKind::OpGt),
+    lex::basicToken(lex::TokenKind::OpGtEq),
+    lex::basicToken(lex::TokenKind::OpSemi),
+    lex::basicToken(lex::TokenKind::OpQMark),
+    lex::basicToken(lex::TokenKind::OpQMarkQMark),
+    lex::basicToken(lex::TokenKind::OpDot),
+    lex::basicToken(lex::TokenKind::OpColonColon),
+    lex::basicToken(lex::TokenKind::OpSquareSquare),
+    lex::basicToken(lex::TokenKind::OpParenParen),
+    lex::basicToken(lex::TokenKind::SepOpenParen),
+    lex::basicToken(lex::TokenKind::SepCloseParen),
+    lex::basicToken(lex::TokenKind::SepOpenCurly),
+    lex::basicToken(lex::TokenKind::SepCloseCurly),
+    lex::basicToken(lex::TokenKind::SepOpenSquare),
+    lex::basicToken(lex::TokenKind::SepCloseSquare),
+    lex::basicToken(lex::TokenKind::SepComma),
+    lex::basicToken(lex::TokenKind::SepColon),
+    lex::basicToken(lex::TokenKind::SepArrow),
+    lex::litIntToken(42),
+    lex::litLongToken(42L),
+    lex::litFloatToken(42.0),
+    lex::litBoolToken(false),
+    lex::litStrToken("Hello World"),
+    lex::litCharToken('!'),
+    lex::keywordToken(lex::Keyword::Import),
+    lex::keywordToken(lex::Keyword::Fun),
+    lex::keywordToken(lex::Keyword::Act),
+    lex::keywordToken(lex::Keyword::Self),
+    lex::keywordToken(lex::Keyword::Lambda),
+    lex::keywordToken(lex::Keyword::Impure),
+    lex::keywordToken(lex::Keyword::Fork),
+    lex::keywordToken(lex::Keyword::Lazy),
+    lex::keywordToken(lex::Keyword::Struct),
+    lex::keywordToken(lex::Keyword::Union),
+    lex::keywordToken(lex::Keyword::Enum),
+    lex::keywordToken(lex::Keyword::If),
+    lex::keywordToken(lex::Keyword::Else),
+    lex::keywordToken(lex::Keyword::Is),
+    lex::keywordToken(lex::Keyword::As),
+    lex::identiferToken("Fuzz identifier"),
+    lex::lineCommentToken("Hello World"),
+    lex::basicToken(lex::TokenKind::Discard),
+    lex::errorToken("Fuzz error token"),
+};
+
+class TokenItr final : public lex::TokenItrTraits {
+public:
+  TokenItr(const uint8_t* fuzzPtr) : m_fuzzPtr{fuzzPtr} {}
+
+  auto operator*() -> lex::Token { return fuzzTokens[*m_fuzzPtr % fuzzTokens.size()]; }
+
+  auto operator==(const TokenItr& rhs) noexcept { return m_fuzzPtr == rhs.m_fuzzPtr; }
+
+  auto operator!=(const TokenItr& rhs) noexcept { return m_fuzzPtr != rhs.m_fuzzPtr; }
+
+  auto operator++() { ++m_fuzzPtr; }
+
+private:
+  const uint8_t* m_fuzzPtr;
+};
+
+} // namespace
+
+extern "C" auto LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) -> int {
+  parse::parseAll(TokenItr{data}, TokenItr{data + size});
+  return 0;
+}

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -11,6 +11,8 @@ namespace parse {
 
 [[nodiscard]] auto errLexError(lex::Token errToken) -> NodePtr;
 
+[[nodiscard]] auto errMaxExprRecursionDepthReached(lex::Token token) -> NodePtr;
+
 [[nodiscard]] auto errInvalidStmtImport(lex::Token kw, lex::Token path) -> NodePtr;
 
 [[nodiscard]] auto errInvalidStmtFuncDecl(

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -14,7 +14,8 @@ namespace internal {
 
 class ParserImpl {
 protected:
-  ParserImpl() : m_readBuffer{} {}
+  ParserImpl() noexcept : m_readBuffer{}, m_exprRecursionDepth{0} {}
+  ~ParserImpl() noexcept;
 
   auto next() -> NodePtr;
   auto nextStmt() -> NodePtr;
@@ -22,6 +23,7 @@ protected:
 
 private:
   std::deque<lex::Token> m_readBuffer;
+  size_t m_exprRecursionDepth;
 
   auto nextComment() -> NodePtr;
   auto nextImport() -> NodePtr;

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -74,7 +74,7 @@ class Parser final : private internal::ParserImpl {
 public:
   Parser() = delete;
   Parser(InputItrBegin inputBegin, const InputItrEnd inputEnd) :
-      m_input{inputBegin}, m_inputEnd(inputEnd) {}
+      m_input{inputBegin}, m_inputEnd{inputEnd}, m_lastTokenSpan{input::Span{0}} {}
 
   [[nodiscard]] auto next() -> NodePtr { return internal::ParserImpl::next(); }
 
@@ -89,13 +89,15 @@ public:
 private:
   InputItrBegin m_input;
   const InputItrEnd m_inputEnd;
+  input::Span m_lastTokenSpan;
 
   auto getFromInput() -> lex::Token override {
     if (m_input == m_inputEnd) {
-      return *m_input;
+      return lex::endToken(m_lastTokenSpan);
     }
     auto val = *m_input;
     ++m_input;
+    m_lastTokenSpan = val.getSpan();
     return val;
   }
 };

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -112,6 +112,5 @@ do
   esac
 done
 
-# Run build.
 buildProj "${numThreads}" "${buildDir}"
 exit 0

--- a/scripts/configure.ps1
+++ b/scripts/configure.ps1
@@ -19,6 +19,8 @@
   Build directory.
 .PARAMETER Tests
   Include compiler and runtime tests.
+.PARAMETER Fuzz
+  Include fuzz targets
 .PARAMETER Lint
   Enable source linter.
 .PARAMETER Sanitize
@@ -34,6 +36,7 @@ param(
   [string]$Gen = "MinGW",
   [string]$Dir = "build",
   [switch]$Tests,
+  [switch]$Fuzz,
   [switch]$Lint,
   [switch]$Sanitize,
   [switch]$Coverage
@@ -68,6 +71,7 @@ function ConfigureProj(
   [string] $gen,
   [string] $dir,
   [bool] $tests,
+  [bool] $fuzz,
   [bool] $lint,
   [bool] $sanitize,
   [bool] $coverage) {
@@ -92,6 +96,7 @@ function ConfigureProj(
     -G "$(MapToCMakeGen $gen)" `
     -DCMAKE_BUILD_TYPE="$type" `
     -DBUILD_TESTING="$($tests ? "On" : "Off")" `
+    -DBUILD_FUZZING="$($fuzz ? "On" : "Off")" `
     -DLINTING="$($lint ? "On" : "Off")" `
     -DSANITIZE="$($sanitize ? "On" : "Off")" `
     -DCOVERAGE="$($coverage ? "On" : "Off")"
@@ -104,5 +109,5 @@ function ConfigureProj(
 }
 
 # Run configuration.
-ConfigureProj $Type $Gen $Dir $Tests $Lint $Sanitize $Coverage
+ConfigureProj $Type $Gen $Dir $Tests $Fuzz $Lint $Sanitize $Coverage
 exit 0

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -53,12 +53,14 @@ configureProj()
   local type="${1}"
   local dir="${2}"
   local testsMode="${3}"
-  local lintMode="${4}"
-  local sanitizeMode="${5}"
-  local coverageMode="${6}"
+  local fuzzMode="${4}"
+  local lintMode="${5}"
+  local sanitizeMode="${6}"
+  local coverageMode="${7}"
 
   verifyBuildTypeOption "${type}"
   verifyBoolOption "${testsMode}"
+  verifyBoolOption "${fuzzMode}"
   verifyBoolOption "${lintMode}"
   verifyBoolOption "${sanitizeMode}"
   verifyBoolOption "${coverageMode}"
@@ -75,6 +77,7 @@ configureProj()
     -G "Unix Makefiles" \
     -DCMAKE_BUILD_TYPE="${type}" \
     -DBUILD_TESTING="${testsMode}" \
+    -DBUILD_FUZZING="${fuzzMode}" \
     -DLINTING="${lintMode}" \
     -DSANITIZE="${sanitizeMode}" \
     -DCOVERAGE="${coverageMode}"
@@ -89,6 +92,7 @@ printUsage()
   echo "-t,--type     Build type, options: Debug, Release (default)"
   echo "-d,--dir      Build directory, default: 'build'"
   echo "--tests       Include compiler and runtime tests"
+  echo "--fuzz        Include fuzz targets"
   echo "--lint        Enable source linter"
   echo "--sanitize    Should santiser instrumentation be included in targets"
   echo "--coverage    Should coverage instrumentation be included in targets"
@@ -98,6 +102,7 @@ printUsage()
 buildType="Release"
 buildDir="build"
 testsMode="Off"
+fuzzMode="Off"
 lintMode="Off"
 sanitizeMode="Off"
 coverageMode="Off"
@@ -123,6 +128,10 @@ do
       testsMode="On"
       shift 1
       ;;
+    --fuzz)
+      fuzzMode="On"
+      shift 1
+      ;;
     --lint)
       lintMode="On"
       shift 1
@@ -143,11 +152,11 @@ do
   esac
 done
 
-# Run configuration.
 configureProj \
   "${buildType}" \
   "${buildDir}" \
   "${testsMode}" \
+  "${fuzzMode}" \
   "${lintMode}" \
   "${sanitizeMode}" \
   "${coverageMode}"

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -53,6 +53,7 @@ fuzz()
   "${executablePath}" "${corpusPath}" \
     -max_total_time=${duration} \
     -jobs=${numJobs} \
+    -workers=${numJobs} \
     -print_final_stats=1 \
     -print_pcs=1
 

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+# --------------------------------------------------------------------------------------------------
+# Run a fuzz executable.
+# --------------------------------------------------------------------------------------------------
+
+info()
+{
+  echo "${1}"
+}
+
+error()
+{
+  echo "ERROR: ${1}" >&2
+}
+
+fail()
+{
+  error "${1}"
+  exit 1
+}
+
+hasCommand()
+{
+  [ -x "$(command -v "${1}")" ]
+}
+
+fuzz()
+{
+  local executablePath="${1}"
+  local corpusPath="${2}"
+  local duration="${3}"
+  local numJobs="${4}"
+  local rawCoverageDir="$(pwd)/fuzz_rawcoverage/"
+  local indexedCoveragePath="$(pwd)/fuzz_coverage.profdata"
+
+  test -f "${executablePath}" || fail "No fuzz executable found at path '${executablePath}'"
+
+  if test -z "${corpusPath}"
+  then
+    local corpusPath="$(pwd)/fuzz/corpus/$(basename ${executablePath})"
+  fi
+
+  mkdir -p "${corpusPath}"                            # Create the corpus directory if its missing.
+  rm -rf "${rawCoverageDir}" "${indexedCoveragePath}" # Remove previous coverage outputs (if they exist).
+  rm -f fuzz-*.log                                    # Remove any old fuzz logs.
+
+  info "Begin fuzzing for '${duration}' seconds"
+
+  # Run fuzz executable
+  LLVM_PROFILE_FILE="${rawCoverageDir}/%p.profraw" \
+  "${executablePath}" "${corpusPath}" \
+    -max_total_time=${duration} \
+    -jobs=${numJobs} \
+    -print_final_stats=1 \
+    -print_pcs=1
+
+  info "Finished fuzzing"
+
+  if test -d ${rawCoverageDir}
+  then
+    info "Found raw coverage data, indexing..."
+    hasCommand llvm-profdata || fail "'llvm-profdata' not found on path, it is required to create coverage data"
+    hasCommand llvm-cov || fail "'llvm-cov' not found on path, it is required to create coverage reports"
+
+    llvm-profdata merge -sparse "${rawCoverageDir}"/* -o "${indexedCoveragePath}"
+    info "Coverage data indexed, printing report:"
+    llvm-cov report "${executablePath}" "-instr-profile=${indexedCoveragePath}"
+  fi
+}
+
+printUsage()
+{
+  echo "Options:"
+  echo "-h,--help       Print this usage information"
+  echo "-p,--path       Path to fuzz executable"
+  echo "-c,--corpus     Path to the corpus to use, default: 'fuzz/corpus/{EXE_NAME}'"
+  echo "-d,--duration   Duration to run the fuzzer in seconds, default: '60'"
+  echo "-j,--jobs       Number of fuzz jobs to run, default: '2'"
+}
+
+# Defaults.
+duration="60"
+numJob="2"
+
+# Parse options.
+while [[ $# -gt 0 ]]
+do
+  case "${1}" in
+    -h|--help)
+      echo "Novus -- Fuzz"
+      printUsage
+      exit 0
+      ;;
+    -p|--path)
+      executablePath="${2}"
+      shift 2
+      ;;
+    -c|--corpus)
+      corpusPath="${2}"
+      shift 2
+      ;;
+    -d|--duration)
+      duration="${2}"
+      shift 2
+      ;;
+    -j|--jobs)
+      numJob="${2}"
+      shift 2
+      ;;
+    *)
+      error "Unknown option '${1}'"
+      printUsage
+      exit 1
+      ;;
+  esac
+done
+
+! test -z "${executablePath}" || fail "Provide a path to an fuzz executable using the '--path' parameter"
+
+fuzz "${executablePath}" "${corpusPath}" "${duration}" "${numJob}"
+exit 0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -32,7 +32,7 @@ testProj()
   local coverageExecutable="${2}"
   local coverageIgnoreRegex="${3}"
   local coverageReportPath="${4}"
-  local rawCoverageDir="$(pwd)/${dir}/tests/raw_coverage/"
+  local rawCoverageDir="$(pwd)/${dir}/tests/test_rawcoverage/"
   local indexedCoveragePath="$(pwd)/${dir}/tests/test_coverage.profdata"
 
   # Verify build directory exists.
@@ -58,11 +58,10 @@ testProj()
 
   if test -d ${rawCoverageDir}
   then
-    info "Found raw coverage data"
+    info "Found raw coverage data, indexing..."
     hasCommand llvm-profdata || fail "'llvm-profdata' not found on path, it is required to create coverage data"
     hasCommand llvm-cov || fail "'llvm-cov' not found on path, it is required to create coverage reports"
 
-    info "Indexing coverage profile"
     llvm-profdata merge -sparse "${rawCoverageDir}"/* -o "${indexedCoveragePath}"
     info "Generating coverage report"
     llvm-cov export "${coverageExecutable}" \
@@ -122,6 +121,5 @@ do
   esac
 done
 
-# Run test.
 testProj "${buildDir}" "${coverageExecutable}" "${coverageIgnoreRegex}" "${coverageReportPath}"
 exit 0

--- a/src/lex/token.cpp
+++ b/src/lex/token.cpp
@@ -23,7 +23,7 @@ Token::Token(const TokenKind kind, std::unique_ptr<TokenPayload> payload, const 
 
 Token::Token(const Token& rhs) :
     m_kind{rhs.m_kind},
-    m_payload{!rhs.m_payload ? nullptr : rhs.m_payload->clone()},
+    m_payload{rhs.m_payload ? rhs.m_payload->clone() : nullptr},
     m_span{rhs.m_span} {}
 
 Token::Token(Token&& rhs) noexcept :

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -16,6 +16,12 @@ auto errLexError(lex::Token errToken) -> NodePtr {
   return errorNode(msg, std::move(errToken));
 }
 
+auto errMaxExprRecursionDepthReached(lex::Token token) -> NodePtr {
+  std::ostringstream oss;
+  oss << "Maximum expression recursion depth reached, token: '" << token << '\'';
+  return errorNode(oss.str(), std::move(token));
+}
+
 static auto addTokens(const TypeParamList& paramList, std::vector<lex::Token>* tokens) -> void {
   tokens->push_back(paramList.getOpen());
   for (const auto& type : paramList.getTypes()) {

--- a/src/vm/internal/executor_registry.hpp
+++ b/src/vm/internal/executor_registry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "internal/executor_handle.hpp"
 #include "internal/stack.hpp"
+#include <atomic>
 #include <mutex>
 
 namespace vm::internal {
@@ -16,7 +17,19 @@ public:
   auto operator=(const ExecutorRegistry& rhs) -> ExecutorRegistry& = delete;
   auto operator=(ExecutorRegistry&& rhs) -> ExecutorRegistry& = delete;
 
-  [[nodiscard]] inline auto getHeadExecutor() noexcept -> ExecutorHandle* { return m_head; }
+  [[nodiscard]] auto getHeadExecutor() noexcept -> ExecutorHandle* { return m_head; }
+
+  [[nodiscard]] auto isRunning() noexcept {
+    return m_state.load(std::memory_order_acquire) == RegistryState::Running;
+  }
+
+  [[nodiscard]] auto isPaused() noexcept {
+    return m_state.load(std::memory_order_acquire) == RegistryState::Paused;
+  }
+
+  [[nodiscard]] auto isAborted() noexcept {
+    return m_state.load(std::memory_order_acquire) == RegistryState::Aborted;
+  }
 
   auto registerExecutor(ExecutorHandle* handle) noexcept -> void;
   auto unregisterExecutor(ExecutorHandle* handle) noexcept -> void;
@@ -26,8 +39,15 @@ public:
   auto resumeExecutors() noexcept -> void;
 
 private:
+  enum class RegistryState : int {
+    Running = 0,
+    Paused  = 1,
+    Aborted = 2,
+  };
+
   std::mutex m_mutex;
   ExecutorHandle* m_head;
+  std::atomic<RegistryState> m_state;
 };
 
 } // namespace vm::internal

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -85,6 +85,8 @@ auto run(const novasm::Assembly* assembly, PlatformInterface* iface) noexcept ->
   auto refAlloc     = internal::RefAllocator{&memAlloc};
   auto gc           = internal::GarbageCollector{&refAlloc, &execRegistry};
 
+  assert(execRegistry.isRunning());
+
   auto resultState = execute(
       settings,
       assembly,
@@ -103,6 +105,8 @@ auto run(const novasm::Assembly* assembly, PlatformInterface* iface) noexcept ->
   // NOTE: First terminate the garbage collector as that might attempt to pause / resume executors
   // while we are trying to abort them.
   execRegistry.abortExecutors();
+
+  assert(execRegistry.isAborted());
 
   teardown(&settings);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ add_executable(novtests
   parse/expr_group_test.cpp
   parse/expr_index_test.cpp
   parse/expr_is_test.cpp
+  parse/expr_misc_test.cpp
   parse/expr_paren_test.cpp
   parse/expr_primary_test.cpp
   parse/expr_switch_test.cpp

--- a/tests/parse/expr_misc_test.cpp
+++ b/tests/parse/expr_misc_test.cpp
@@ -1,0 +1,27 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "parse/error.hpp"
+#include "parse/node_error.hpp"
+
+namespace {
+
+auto nestedInvalidParenExpr(int depth, parse::NodePtr node) -> parse::NodePtr {
+  if (depth <= 0) {
+    return node;
+  }
+  return errInvalidParenExpr(OPAREN, nestedInvalidParenExpr(depth - 1, std::move(node)), END);
+};
+
+} // namespace
+
+namespace parse {
+
+TEST_CASE("Parsing miscellaneous expressions", "[parse]") {
+
+  SECTION("Max recursion depth") {
+    CHECK_EXPR(
+        std::string(100, '('), nestedInvalidParenExpr(99, errMaxExprRecursionDepthReached(OPAREN)));
+  }
+}
+
+} // namespace parse


### PR DESCRIPTION
Add basic fuzz tests for the lexer and the parser using [LibFuzzer](https://llvm.org/docs/LibFuzzer.html).

This is only a very basic setup, more experimentation is needed to find out how we can use fuzzing for the other parts of the compiler (and potentially the runtime). But for the lexer and parser this basic setup seems sufficient, its able to reach a high coverage in relatively little time. 