### PR TITLE
Compiler intrinsic syntax

### DIFF
--- a/apps/novdiag-parse/get_color.hpp
+++ b/apps/novdiag-parse/get_color.hpp
@@ -67,6 +67,11 @@ public:
     m_bg = rang::bg::reset;
   }
 
+  auto visit(const parse::IntrinsicExprNode & /*unused*/) -> void override {
+    m_fg = rang::fg::magenta;
+    m_bg = rang::bg::reset;
+  }
+
   auto visit(const parse::IsExprNode & /*unused*/) -> void override {
     m_fg = rang::fg::yellow;
     m_bg = rang::bg::reset;

--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -97,7 +97,7 @@ act handleConnection(ClientContext ctx)
   else                                                          -> print("- Client disconnected")
 
 act main(int port, Content content)
-  print("Starting server (port: " + port + ")");
+  print("Starting server (url: http://localhost:" + port + ")");
 
   startTime   = timeNow();
   respWriter  = httpRespWriter();

--- a/fuzz/fuzz_parse.cpp
+++ b/fuzz/fuzz_parse.cpp
@@ -4,7 +4,7 @@
 
 namespace {
 
-const std::array<lex::Token, 65> fuzzTokens = {
+const std::array<lex::Token, 66> fuzzTokens = {
     lex::basicToken(lex::TokenKind::OpPlus),
     lex::basicToken(lex::TokenKind::OpPlusPlus),
     lex::basicToken(lex::TokenKind::OpMinus),
@@ -51,6 +51,7 @@ const std::array<lex::Token, 65> fuzzTokens = {
     lex::litBoolToken(false),
     lex::litStrToken("Hello World"),
     lex::litCharToken('!'),
+    lex::keywordToken(lex::Keyword::Intrinsic),
     lex::keywordToken(lex::Keyword::Import),
     lex::keywordToken(lex::Keyword::Fun),
     lex::keywordToken(lex::Keyword::Act),

--- a/ide/nano/novus.nanorc
+++ b/ide/nano/novus.nanorc
@@ -4,7 +4,7 @@ syntax "nov" "\.nov$"
 comment "//"
 
 # Keywords.
-color brightblue "\b(import|struct|union|enum|fun|act|lambda|impure|fork|lazy)\b"
+color brightblue "\b(intrinsic|import|struct|union|enum|fun|act|lambda|impure|fork|lazy)\b"
 color red "(\b(if|else)\b)|(\?|\:)"
 color brightyellow "((\b(is|as)\b)|(\+\+)|(\-\-)|(\&\&)|(\|\|)|(\<\<)|(\>\>)|(\<\=)|(\>\=)|(\=\=)|(\!\=)|\+|\-|\*|(\/)|\^|\~|\%|\&|\!|<|>)"
 

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -164,6 +164,13 @@ errUninitializedConst(const Source& src, const std::string& name, input::Span sp
     const std::vector<std::string>& argTypes,
     input::Span span) -> Diag;
 
+[[nodiscard]] auto errUnknownIntrinsic(
+    const Source& src,
+    const std::string& name,
+    bool pureOnly,
+    const std::vector<std::string>& argTypes,
+    input::Span span) -> Diag;
+
 [[nodiscard]] auto errPureFuncInfRecursion(const Source& src, input::Span span) -> Diag;
 
 [[nodiscard]] auto errNoPureFuncFoundToInstantiate(

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -243,4 +243,6 @@ errUnsupportedOperator(const Source& src, const std::string& name, input::Span s
 [[nodiscard]] auto errInvalidFailCall(
     const Source& src, unsigned int typeParams, unsigned int argCount, input::Span span) -> Diag;
 
+[[nodiscard]] auto errIntrinsicFuncLiteral(const Source& src, input::Span span) -> Diag;
+
 } // namespace frontend

--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -6,6 +6,7 @@
 namespace lex {
 
 enum class Keyword {
+  Intrinsic,
   Import,
   Fun,
   Act,

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -65,6 +65,10 @@ namespace parse {
     -> NodePtr;
 
 [[nodiscard]] auto
+errInvalidIntrinsicExpr(lex::Token kw, lex::Token open, lex::Token intrinsic, lex::Token close)
+    -> NodePtr;
+
+[[nodiscard]] auto
 errInvalidIsExpr(NodePtr lhs, lex::Token kw, const Type& type, std::optional<lex::Token> id)
     -> NodePtr;
 

--- a/include/parse/node_expr_intrinsic.hpp
+++ b/include/parse/node_expr_intrinsic.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include "lex/token.hpp"
+#include "parse/node.hpp"
+
+namespace parse {
+
+// Intrinsic expression node.
+// Example in source: 'intrinsic{fileOpenStream}'.
+class IntrinsicExprNode final : public Node {
+  friend auto
+  intrinsicExprNode(lex::Token kw, lex::Token open, lex::Token intrinsic, lex::Token close)
+      -> NodePtr;
+
+public:
+  IntrinsicExprNode() = delete;
+
+  auto operator==(const Node& rhs) const noexcept -> bool override;
+  auto operator!=(const Node& rhs) const noexcept -> bool override;
+
+  [[nodiscard]] auto operator[](unsigned int i) const -> const Node& override;
+  [[nodiscard]] auto getChildCount() const -> unsigned int override;
+  [[nodiscard]] auto getSpan() const -> input::Span override;
+
+  [[nodiscard]] auto getIntrinsic() const -> const lex::Token&;
+
+  auto accept(NodeVisitor* visitor) const -> void override;
+
+private:
+  const lex::Token m_kw;
+  const lex::Token m_open;
+  const lex::Token m_intrinsic;
+  const lex::Token m_close;
+
+  explicit IntrinsicExprNode(
+      lex::Token kw, lex::Token open, lex::Token intrinsic, lex::Token close);
+
+  auto print(std::ostream& out) const -> std::ostream& override;
+};
+
+// Factories.
+auto intrinsicExprNode(lex::Token kw, lex::Token open, lex::Token intrinsic, lex::Token close)
+    -> NodePtr;
+
+} // namespace parse

--- a/include/parse/node_visitor.hpp
+++ b/include/parse/node_visitor.hpp
@@ -13,6 +13,7 @@ class IdExprNode;
 class FieldExprNode;
 class GroupExprNode;
 class IndexExprNode;
+class IntrinsicExprNode;
 class IsExprNode;
 class LitExprNode;
 class ParenExprNode;
@@ -40,6 +41,7 @@ public:
   virtual auto visit(const FieldExprNode& n) -> void       = 0;
   virtual auto visit(const GroupExprNode& n) -> void       = 0;
   virtual auto visit(const IndexExprNode& n) -> void       = 0;
+  virtual auto visit(const IntrinsicExprNode& n) -> void   = 0;
   virtual auto visit(const IsExprNode& n) -> void          = 0;
   virtual auto visit(const LitExprNode& n) -> void         = 0;
   virtual auto visit(const ParenExprNode& n) -> void       = 0;

--- a/include/parse/node_visitor_deep.hpp
+++ b/include/parse/node_visitor_deep.hpp
@@ -17,6 +17,7 @@ public:
   auto visit(const FieldExprNode& n) -> void override;
   auto visit(const GroupExprNode& n) -> void override;
   auto visit(const IndexExprNode& n) -> void override;
+  auto visit(const IntrinsicExprNode& n) -> void override;
   auto visit(const IsExprNode& n) -> void override;
   auto visit(const LitExprNode& n) -> void override;
   auto visit(const ParenExprNode& n) -> void override;

--- a/include/parse/node_visitor_optional.hpp
+++ b/include/parse/node_visitor_optional.hpp
@@ -6,30 +6,31 @@ namespace parse {
 // Optionally visit a node in the parse tree.
 class OptionalNodeVisitor : public NodeVisitor {
 public:
-  auto visit(const CommentNode & /*unused*/) -> void override {}
-  auto visit(const ErrorNode & /*unused*/) -> void override {}
-  auto visit(const AnonFuncExprNode & /*unused*/) -> void override {}
-  auto visit(const BinaryExprNode & /*unused*/) -> void override {}
-  auto visit(const CallExprNode & /*unused*/) -> void override {}
-  auto visit(const ConditionalExprNode & /*unused*/) -> void override {}
-  auto visit(const ConstDeclExprNode & /*unused*/) -> void override {}
-  auto visit(const IdExprNode & /*unused*/) -> void override {}
-  auto visit(const FieldExprNode & /*unused*/) -> void override {}
-  auto visit(const GroupExprNode & /*unused*/) -> void override {}
-  auto visit(const IndexExprNode & /*unused*/) -> void override {}
-  auto visit(const IsExprNode & /*unused*/) -> void override {}
-  auto visit(const LitExprNode & /*unused*/) -> void override {}
-  auto visit(const ParenExprNode & /*unused*/) -> void override {}
-  auto visit(const SwitchExprElseNode & /*unused*/) -> void override {}
-  auto visit(const SwitchExprIfNode & /*unused*/) -> void override {}
-  auto visit(const SwitchExprNode & /*unused*/) -> void override {}
-  auto visit(const UnaryExprNode & /*unused*/) -> void override {}
-  auto visit(const EnumDeclStmtNode & /*unused*/) -> void override {}
-  auto visit(const ExecStmtNode & /*unused*/) -> void override {}
-  auto visit(const FuncDeclStmtNode & /*unused*/) -> void override {}
-  auto visit(const ImportStmtNode & /*unused*/) -> void override {}
-  auto visit(const StructDeclStmtNode & /*unused*/) -> void override {}
-  auto visit(const UnionDeclStmtNode & /*unused*/) -> void override {}
+  auto visit(const CommentNode& /*unused*/) -> void override {}
+  auto visit(const ErrorNode& /*unused*/) -> void override {}
+  auto visit(const AnonFuncExprNode& /*unused*/) -> void override {}
+  auto visit(const BinaryExprNode& /*unused*/) -> void override {}
+  auto visit(const CallExprNode& /*unused*/) -> void override {}
+  auto visit(const ConditionalExprNode& /*unused*/) -> void override {}
+  auto visit(const ConstDeclExprNode& /*unused*/) -> void override {}
+  auto visit(const IdExprNode& /*unused*/) -> void override {}
+  auto visit(const FieldExprNode& /*unused*/) -> void override {}
+  auto visit(const GroupExprNode& /*unused*/) -> void override {}
+  auto visit(const IndexExprNode& /*unused*/) -> void override {}
+  auto visit(const IntrinsicExprNode&) -> void override {}
+  auto visit(const IsExprNode& /*unused*/) -> void override {}
+  auto visit(const LitExprNode& /*unused*/) -> void override {}
+  auto visit(const ParenExprNode& /*unused*/) -> void override {}
+  auto visit(const SwitchExprElseNode& /*unused*/) -> void override {}
+  auto visit(const SwitchExprIfNode& /*unused*/) -> void override {}
+  auto visit(const SwitchExprNode& /*unused*/) -> void override {}
+  auto visit(const UnaryExprNode& /*unused*/) -> void override {}
+  auto visit(const EnumDeclStmtNode& /*unused*/) -> void override {}
+  auto visit(const ExecStmtNode& /*unused*/) -> void override {}
+  auto visit(const FuncDeclStmtNode& /*unused*/) -> void override {}
+  auto visit(const ImportStmtNode& /*unused*/) -> void override {}
+  auto visit(const StructDeclStmtNode& /*unused*/) -> void override {}
+  auto visit(const UnionDeclStmtNode& /*unused*/) -> void override {}
 };
 
 } // namespace parse

--- a/include/parse/nodes.hpp
+++ b/include/parse/nodes.hpp
@@ -9,6 +9,7 @@
 #include "parse/node_expr_group.hpp"
 #include "parse/node_expr_id.hpp"
 #include "parse/node_expr_index.hpp"
+#include "parse/node_expr_intrinsic.hpp"
 #include "parse/node_expr_is.hpp"
 #include "parse/node_expr_lit.hpp"
 #include "parse/node_expr_paren.hpp"

--- a/include/parse/parser.hpp
+++ b/include/parse/parser.hpp
@@ -39,6 +39,7 @@ private:
   auto nextExprPrimary() -> NodePtr;
   auto nextExprId() -> NodePtr;
   auto nextExprId(lex::Token idToken) -> NodePtr;
+  auto nextExprIntrinsic() -> NodePtr;
   auto nextExprField(NodePtr lhs) -> NodePtr;
   auto nextExprIs(NodePtr lhs) -> NodePtr;
   auto nextExprCall(NodePtr lhs, std::vector<lex::Token> modifiers = {}) -> NodePtr;

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -99,7 +99,14 @@ public:
       const std::vector<sym::FuncId>& funcs, const sym::TypeSet& input, OvOptions options) const
       -> std::optional<sym::FuncId>;
 
-  [[nodiscard]] auto lookupFuncs(const std::string& name, OvOptions options) const
+  [[nodiscard]] auto lookupFunc(const std::string& name, OvOptions options) const
+      -> std::vector<sym::FuncId>;
+
+  [[nodiscard]] auto
+  lookupIntrinsic(const std::string& name, const sym::TypeSet& input, OvOptions options) const
+      -> std::optional<sym::FuncId>;
+
+  [[nodiscard]] auto lookupIntrinsic(const std::string& name, OvOptions options) const
       -> std::vector<sym::FuncId>;
 
   [[nodiscard]] auto lookupImplicitConv(sym::TypeId from, sym::TypeId to) const

--- a/include/prog/sym/func_decl.hpp
+++ b/include/prog/sym/func_decl.hpp
@@ -21,6 +21,7 @@ public:
   [[nodiscard]] auto getId() const -> const FuncId&;
   [[nodiscard]] auto getKind() const -> const FuncKind&;
   [[nodiscard]] auto isAction() const -> bool;
+  [[nodiscard]] auto isIntrinsic() const -> bool;
   [[nodiscard]] auto isImplicitConv() const -> bool;
   [[nodiscard]] auto getName() const -> const std::string&;
   [[nodiscard]] auto getInput() const -> const TypeSet&;
@@ -32,6 +33,7 @@ private:
   FuncId m_id;
   FuncKind m_kind;
   bool m_isAction;
+  bool m_isIntrinsic;
   bool m_isImplicitConv;
   std::string m_name;
   TypeSet m_input;
@@ -41,6 +43,7 @@ private:
       FuncId id,
       FuncKind kind,
       bool isAction,
+      bool isIntrinsic,
       bool isImplicitConv,
       std::string name,
       TypeSet input,

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -72,7 +72,7 @@ public:
   registerAction(const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output)
       -> FuncId;
 
-  auto registerIntrinsicFunc(
+  auto registerIntrinsic(
       const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId;
 
   auto registerIntrinsicAction(

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -76,7 +76,7 @@ public:
 
 private:
   std::map<FuncId, FuncDecl> m_funcs;
-  std::unordered_map<std::string, std::vector<FuncId>> m_lookup;
+  std::unordered_multimap<std::string, FuncId> m_lookup;
 
   auto registerFunc(
       const Program& prog,

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -44,9 +44,18 @@ public:
 
   [[nodiscard]] auto exists(const FuncId& id) const -> bool;
   [[nodiscard]] auto exists(const std::string& name) const -> bool;
+
   [[nodiscard]] auto lookup(const std::string& name, OverloadOptions options) const
       -> std::vector<FuncId>;
   [[nodiscard]] auto lookup(
+      const Program& prog,
+      const std::string& name,
+      const TypeSet& input,
+      OverloadOptions options) const -> std::optional<FuncId>;
+
+  [[nodiscard]] auto lookupIntrinsic(const std::string& name, OverloadOptions options) const
+      -> std::vector<FuncId>;
+  [[nodiscard]] auto lookupIntrinsic(
       const Program& prog,
       const std::string& name,
       const TypeSet& input,
@@ -63,10 +72,17 @@ public:
   registerAction(const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output)
       -> FuncId;
 
+  auto registerIntrinsicFunc(
+      const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId;
+
+  auto registerIntrinsicAction(
+      const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId;
+
   auto insertFunc(
       FuncId id,
       FuncKind kind,
       bool isAction,
+      bool isIntrinsic,
       bool isImplicitConv,
       std::string name,
       TypeSet input,
@@ -76,12 +92,18 @@ public:
 
 private:
   std::map<FuncId, FuncDecl> m_funcs;
-  std::unordered_multimap<std::string, FuncId> m_lookup;
+  std::unordered_multimap<std::string, FuncId> m_normalLookup;
+  std::unordered_multimap<std::string, FuncId> m_intrinsicLookup;
+
+  [[nodiscard]] auto
+  lookupByName(const std::string& name, bool intrinsic, OverloadOptions options) const
+      -> std::vector<FuncId>;
 
   auto registerFunc(
       const Program& prog,
       FuncKind kind,
       bool isAction,
+      bool isIntrinsic,
       bool isImplicitConv,
       std::string name,
       TypeSet input,

--- a/novstd/bits.nov
+++ b/novstd/bits.nov
@@ -166,7 +166,7 @@ fun bitInt64Writer(Endianness e) -> Writer{long}
 
 // -- Actions
 
-act endiannessNative() Endianness(endiannessNativeCode())
+act endiannessNative() Endianness(intrinsic{platform_endianness_native}())
 
 // -- Tests
 

--- a/novstd/math.nov
+++ b/novstd/math.nov
@@ -90,6 +90,33 @@ fun degToRad(float deg)
 fun radToDeg(float rad)
   rad * 57.29578
 
+fun pow(float base, float exponent) -> float
+  intrinsic{float_pow}(base, exponent)
+
+fun sqrt(float x) -> float
+  intrinsic{float_sqrt}(x)
+
+fun sin(float x) -> float
+  intrinsic{float_sin}(x)
+
+fun cos(float x) -> float
+  intrinsic{float_cos}(x)
+
+fun tan(float x) -> float
+  intrinsic{float_tan}(x)
+
+fun asin(float x) -> float
+  intrinsic{float_asin}(x)
+
+fun acos(float x) -> float
+  intrinsic{float_acos}(x)
+
+fun atan(float x) -> float
+  intrinsic{float_atan}(x)
+
+fun atan2(float x, float y) -> float
+  intrinsic{float_atan2}(x, y)
+
 // -- Tests
 
 assert(

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -52,6 +52,9 @@ fun appendChar(string str, char c)
 fun contains(string str, string subStr)
   str.indexOf(subStr) >= 0
 
+fun length(string str) -> int
+  intrinsic{string_length}(str)
+
 fun indexOf(string str, string subStr)
   indexOf(str, 0, subStr, 0)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(parse STATIC
   parse/node_expr_group.cpp
   parse/node_expr_id.cpp
   parse/node_expr_index.cpp
+  parse/node_expr_intrinsic.cpp
   parse/node_expr_is.cpp
   parse/node_expr_lit.cpp
   parse/node_expr_paren.cpp

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -382,6 +382,28 @@ auto errUndeclaredFuncOrAction(
   return error(src, oss.str(), span);
 }
 
+auto errUnknownIntrinsic(
+    const Source& src,
+    const std::string& name,
+    bool pureOnly,
+    const std::vector<std::string>& argTypes,
+    input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "No " << (pureOnly ? "pure " : "") << "compiler intrinsic called: '" << name << "' ";
+  if (argTypes.empty()) {
+    oss << "found without arguments";
+  } else {
+    oss << "found with argument types: ";
+    for (auto i = 0U; i < argTypes.size(); ++i) {
+      if (i != 0) {
+        oss << ", ";
+      }
+      oss << '\'' << argTypes[i] << '\'';
+    }
+  }
+  return error(src, oss.str(), span);
+}
+
 auto errPureFuncInfRecursion(const Source& src, input::Span span) -> Diag {
   std::ostringstream oss;
   oss << "Pure function recurses infinitely";

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -596,4 +596,10 @@ auto errInvalidFailCall(
   return error(src, oss.str(), span);
 }
 
+auto errIntrinsicFuncLiteral(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Compiler intrinsic cannot be used as a function literal";
+  return error(src, oss.str(), span);
+}
+
 } // namespace frontend

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -516,8 +516,9 @@ auto GetExpr::visit(const parse::IndexExprNode& n) -> void {
   m_expr = prog::expr::callExprNode(*m_ctx->getProg(), func.value(), std::move(args->first));
 }
 
-auto GetExpr::visit(const parse::IntrinsicExprNode& /*unused*/) -> void {
-  throw std::logic_error{"GetExpr is not implemented for this node type"};
+auto GetExpr::visit(const parse::IntrinsicExprNode& n) -> void {
+  // Compiler intrinsics are only callable, they are not valid as function literals.
+  m_ctx->reportDiag(errIntrinsicFuncLiteral, n.getSpan());
 }
 
 auto GetExpr::visit(const parse::IsExprNode& n) -> void {

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -516,6 +516,10 @@ auto GetExpr::visit(const parse::IndexExprNode& n) -> void {
   m_expr = prog::expr::callExprNode(*m_ctx->getProg(), func.value(), std::move(args->first));
 }
 
+auto GetExpr::visit(const parse::IntrinsicExprNode& /*unused*/) -> void {
+  throw std::logic_error{"GetExpr is not implemented for this node type"};
+}
+
 auto GetExpr::visit(const parse::IsExprNode& n) -> void {
   auto lhsExpr = getSubExpr(n[0], prog::sym::TypeId::inferType());
   if (lhsExpr == nullptr) {

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -45,6 +45,7 @@ public:
   auto visit(const parse::FieldExprNode& n) -> void override;
   auto visit(const parse::GroupExprNode& n) -> void override;
   auto visit(const parse::IndexExprNode& n) -> void override;
+  auto visit(const parse::IntrinsicExprNode& n) -> void override;
   auto visit(const parse::IsExprNode& n) -> void override;
   auto visit(const parse::LitExprNode& n) -> void override;
   auto visit(const parse::ParenExprNode& n) -> void override;
@@ -129,8 +130,9 @@ private:
   }
 
   [[nodiscard]] inline auto getOvOptions(
-      int maxImplicitConvs, bool excludeNonUser = false, bool noConvOnFirstArg = false) const
-      noexcept {
+      int maxImplicitConvs,
+      bool excludeNonUser   = false,
+      bool noConvOnFirstArg = false) const noexcept {
 
     auto ovFlags = prog::OvFlags::None;
     if (!hasFlag<Flags::AllowPureFuncCalls>()) {

--- a/src/frontend/internal/get_identifier.hpp
+++ b/src/frontend/internal/get_identifier.hpp
@@ -3,6 +3,7 @@
 #include "parse/node.hpp"
 #include "parse/node_expr_field.hpp"
 #include "parse/node_expr_id.hpp"
+#include "parse/node_expr_intrinsic.hpp"
 #include "parse/node_visitor_optional.hpp"
 #include "parse/type_param_list.hpp"
 #include "prog/program.hpp"
@@ -16,11 +17,13 @@ public:
       m_includeInstances{includeInstances},
       m_instance{nullptr},
       m_isSelf{false},
+      m_isIntrinsic{false},
       m_identifier{std::nullopt},
       m_typeParams{std::nullopt} {}
 
   [[nodiscard]] auto getInstance() const noexcept -> const parse::Node* { return m_instance; }
   [[nodiscard]] auto isSelf() const noexcept -> bool { return m_isSelf; }
+  [[nodiscard]] auto isIntrinsic() const noexcept -> bool { return m_isIntrinsic; }
   [[nodiscard]] auto getIdentifier() const noexcept -> const std::optional<lex::Token>& {
     return m_identifier;
   }
@@ -41,10 +44,16 @@ public:
     }
   }
 
+  auto visit(const parse::IntrinsicExprNode& n) -> void override {
+    m_identifier  = n.getIntrinsic();
+    m_isIntrinsic = true;
+  }
+
 private:
   bool m_includeInstances;
   const parse::Node* m_instance;
   bool m_isSelf;
+  bool m_isIntrinsic;
   std::optional<lex::Token> m_identifier;
   std::optional<parse::TypeParamList> m_typeParams;
 };

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -276,9 +276,7 @@ auto TypeInferExpr::visit(const parse::IndexExprNode& n) -> void {
   m_type                = inferFuncCall(funcName, argTypeSet);
 }
 
-auto TypeInferExpr::visit(const parse::IntrinsicExprNode& /*ununsed*/) -> void {
-  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
-}
+auto TypeInferExpr::visit(const parse::IntrinsicExprNode& /*ununsed*/) -> void {}
 
 auto TypeInferExpr::visit(const parse::IsExprNode& n) -> void {
   if (n.hasId()) {

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -26,11 +26,11 @@ TypeInferExpr::TypeInferExpr(
 
 auto TypeInferExpr::getInferredType() const noexcept -> prog::sym::TypeId { return m_type; }
 
-auto TypeInferExpr::visit(const parse::CommentNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::CommentNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ErrorNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ErrorNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
@@ -276,6 +276,10 @@ auto TypeInferExpr::visit(const parse::IndexExprNode& n) -> void {
   m_type                = inferFuncCall(funcName, argTypeSet);
 }
 
+auto TypeInferExpr::visit(const parse::IntrinsicExprNode& /*ununsed*/) -> void {
+  throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
+}
+
 auto TypeInferExpr::visit(const parse::IsExprNode& n) -> void {
   if (n.hasId()) {
     // Register the type of the constant this declares.
@@ -316,11 +320,11 @@ auto TypeInferExpr::visit(const parse::LitExprNode& n) -> void {
 
 auto TypeInferExpr::visit(const parse::ParenExprNode& n) -> void { m_type = inferSubExpr(n[0]); }
 
-auto TypeInferExpr::visit(const parse::SwitchExprElseNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::SwitchExprElseNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::SwitchExprIfNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::SwitchExprIfNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
@@ -363,27 +367,27 @@ auto TypeInferExpr::visit(const parse::UnaryExprNode& n) -> void {
   m_type       = inferFuncCall(prog::getFuncName(*op), {argType});
 }
 
-auto TypeInferExpr::visit(const parse::EnumDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::EnumDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ExecStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ExecStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::FuncDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::FuncDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ImportStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ImportStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::StructDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::StructDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::UnionDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::UnionDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -36,6 +36,7 @@ public:
   auto visit(const parse::FieldExprNode& n) -> void override;
   auto visit(const parse::GroupExprNode& n) -> void override;
   auto visit(const parse::IndexExprNode& n) -> void override;
+  auto visit(const parse::IntrinsicExprNode& n) -> void override;
   auto visit(const parse::IsExprNode& n) -> void override;
   auto visit(const parse::LitExprNode& n) -> void override;
   auto visit(const parse::ParenExprNode& n) -> void override;

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -5,6 +5,9 @@ namespace lex {
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   switch (rhs) {
+  case Keyword::Intrinsic:
+    out << "intrinsic";
+    break;
   case Keyword::Import:
     out << "import";
     break;
@@ -56,6 +59,7 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
 
 auto getKeyword(const std::string& str) -> std::optional<Keyword> {
   static const std::unordered_map<std::string, Keyword> keywordTable = {
+      {"intrinsic", Keyword::Intrinsic},
       {"import", Keyword::Import},
       {"fun", Keyword::Fun},
       {"act", Keyword::Act},

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -374,6 +374,28 @@ auto errInvalidIdExpr(lex::Token id, std::optional<TypeParamList> typeParams) ->
   return errorNode(oss.str(), std::move(tokens), {});
 }
 
+auto errInvalidIntrinsicExpr(lex::Token kw, lex::Token open, lex::Token intrinsic, lex::Token close)
+    -> NodePtr {
+  std::ostringstream oss;
+  if (open.getKind() != lex::TokenKind::SepOpenCurly) {
+    oss << "Expected opening curly-brace '{' but got: '" << open << '\'';
+  } else if (intrinsic.getKind() != lex::TokenKind::Identifier) {
+    oss << "Expected an identifier but got: '" << intrinsic << '\'';
+  } else if (close.getKind() != lex::TokenKind::SepCloseCurly) {
+    oss << "Expected closing curly-brace '}' but got: '" << close << '\'';
+  } else {
+    oss << "Invalid intrinsic";
+  }
+
+  auto tokens = std::vector<lex::Token>{};
+  tokens.push_back(std::move(kw));
+  tokens.push_back(std::move(open));
+  tokens.push_back(std::move(intrinsic));
+  tokens.push_back(std::move(close));
+
+  return errorNode(oss.str(), std::move(tokens), {});
+}
+
 auto errInvalidIsExpr(NodePtr lhs, lex::Token kw, const Type& type, std::optional<lex::Token> id)
     -> NodePtr {
   std::ostringstream oss;

--- a/src/parse/node_expr_intrinsic.cpp
+++ b/src/parse/node_expr_intrinsic.cpp
@@ -1,0 +1,49 @@
+#include "parse/node_expr_intrinsic.hpp"
+#include "lex/keyword.hpp"
+#include "utilities.hpp"
+
+namespace parse {
+
+IntrinsicExprNode::IntrinsicExprNode(
+    lex::Token kw, lex::Token open, lex::Token intrinsic, lex::Token close) :
+    m_kw{std::move(kw)},
+    m_open{std::move(open)},
+    m_intrinsic{std::move(intrinsic)},
+    m_close{std::move(close)} {}
+
+auto IntrinsicExprNode::operator==(const Node& rhs) const noexcept -> bool {
+  const auto r = dynamic_cast<const IntrinsicExprNode*>(&rhs);
+  return r != nullptr && m_kw == r->m_kw && m_intrinsic == r->m_intrinsic;
+}
+
+auto IntrinsicExprNode::operator!=(const Node& rhs) const noexcept -> bool {
+  return !IntrinsicExprNode::operator==(rhs);
+}
+
+auto IntrinsicExprNode::operator[](unsigned int /*unused*/) const -> const Node& {
+  throw std::out_of_range{"No child at given index"};
+}
+
+auto IntrinsicExprNode::getChildCount() const -> unsigned int { return 0; }
+
+auto IntrinsicExprNode::getSpan() const -> input::Span {
+  return input::Span::combine(m_kw.getSpan(), m_close.getSpan());
+}
+
+auto IntrinsicExprNode::getIntrinsic() const -> const lex::Token& { return m_intrinsic; }
+
+auto IntrinsicExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
+
+auto IntrinsicExprNode::print(std::ostream& out) const -> std::ostream& {
+  out << "intrinsic{" << parse::getId(m_intrinsic).value_or("error") << "}";
+  return out;
+}
+
+// Factories.
+auto intrinsicExprNode(lex::Token kw, lex::Token open, lex::Token intrinsic, lex::Token close)
+    -> NodePtr {
+  return std::unique_ptr<IntrinsicExprNode>{new IntrinsicExprNode{
+      std::move(kw), std::move(open), std::move(intrinsic), std::move(close)}};
+}
+
+} // namespace parse

--- a/src/parse/node_visitor_deep.cpp
+++ b/src/parse/node_visitor_deep.cpp
@@ -31,6 +31,8 @@ auto DeepNodeVisitor::visit(const GroupExprNode& n) -> void { visitChildren(&n, 
 
 auto DeepNodeVisitor::visit(const IndexExprNode& n) -> void { visitChildren(&n, this); }
 
+auto DeepNodeVisitor::visit(const IntrinsicExprNode& n) -> void { visitChildren(&n, this); }
+
 auto DeepNodeVisitor::visit(const IsExprNode& n) -> void { visitChildren(&n, this); }
 
 auto DeepNodeVisitor::visit(const LitExprNode& n) -> void { visitChildren(&n, this); }

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -325,6 +325,8 @@ auto ParserImpl::nextExprPrimary() -> NodePtr {
   }
   case lex::TokenCat::Keyword: {
     switch (*getKw(nextTok)) {
+    case lex::Keyword::Intrinsic:
+      return nextExprIntrinsic();
     case lex::Keyword::If:
       return nextExprSwitch();
     case lex::Keyword::Impure: {
@@ -366,6 +368,22 @@ auto ParserImpl::nextExprId(lex::Token idToken) -> NodePtr {
     return idExprNode(std::move(idToken), std::move(typeParams));
   }
   return errInvalidIdExpr(std::move(idToken), std::move(typeParams));
+}
+
+auto ParserImpl::nextExprIntrinsic() -> NodePtr {
+  auto kw        = consumeToken();
+  auto open      = consumeToken();
+  auto intrinsic = consumeToken();
+  auto close     = consumeToken();
+
+  auto validIntrinsic = intrinsic.getKind() == lex::TokenKind::Identifier;
+  if (getKw(kw) == lex::Keyword::Intrinsic && open.getKind() == lex::TokenKind::SepOpenCurly &&
+      validIntrinsic && close.getKind() == lex::TokenKind::SepCloseCurly) {
+    return intrinsicExprNode(
+        std::move(kw), std::move(open), std::move(intrinsic), std::move(close));
+  }
+  return errInvalidIntrinsicExpr(
+      std::move(kw), std::move(open), std::move(intrinsic), std::move(close));
 }
 
 auto ParserImpl::nextExprField(NodePtr lhs) -> NodePtr {

--- a/src/prog/copy.cpp
+++ b/src/prog/copy.cpp
@@ -51,6 +51,7 @@ auto copyFunc(
       id,
       fromDecl.getKind(),
       fromDecl.isAction(),
+      fromDecl.isIntrinsic(),
       fromDecl.isImplicitConv(),
       fromDecl.getName(),
       fromDecl.getInput(),

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -157,15 +157,17 @@ Program::Program() :
       *this, Fk::CheckGtEqFloat, getFuncName(Op::GtEq), sym::TypeSet{m_float, m_float}, m_bool);
 
   // Register build-in float functions.
-  m_funcDecls.registerFunc(*this, Fk::PowFloat, "pow", sym::TypeSet{m_float, m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::SqrtFloat, "sqrt", sym::TypeSet{m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::SinFloat, "sin", sym::TypeSet{m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::CosFloat, "cos", sym::TypeSet{m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::TanFloat, "tan", sym::TypeSet{m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::ASinFloat, "asin", sym::TypeSet{m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::ACosFloat, "acos", sym::TypeSet{m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::ATanFloat, "atan", sym::TypeSet{m_float}, m_float);
-  m_funcDecls.registerFunc(*this, Fk::ATan2Float, "atan2", sym::TypeSet{m_float, m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::PowFloat, "float_pow", sym::TypeSet{m_float, m_float}, m_float);
+  m_funcDecls.registerIntrinsic(*this, Fk::SqrtFloat, "float_sqrt", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(*this, Fk::SinFloat, "float_sin", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(*this, Fk::CosFloat, "float_cos", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(*this, Fk::TanFloat, "float_tan", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(*this, Fk::ASinFloat, "float_asin", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(*this, Fk::ACosFloat, "float_acos", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(*this, Fk::ATanFloat, "float_atan", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ATan2Float, "float_atan2", sym::TypeSet{m_float, m_float}, m_float);
 
   // Register build-in unary bool operators.
   m_funcDecls.registerFunc(*this, Fk::InvBool, getFuncName(Op::Bang), sym::TypeSet{m_bool}, m_bool);
@@ -187,7 +189,8 @@ Program::Program() :
       *this, Fk::CheckNEqString, getFuncName(Op::BangEq), sym::TypeSet{m_string, m_string}, m_bool);
 
   // Register build-in string functions.
-  m_funcDecls.registerFunc(*this, Fk::LengthString, "length", sym::TypeSet{m_string}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::LengthString, "string_length", sym::TypeSet{m_string}, m_int);
   m_funcDecls.registerFunc(
       *this, Fk::IndexString, getFuncName(Op::SquareSquare), sym::TypeSet{m_string, m_int}, m_char);
   m_funcDecls.registerFunc(
@@ -257,8 +260,8 @@ Program::Program() :
   m_funcDecls.registerFunc(*this, Fk::NoOp, "asInt", sym::TypeSet{m_float}, m_int);
 
   // Register build-in actions.
-  m_funcDecls.registerAction(
-      *this, Fk::ActionEndiannessNative, "endiannessNativeCode", sym::TypeSet{}, m_int);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionEndiannessNative, "platform_endianness_native", sym::TypeSet{}, m_int);
 
   m_funcDecls.registerAction(
       *this, Fk::ActionStreamCheckValid, "streamCheckValid", sym::TypeSet{m_stream}, m_bool);
@@ -388,9 +391,19 @@ auto Program::lookupFunc(
   return internal::findOverload(*this, m_funcDecls, funcs, input, options);
 }
 
-auto Program::lookupFuncs(const std::string& name, OvOptions options) const
+auto Program::lookupFunc(const std::string& name, OvOptions options) const
     -> std::vector<sym::FuncId> {
   return m_funcDecls.lookup(name, options);
+}
+
+auto Program::lookupIntrinsic(const std::string& name, const sym::TypeSet& input, OvOptions options)
+    const -> std::optional<sym::FuncId> {
+  return m_funcDecls.lookupIntrinsic(*this, name, input, options);
+}
+
+auto Program::lookupIntrinsic(const std::string& name, OvOptions options) const
+    -> std::vector<sym::FuncId> {
+  return m_funcDecls.lookupIntrinsic(name, options);
 }
 
 auto Program::lookupImplicitConv(sym::TypeId from, sym::TypeId to) const

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -609,7 +609,6 @@ auto Program::defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t
 
   // Register implicit conversion to int and long.
   m_funcDecls.registerImplicitConv(*this, fk::NoOp, id, m_int);
-  m_funcDecls.registerImplicitConv(*this, fk::ConvIntLong, id, m_long);
 
   // Register ordering operators (<, <=, >, >=).
   m_funcDecls.registerFunc(

--- a/src/prog/sym/func_decl.cpp
+++ b/src/prog/sym/func_decl.cpp
@@ -6,6 +6,7 @@ FuncDecl::FuncDecl(
     FuncId id,
     FuncKind kind,
     bool isAction,
+    bool isIntrinsic,
     bool isImplicitConv,
     std::string name,
     TypeSet input,
@@ -13,6 +14,7 @@ FuncDecl::FuncDecl(
     m_id{id},
     m_kind{kind},
     m_isAction{isAction},
+    m_isIntrinsic{isIntrinsic},
     m_isImplicitConv{isImplicitConv},
     m_name{std::move(name)},
     m_input{std::move(input)},
@@ -29,6 +31,8 @@ auto FuncDecl::getId() const -> const FuncId& { return m_id; }
 auto FuncDecl::getKind() const -> const FuncKind& { return m_kind; }
 
 auto FuncDecl::isAction() const -> bool { return m_isAction; }
+
+auto FuncDecl::isIntrinsic() const -> bool { return m_isIntrinsic; }
 
 auto FuncDecl::isImplicitConv() const -> bool { return m_isImplicitConv; }
 

--- a/src/prog/sym/func_decl_table.cpp
+++ b/src/prog/sym/func_decl_table.cpp
@@ -71,7 +71,7 @@ auto FuncDeclTable::registerAction(
   return registerFunc(prog, kind, true, false, false, std::move(name), std::move(input), output);
 }
 
-auto FuncDeclTable::registerIntrinsicFunc(
+auto FuncDeclTable::registerIntrinsic(
     const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId {
   return registerFunc(prog, kind, false, true, false, std::move(name), std::move(input), output);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ add_executable(novtests
   parse/expr_field_test.cpp
   parse/expr_group_test.cpp
   parse/expr_index_test.cpp
+  parse/expr_intrinsic_test.cpp
   parse/expr_is_test.cpp
   parse/expr_misc_test.cpp
   parse/expr_paren_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(novtests
   frontend/get_field_expr_test.cpp
   frontend/get_group_expr_test.cpp
   frontend/get_index_expr_test.cpp
+  frontend/get_intrinsic_expr_test.cpp
   frontend/get_is_expr_test.cpp
   frontend/get_lit_expr_test.cpp
   frontend/get_paren_expr_test.cpp

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -226,31 +226,31 @@ TEST_CASE("Generate assembly for call expressions", "[backend]") {
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addModFloat();
     });
-    CHECK_EXPR("sin(2.0)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR("float(intrinsic{float_sin}(2.0))", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addSinFloat();
     });
-    CHECK_EXPR("cos(2.0)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR("float(intrinsic{float_cos}(2.0))", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addCosFloat();
     });
-    CHECK_EXPR("tan(2.0)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR("float(intrinsic{float_tan}(2.0))", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addTanFloat();
     });
-    CHECK_EXPR("asin(2.0)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR("float(intrinsic{float_asin}(2.0))", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addASinFloat();
     });
-    CHECK_EXPR("acos(2.0)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR("float(intrinsic{float_acos}(2.0))", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addACosFloat();
     });
-    CHECK_EXPR("atan(2.0)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR("float(intrinsic{float_atan}(2.0))", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addATanFloat();
     });
-    CHECK_EXPR("atan2(6.0, 2.0)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR("float(intrinsic{float_atan2}(6.0, 2.0))", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(6.0F); // NOLINT: Magic numbers
       asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
       asmb->addATan2Float();
@@ -482,10 +482,11 @@ TEST_CASE("Generate assembly for call expressions", "[backend]") {
       asmb->addAppendChar();
     });
 
-    CHECK_EXPR("length(\"hello world\")", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitString("hello world");
-      asmb->addLengthString();
-    });
+    CHECK_EXPR(
+        "int(intrinsic{string_length}(\"hello world\"))", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("hello world");
+          asmb->addLengthString();
+        });
 
     CHECK_EXPR("\"hello world\"[6]", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitString("hello world");

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -29,8 +29,8 @@ TEST_CASE("Analyzing execute statements", "[frontend]") {
   }
 
   SECTION("Define exec statement with conversion") {
-    const auto& output = ANALYZE("enum SleepTimes = short : 10, long : 100 "
-                                 "sleepNano(SleepTimes.short)");
+    const auto& output = ANALYZE("enum ConsoleKind = StdIn, StdOut, StdErr "
+                                 "consoleOpenStream(ConsoleKind.StdOut)");
     REQUIRE(output.isSuccess());
 
     auto execsBegin     = output.getProg().beginExecStmts();
@@ -39,12 +39,12 @@ TEST_CASE("Analyzing execute statements", "[frontend]") {
     auto args = std::vector<prog::expr::NodePtr>{};
     args.push_back(applyConv(
         output,
-        "SleepTimes",
-        "long",
-        prog::expr::litEnumNode(output.getProg(), GET_TYPE_ID(output, "SleepTimes"), "short")));
+        "ConsoleKind",
+        "int",
+        prog::expr::litEnumNode(output.getProg(), GET_TYPE_ID(output, "ConsoleKind"), "StdOut")));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
-        GET_FUNC_ID(output, "sleepNano", GET_TYPE_ID(output, "long")),
+        GET_FUNC_ID(output, "consoleOpenStream", GET_TYPE_ID(output, "int")),
         std::move(args));
 
     CHECK(execsBegin->getExpr() == *callExpr);

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -242,12 +242,13 @@ TEST_CASE("Analyzing call expressions", "[frontend]") {
         "fun f1(int i) -> int i.f2()",
         errFieldNotFoundOnType(src, "f2", "int", input::Span{21, 24}));
     CHECK_DIAG(
+        "act length(string str) -> int intrinsic{string_length}(str) "
         "fun f() -> int (42).length()",
-        errUndeclaredPureFunc(src, "length", {"int"}, input::Span{15, 27}));
+        errUndeclaredPureFunc(src, "length", {"int"}, input::Span{75, 87}));
     CHECK_DIAG(
-        "fun ()(string s) -> int s.length() "
+        "fun ()(string s) -> int intrinsic{string_length}(s) "
         "fun f() -> int 42()",
-        errUndeclaredCallOperator(src, {"int"}, input::Span{50, 53}));
+        errUndeclaredCallOperator(src, {"int"}, input::Span{67, 70}));
     CHECK_DIAG(
         "act a() -> int 1 "
         "fun f2() -> int a()",

--- a/tests/frontend/get_intrinsic_expr_test.cpp
+++ b/tests/frontend/get_intrinsic_expr_test.cpp
@@ -1,20 +1,81 @@
 #include "catch2/catch.hpp"
 #include "frontend/diag_defs.hpp"
 #include "helpers.hpp"
+#include "prog/expr/node_lit_float.hpp"
 
 namespace frontend {
 
 TEST_CASE("Analyzing intrinsic expressions", "[frontend]") {
 
+  SECTION("Call intrinsic expression") {
+    const auto& output = ANALYZE("fun f() -> float intrinsic{float_sin}(42.0)");
+    REQUIRE(output.isSuccess());
+    const auto& func = GET_FUNC_DEF(output, "f");
+
+    auto args = std::vector<prog::expr::NodePtr>{};
+    args.push_back(prog::expr::litFloatNode(output.getProg(), 42.0f));
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(),
+        GET_INTRINSIC_ID(output, "float_sin", GET_TYPE_ID(output, "float")),
+        std::move(args));
+
+    CHECK(func.getExpr() == *callExpr);
+  }
+
+  SECTION("Call impure intrinsic expression") {
+    const auto& output = ANALYZE("act a() -> int intrinsic{platform_endianness_native}()");
+    REQUIRE(output.isSuccess());
+    const auto& func = GET_FUNC_DEF(output, "a");
+
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(), GET_INTRINSIC_ID(output, "platform_endianness_native"), {});
+
+    CHECK(func.getExpr() == *callExpr);
+  }
+
   SECTION("Diagnostics") {
     CHECK_DIAG(
-        "fun test() "
-        "intrinsic{test}",
-        errIntrinsicFuncLiteral(src, input::Span{11, 25}));
+        "fun f() "
+        "  intrinsic{test}",
+        errIntrinsicFuncLiteral(src, input::Span{10, 24}));
     CHECK_DIAG(
-        "fun test() -> int "
-        "intrinsic{test}",
-        errIntrinsicFuncLiteral(src, input::Span{18, 32}));
+        "fun f() -> int "
+        "  intrinsic{test}",
+        errIntrinsicFuncLiteral(src, input::Span{17, 31}));
+    CHECK_DIAG(
+        "fun f() "
+        "  intrinsic{does_not_exist}()",
+        errUnknownIntrinsic(src, "does_not_exist", true, {}, input::Span{10, 36}));
+    CHECK_DIAG(
+        "act a() "
+        "  intrinsic{does_not_exist}()",
+        errUnknownIntrinsic(src, "does_not_exist", false, {}, input::Span{10, 36}));
+    CHECK_DIAG(
+        "fun f() "
+        "  intrinsic{does_not_exist}(1)",
+        errUnknownIntrinsic(src, "does_not_exist", true, {"int"}, input::Span{10, 37}));
+    CHECK_DIAG(
+        "act a() "
+        "  intrinsic{does_not_exist}(1)",
+        errUnknownIntrinsic(src, "does_not_exist", false, {"int"}, input::Span{10, 37}));
+    CHECK_DIAG(
+        "fun f() "
+        "  intrinsic{does_not_exist}(1, false)",
+        errUnknownIntrinsic(src, "does_not_exist", true, {"int", "bool"}, input::Span{10, 44}));
+    CHECK_DIAG(
+        "act a() "
+        "  intrinsic{does_not_exist}(1, false)",
+        errUnknownIntrinsic(src, "does_not_exist", false, {"int", "bool"}, input::Span{10, 44}));
+    CHECK_DIAG(
+        "fun f() "
+        "  intrinsic{platform_endianness_native}()",
+        errUnknownIntrinsic(src, "platform_endianness_native", true, {}, input::Span{10, 48}));
+    CHECK_DIAG(
+        "fun f() -> future{float} lazy intrinsic{float_sin}(42.0)",
+        errLazyNonUserFunc(src, input::Span{25, 55}));
+    CHECK_DIAG(
+        "fun f() -> future{float} fork intrinsic{float_sin}(42.0)",
+        errForkedNonUserFunc(src, input::Span{25, 55}));
   }
 }
 

--- a/tests/frontend/get_intrinsic_expr_test.cpp
+++ b/tests/frontend/get_intrinsic_expr_test.cpp
@@ -1,0 +1,21 @@
+#include "catch2/catch.hpp"
+#include "frontend/diag_defs.hpp"
+#include "helpers.hpp"
+
+namespace frontend {
+
+TEST_CASE("Analyzing intrinsic expressions", "[frontend]") {
+
+  SECTION("Diagnostics") {
+    CHECK_DIAG(
+        "fun test() "
+        "intrinsic{test}",
+        errIntrinsicFuncLiteral(src, input::Span{11, 25}));
+    CHECK_DIAG(
+        "fun test() -> int "
+        "intrinsic{test}",
+        errIntrinsicFuncLiteral(src, input::Span{18, 32}));
+  }
+}
+
+} // namespace frontend

--- a/tests/frontend/helpers.hpp
+++ b/tests/frontend/helpers.hpp
@@ -10,8 +10,7 @@ inline auto buildSource(std::string input) {
   return buildSource("test", std::nullopt, input.begin(), input.end());
 }
 
-#define SRC(INPUT)                                                                                 \
-  buildSource(std::string{INPUT})
+#define SRC(INPUT) buildSource(std::string{INPUT})
 
 #define ANALYZE(INPUT) analyze(SRC(INPUT))
 
@@ -24,6 +23,12 @@ inline auto buildSource(std::string input) {
 #define GET_FUNC_ID(OUTPUT, FUNCNAME, ...)                                                         \
   OUTPUT.getProg()                                                                                 \
       .lookupFunc(FUNCNAME, prog::sym::TypeSet{__VA_ARGS__}, prog::sym::OverloadOptions{0})        \
+      .value()
+
+#define GET_INTRINSIC_ID(OUTPUT, INTRINSIC_NAME, ...)                                              \
+  OUTPUT.getProg()                                                                                 \
+      .lookupIntrinsic(                                                                            \
+          INTRINSIC_NAME, prog::sym::TypeSet{__VA_ARGS__}, prog::sym::OverloadOptions{0})          \
       .value()
 
 #define GET_OP_ID(OUTPUT, OP, ...) GET_FUNC_ID(OUTPUT, getFuncName(OP), __VA_ARGS__)

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -196,7 +196,7 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
 
   SECTION("Forked conversion call") {
     const auto& output = ANALYZE("struct s = int i "
-                                 "fun s(string str) s(str.length()) "
+                                 "fun s(string str) s(intrinsic{string_length}(str)) "
                                  "fun f2() fork s(\"hello world\")");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f2").getOutput() == GET_TYPE_ID(output, "__future_s"));
@@ -220,7 +220,7 @@ TEST_CASE("Infer return type of user functions", "[frontend]") {
 
   SECTION("Lazy conversion call") {
     const auto& output = ANALYZE("struct s = int i "
-                                 "fun s(string str) s(str.length()) "
+                                 "fun s(string str) s(intrinsic{string_length}(str)) "
                                  "fun f2() lazy s(\"hello world\")");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f2").getOutput() == GET_TYPE_ID(output, "__lazy_s"));

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -202,7 +202,7 @@ TEST_CASE("Analyzing user-function templates", "[frontend]") {
                                  "fun ft{T}(B{T} b) b.v2 "
                                  "fun f() ft(B(42, false))");
     REQUIRE(output.isSuccess());
-    CHECK(output.getProg().lookupFuncs("ft__int", prog::OvOptions{0}).size() == 1);
+    CHECK(output.getProg().lookupFunc("ft__int", prog::OvOptions{0}).size() == 1);
   }
 
   SECTION("Overloaded func templates prefer simpler matches") {

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -4,6 +4,7 @@
 namespace lex {
 
 TEST_CASE("Lexing keywords", "[lex]") {
+  CHECK_TOKENS("intrinsic", keywordToken(Keyword::Intrinsic));
   CHECK_TOKENS("import", keywordToken(Keyword::Import));
   CHECK_TOKENS("fun", keywordToken(Keyword::Fun));
   CHECK_TOKENS("act", keywordToken(Keyword::Act));

--- a/tests/novasm/serialization_test.cpp
+++ b/tests/novasm/serialization_test.cpp
@@ -20,8 +20,8 @@ static auto testSerializeAndDeserializeAsm(Assembly a) {
 TEST_CASE("Assembly serialization", "[novasm]") {
 
   SECTION("Basic program") {
-    testSerializeAndDeserializeAsm(GEN_ASM("act main(int i, float f) "
-                                           "  pow(i, f) + sin(f) "
+    testSerializeAndDeserializeAsm(GEN_ASM("act main(int i, float f) -> float"
+                                           "  intrinsic{float_pow}(i, f) + intrinsic{float_sin}(f) "
                                            "main(42, 1.337)"));
   }
 

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -103,19 +103,44 @@ TEST_CASE("Precompute literals", "[opt]") {
     ASSERT_EXPR(precomputeLiterals, "3.3 / 1.1", litFloatNode(prog, 3.0));  // NOLINT: Magic numbers
     ASSERT_EXPR(precomputeLiterals, "5.2 % 2.2", litFloatNode(prog, 0.8));  // NOLINT: Magic numbers
     ASSERT_EXPR(
-        precomputeLiterals, "pow(1.1, 2.0)", litFloatNode(prog, 1.21));    // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "sqrt(4.0)", litFloatNode(prog, 2.0)); // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "sin(0.0)", litFloatNode(prog, 0.0));  // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "cos(0.0)", litFloatNode(prog, 1.0));  // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "tan(0.0)", litFloatNode(prog, 0.0));  // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "asin(0.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "acos(1.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "atan(0.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+        precomputeLiterals,
+        "float(intrinsic{float_pow}(1.1, 2.0))",
+        litFloatNode(prog, 1.21)); // NOLINT: Magic numbers
     ASSERT_EXPR(
-        precomputeLiterals, "atan2(0.0, 0.0)", litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "-1.1", litFloatNode(prog, -1.1));   // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "--1.1", litFloatNode(prog, 0.1));   // NOLINT: Magic numbers
-    ASSERT_EXPR(precomputeLiterals, "++1.1", litFloatNode(prog, 2.1));   // NOLINT: Magic numbers
+        precomputeLiterals,
+        "float(intrinsic{float_sqrt}(4.0))",
+        litFloatNode(prog, 2.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "float(intrinsic{float_sin}(0.0))",
+        litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "float(intrinsic{float_cos}(0.0))",
+        litFloatNode(prog, 1.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "float(intrinsic{float_tan}(0.0))",
+        litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "float(intrinsic{float_asin}(0.0))",
+        litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "float(intrinsic{float_acos}(1.0))",
+        litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "float(intrinsic{float_atan}(0.0))",
+        litFloatNode(prog, 0.0)); // NOLINT: Magic numbers
+    ASSERT_EXPR(
+        precomputeLiterals,
+        "float(intrinsic{float_atan2}(0.0, 0.0))",
+        litFloatNode(prog, 0.0));                                      // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "-1.1", litFloatNode(prog, -1.1)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "--1.1", litFloatNode(prog, 0.1)); // NOLINT: Magic numbers
+    ASSERT_EXPR(precomputeLiterals, "++1.1", litFloatNode(prog, 2.1)); // NOLINT: Magic numbers
     ASSERT_EXPR(precomputeLiterals, "1.1 == 1.2", litBoolNode(prog, false));
     ASSERT_EXPR(precomputeLiterals, "1.1 != 1.2", litBoolNode(prog, true));
     ASSERT_EXPR(precomputeLiterals, "1.1 < 1.2", litBoolNode(prog, true));
@@ -205,7 +230,8 @@ TEST_CASE("Precompute literals", "[opt]") {
   SECTION("string intrinsics") {
     ASSERT_EXPR(precomputeLiterals, "\"hello\" + \"world\"", litStringNode(prog, "helloworld"));
     ASSERT_EXPR(precomputeLiterals, "\"hello\" + ' '", litStringNode(prog, "hello "));
-    ASSERT_EXPR(precomputeLiterals, "length(\"hello\")", litIntNode(prog, 5));
+    ASSERT_EXPR(
+        precomputeLiterals, "int(intrinsic{string_length}(\"hello\"))", litIntNode(prog, 5));
     ASSERT_EXPR(precomputeLiterals, "\"hello\"[0]", litCharNode(prog, 'h'));
     ASSERT_EXPR(precomputeLiterals, "\"hello\"[4]", litCharNode(prog, 'o'));
     ASSERT_EXPR(precomputeLiterals, "\"hello\"[-1]", litCharNode(prog, '\0'));

--- a/tests/parse/expr_intrinsic_test.cpp
+++ b/tests/parse/expr_intrinsic_test.cpp
@@ -1,0 +1,56 @@
+#include "catch2/catch.hpp"
+#include "helpers.hpp"
+#include "parse/error.hpp"
+#include "parse/node_expr_call.hpp"
+#include "parse/node_expr_intrinsic.hpp"
+
+namespace parse {
+
+TEST_CASE("Parsing intrinsic expressions", "[parse]") {
+
+  CHECK_EXPR("intrinsic{test}", intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY));
+  CHECK_EXPR("intrinsic {test}", intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY));
+  CHECK_EXPR(
+      "intrinsic{test}()",
+      callExprNode(
+          {},
+          intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY),
+          OPAREN,
+          NODES(),
+          COMMAS(0),
+          CPAREN));
+  CHECK_EXPR(
+      "intrinsic{test}(1,2)",
+      callExprNode(
+          {},
+          intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY),
+          OPAREN,
+          NODES(INT(1), INT(2)),
+          COMMAS(1),
+          CPAREN));
+  CHECK_EXPR(
+      "intrinsic {test} (1,2)",
+      callExprNode(
+          {},
+          intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY),
+          OPAREN,
+          NODES(INT(1), INT(2)),
+          COMMAS(1),
+          CPAREN));
+
+  SECTION("Errors") {
+    CHECK_EXPR("intrinsic{}", errInvalidIntrinsicExpr(INTRINSIC, OCURLY, CCURLY, END));
+    CHECK_EXPR("intrinsic", errInvalidIntrinsicExpr(INTRINSIC, END, END, END));
+    CHECK_EXPR("intrinsic{test", errInvalidIntrinsicExpr(INTRINSIC, OCURLY, ID("test"), END));
+    CHECK_EXPR("intrinsic{a,", errInvalidIntrinsicExpr(INTRINSIC, OCURLY, ID("a"), COMMA));
+    CHECK_EXPR("intrinsic(test)", errInvalidIntrinsicExpr(INTRINSIC, OPAREN, ID("test"), CPAREN));
+    CHECK_EXPR("intrinsic{1}", errInvalidIntrinsicExpr(INTRINSIC, OCURLY, INT_TOK(1), CCURLY));
+  }
+
+  SECTION("Spans") {
+    CHECK_EXPR_SPAN("intrinsic{test}", input::Span(0, 14));
+    CHECK_EXPR_SPAN("intrinsic {test}", input::Span(0, 15));
+  }
+}
+
+} // namespace parse

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -51,6 +51,7 @@ namespace parse {
 #define ARROW lex::basicToken(lex::TokenKind::SepArrow)
 #define DISCARD lex::basicToken(lex::TokenKind::Discard)
 #define IMPORT lex::keywordToken(lex::Keyword::Import)
+#define INTRINSIC lex::keywordToken(lex::Keyword::Intrinsic)
 #define FUN lex::keywordToken(lex::Keyword::Fun)
 #define ACT lex::keywordToken(lex::Keyword::Act)
 #define LAMBDA lex::keywordToken(lex::Keyword::Lambda)


### PR DESCRIPTION
Currently compiler intrinsics  (aka build-in functions) are implemented as regular functions that are predeclared in the program. The downside to this is that they become 'magic' functions are not defined anywhere in novus code. Also even though they looked like normal functions they are special as you cannot create a function literal from them, fork call them or lazy call them.

This pr adds a special syntax `intrinsic{string_length}` that has to be used to call compiler intrinsics, then in the standard library we create a wrapper function that provides a nice api:
```
fun length(string str) -> int
  intrinsic{string_length}(str)
```
This way the `length` function is a normal function (can create a function literal from it, can fork it, can lazily call it) but calls the compiler intrinsic in its implementation.

Note: The optimizer easily gets rid of these wrapper functions so the resulting program is identical to before this pr.

Only a few build-ins have been replaced by intrinsics so far, so there are still build-in normal functions. The long term the goal would be to replace all build-ins by intrinsics.



