### PR TITLE
Convert build-in platform function to intrinsics

### DIFF
--- a/novstd/console.nov
+++ b/novstd/console.nov
@@ -16,7 +16,7 @@ act consoleOpen() -> Either{Console, Error}
   stdIn   = consoleOpenStream(0);
   stdOut  = consoleOpenStream(1);
   stdErr  = consoleOpenStream(2);
-  if stdIn.streamCheckValid() && stdOut.streamCheckValid() && stdErr.streamCheckValid() ->
+  if stdIn.isValid() && stdOut.isValid() && stdErr.isValid() ->
     Console(stdIn, stdOut, stdErr)
   else ->
     Error("Failed to open console")
@@ -27,8 +27,8 @@ act setNoBlockInput(Console c) -> bool
 act unsetNoBlockInput(Console c) -> bool
   c.stdIn.unsetOptions(StreamOptions.NoBlock)
 
-act readChar(Console c) -> char
-  c.stdIn.readChar()
+act read(Console c) -> char
+  c.stdIn.read()
 
 act readLine(Console c) -> string
   c.stdIn.readLine()
@@ -39,8 +39,8 @@ act readToEnd(Console c) -> string
 act readToEnd{T}(Console c, Parser{T} parser) -> Either{T, Error}
   parser.run(c.readToEnd())
 
-act readChar() -> char
-  consoleOpen().failOnError().readChar()
+act read() -> char
+  consoleOpen().failOnError().read()
 
 act readLine() -> string
   consoleOpen().failOnError().readLine()
@@ -72,21 +72,21 @@ act writeErr{T}(Console c, Writer{T} writer, T val) -> Option{Error}
   c.write(writer.run(val))
 
 act flushOut(Console c)
-  c.stdOut.streamFlush()
+  c.stdOut.flush()
 
 act flushErr(Console c)
-  c.stdErr.streamFlush()
+  c.stdErr.flush()
 
 act print{T}(T x) -> Option{Error}
   c       = consoleOpen().failOnError();
-  success =   c.stdOut.streamWrite(x.string() + '\n') &&
-              c.stdOut.streamFlush();
+  success =   c.stdOut.write(x.string() + '\n') &&
+              c.stdOut.flush();
   success ? None() : Error("Failed to write to the stdOut stream of the console")
 
 act printErr{T}(T x) -> Option{Error}
   c       = consoleOpen().failOnError();
-  success =   c.stdOut.streamWrite(x.string() + '\n') &&
-              c.stdOut.streamFlush();
+  success =   c.stdOut.write(x.string() + '\n') &&
+              c.stdOut.flush();
   success ? None() : Error("Failed to write to the stdErr stream of the console")
 
 act printBits(int i) -> Option{Error}

--- a/novstd/console.nov
+++ b/novstd/console.nov
@@ -13,9 +13,9 @@ struct Console =
 // -- Actions
 
 act consoleOpen() -> Either{Console, Error}
-  stdIn   = consoleOpenStream(0);
-  stdOut  = consoleOpenStream(1);
-  stdErr  = consoleOpenStream(2);
+  stdIn   = intrinsic{console_openstream}(0);
+  stdOut  = intrinsic{console_openstream}(1);
+  stdErr  = intrinsic{console_openstream}(2);
   if stdIn.isValid() && stdOut.isValid() && stdErr.isValid() ->
     Console(stdIn, stdOut, stdErr)
   else ->

--- a/novstd/file.nov
+++ b/novstd/file.nov
@@ -27,7 +27,7 @@ act fileOpen(Path p, FileMode m) -> Either{File, Error}
 act fileOpen(Path p, FileMode m, FileFlags flags) -> Either{File, Error}
   absPath     = p.getPathAbsolute();
   absPathStr  = absPath.string();
-  stream      = fileOpenStream(absPathStr, int(m) | flags << 8);
+  stream      = intrinsic{file_openstream}(absPathStr, int(m) | flags << 8);
   if stream.isValid() -> File(absPath, m, flags, stream)
   else                -> Error("Failed to open file: '" + absPathStr + "'")
 
@@ -66,7 +66,7 @@ act fileAppend{T}(Path p, Writer{T} writer, T val) -> Option{Error}
 act fileRemove(Path p) -> Option{Error}
   absPath     = p.getPathAbsolute();
   absPathStr  = absPath.string();
-  fileRemove(absPathStr)
+  intrinsic{file_remove}(absPathStr)
     ? None()
     : Error("Failed to remove file: '" + absPathStr + "'")
 

--- a/novstd/file.nov
+++ b/novstd/file.nov
@@ -28,8 +28,8 @@ act fileOpen(Path p, FileMode m, FileFlags flags) -> Either{File, Error}
   absPath     = p.getPathAbsolute();
   absPathStr  = absPath.string();
   stream      = fileOpenStream(absPathStr, int(m) | flags << 8);
-  if stream.streamCheckValid()  -> File(absPath, m, flags, stream)
-  else                          -> Error("Failed to open file: '" + absPathStr + "'")
+  if stream.isValid() -> File(absPath, m, flags, stream)
+  else                -> Error("Failed to open file: '" + absPathStr + "'")
 
 act readToEnd(File f) -> string
   f.stream.readToEnd()
@@ -38,7 +38,7 @@ act readToEnd{T}(File f, Parser{T} parser) -> Either{T, Error}
   parser.run(f.readToEnd())
 
 act write(File f, string str) -> Option{Error}
-  f.stream.streamWrite(str) && f.stream.streamFlush()
+  f.stream.write(str) && f.stream.flush()
     ? None()
     : Error("Failed to write to file")
 

--- a/novstd/ip.nov
+++ b/novstd/ip.nov
@@ -142,11 +142,11 @@ fun ipBinWriter() -> Writer{IpAddress}
 // -- Actions
 
 act ipLookupV4Address(string hostname) -> Either{IpV4Address, Error}
-  ipV4BinParser().run(ipLookupAddress(hostname, IpFamily.V4.int()))
+  ipV4BinParser().run(intrinsic{ip_lookupaddress}(hostname, IpFamily.V4.int()))
   !! Error("Failed to lookup ipv4 address for hostname: '" + hostname + "'")
 
 act ipLookupV6Address(string hostname) -> Either{IpV6Address, Error}
-  ipV6BinParser().run(ipLookupAddress(hostname, IpFamily.V6.int()))
+  ipV6BinParser().run(intrinsic{ip_lookupaddress}(hostname, IpFamily.V6.int()))
   !! Error("Failed to lookup ipv6 address for hostname: '" + hostname + "'")
 
 act ipLookupAddress(string hostname) -> Either{IpAddress, Error}

--- a/novstd/process.nov
+++ b/novstd/process.nov
@@ -54,23 +54,26 @@ act run(string prog, List{string} args) -> Process
   run(toCmdLine(prog, args))
 
 act run(string cmdLine) -> Process
-  handle = processStart(cmdLine);
+  handle = intrinsic{process_start}(cmdLine);
   Process(
     cmdLine,
     handle,
-    ProcessId(processGetId(handle)),
-    processOpenStream(handle, 0),
-    processOpenStream(handle, 1),
-    processOpenStream(handle, 2))
+    ProcessId(intrinsic{process_getid}(handle)),
+    intrinsic{process_openstream}(handle, 0),
+    intrinsic{process_openstream}(handle, 1),
+    intrinsic{process_openstream}(handle, 2))
 
-act sendInterupt(Process p)         processSendSignal(p.handle, Signal.Interupt)
-act sendSignal(Process p, Signal s) processSendSignal(p.handle, s)
+act sendInterupt(Process p) -> bool
+  p.sendSignal(Signal.Interupt)
+
+act sendSignal(Process p, Signal s) -> bool
+  intrinsic{process_sendsignal}(p.handle, int(s))
 
 act wait(Process p) -> ProcessResult
   ProcessResult(
     p.stdOut.readToEnd(),
     p.stdErr.readToEnd(),
-    ExitCode(processBlock(p.handle)))
+    ExitCode(intrinsic{process_block}(p.handle)))
 
 act waitAsync(Process p) -> future{ProcessResult}
   fork p.wait()

--- a/novstd/stream.nov
+++ b/novstd/stream.nov
@@ -19,59 +19,42 @@ fun StreamReadState(sys_stream src)
 
 // -- Actions
 
+act isValid(sys_stream s) -> bool
+  intrinsic{stream_checkvalid}(s)
+
+act flush(sys_stream s) -> bool
+  intrinsic{stream_flush}(s)
+
 act setOptions(sys_stream s, StreamOptions opts) -> bool
-  s.streamSetOptions(int(opts))
+  intrinsic{stream_setoptions}(s, int(opts))
 
 act unsetOptions(sys_stream s, StreamOptions opts) -> bool
-  s.streamUnsetOptions(int(opts))
+  intrinsic{stream_unsetoptions}(s, int(opts))
 
-act write(sys_stream s, string str) -> bool
-  s.streamWrite(str)
+// -- Reading actions
 
-act write(sys_stream s, char c) -> bool
-  s.streamWrite(c)
+act read(sys_stream s, int maxChars) -> string
+  intrinsic{stream_read_string}(s, maxChars)
+
+act read(sys_stream s) -> char
+  intrinsic{stream_read_char}(s)
 
 act readToEnd(sys_stream s) -> string
   invoke(
     impure lambda (string result)
-      read = s.streamRead(512);
+      read = s.read(512);
       if read.length() > 0  -> self(result + read)
       else                  -> result
     , "")
 
-act readChar(sys_stream s) -> char
-  s.streamRead()
-
 act readLine(sys_stream s) -> string
   invoke(
     impure lambda (string result)
-      c = s.streamRead();
+      c = s.read();
       if c == '\r'              -> self(result)
       if c == '\n' || c == '\0' -> result
       else                      -> self(result + c)
   , "")
-
-act copy(sys_stream from, sys_stream to) -> int
-  bytesCopied = invoke(
-    impure lambda(int bytesCopied)
-      read        = from.streamRead(512);
-      readLength  = read.length();
-      if readLength > 0 -> to.streamWrite(read); self(bytesCopied + readLength)
-      else              -> bytesCopied
-  , 0);
-  to.streamFlush(); bytesCopied
-
-act copyLines(sys_stream from, sys_stream to) -> int
-  invoke(impure lambda (StreamReadState state, int lines)
-  (
-    res = state.readLine();
-    if res.second.reachedEnd  -> lines
-    else                      ->
-      to.write(res.first);
-      to.write('\n');
-      to.streamFlush();
-      self(res.second, ++lines)
-  ), StreamReadState(from), 0)
 
 act readLine(StreamReadState state) -> Pair{string, StreamReadState}
   state.readUntil("\n" :: "\r\n")
@@ -91,7 +74,38 @@ act readUntil(StreamReadState state, List{string} patterns) -> Pair{string, Stre
         remTxt      = txt[idx + p.second.length(), txt.length()];
         Pair(matchedTxt, StreamReadState(remTxt, false, state.src))
       else        ->
-        read = state.src.streamRead(512);
+        read = state.src.read(512);
         if read.isEmpty() -> Pair("", StreamReadState(txt, true, state.src))
         else              -> self(txt + read)
   , state.txt)
+
+
+// -- Writing actions
+
+act write(sys_stream s, string str) -> bool
+  intrinsic{stream_write_string}(s, str)
+
+act write(sys_stream s, char c) -> bool
+  intrinsic{stream_write_char}(s, c)
+
+act copy(sys_stream from, sys_stream to) -> int
+  bytesCopied = invoke(
+    impure lambda(int bytesCopied)
+      read        = from.read(512);
+      readLength  = read.length();
+      if readLength > 0 -> to.write(read); self(bytesCopied + readLength)
+      else              -> bytesCopied
+  , 0);
+  to.flush(); bytesCopied
+
+act copyLines(sys_stream from, sys_stream to) -> int
+  invoke(impure lambda (StreamReadState state, int lines)
+  (
+    res = state.readLine();
+    if res.second.reachedEnd  -> lines
+    else                      ->
+      to.write(res.first);
+      to.write('\n');
+      to.flush();
+      self(res.second, ++lines)
+  ), StreamReadState(from), 0)

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -56,7 +56,7 @@ act tcpConnection(IpAddress addr) -> Either{TcpConnection, Error}
 
 act tcpConnection(IpAddress addr, int port) -> Either{TcpConnection, Error}
   binAddr = ipBinWriter().run(addr);
-  socket  = tcpOpenConnection(binAddr, IpFamily(addr).int(), port);
+  socket  = intrinsic{tcp_connection_open}(binAddr, IpFamily(addr).int(), port);
   if socket.isValid() -> TcpConnection(socket)
   else                -> Error("Failed to open connection to: '" + addr.string() + " [" + port + "]")
 
@@ -69,14 +69,14 @@ act tcpConnectionAsync(IpAddress addr, int port) -> future{Either{TcpConnection,
 // -- Server
 
 act tcpServer(TcpServerSettings settings) -> Either{TcpServerState, Error}
-  serverSocket = tcpStartServer(settings.family.int(), settings.port, settings.maxBacklog);
+  serverSocket = intrinsic{tcp_server_start}(settings.family.int(), settings.port, settings.maxBacklog);
   if !serverSocket.isValid() -> Error("Failed to start tcp-server")
   else ->
-    teardown = (impure lambda ()
-      serverSocket.tcpShutdown()
+    teardown = (impure lambda () -> bool
+      intrinsic{tcp_shutdown}(serverSocket)
     );
     acceptCon = (impure lambda () -> Either{TcpConnection, Error}
-      socket = tcpAcceptConnection(serverSocket);
+      socket = intrinsic{tcp_server_accept}(serverSocket);
       if socket.isValid() -> TcpConnection(socket)
       else                -> teardown(); Error("Failed to accept new connection")
     );

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -57,8 +57,8 @@ act tcpConnection(IpAddress addr) -> Either{TcpConnection, Error}
 act tcpConnection(IpAddress addr, int port) -> Either{TcpConnection, Error}
   binAddr = ipBinWriter().run(addr);
   socket  = tcpOpenConnection(binAddr, IpFamily(addr).int(), port);
-  if socket.streamCheckValid()  -> TcpConnection(socket)
-  else                          -> Error("Failed to open connection to: '" + addr.string() + " [" + port + "]")
+  if socket.isValid() -> TcpConnection(socket)
+  else                -> Error("Failed to open connection to: '" + addr.string() + " [" + port + "]")
 
 act tcpConnectionAsync(IpAddress addr) -> future{Either{TcpConnection, Error}}
   fork tcpConnection(addr)
@@ -70,15 +70,15 @@ act tcpConnectionAsync(IpAddress addr, int port) -> future{Either{TcpConnection,
 
 act tcpServer(TcpServerSettings settings) -> Either{TcpServerState, Error}
   serverSocket = tcpStartServer(settings.family.int(), settings.port, settings.maxBacklog);
-  if !serverSocket.streamCheckValid() -> Error("Failed to start tcp-server")
+  if !serverSocket.isValid() -> Error("Failed to start tcp-server")
   else ->
     teardown = (impure lambda ()
       serverSocket.tcpShutdown()
     );
     acceptCon = (impure lambda () -> Either{TcpConnection, Error}
       socket = tcpAcceptConnection(serverSocket);
-      if socket.streamCheckValid()  -> TcpConnection(socket)
-      else                          -> teardown(); Error("Failed to accept new connection")
+      if socket.isValid() -> TcpConnection(socket)
+      else                -> teardown(); Error("Failed to accept new connection")
     );
     loop = (impure lambda (
       future{Either{TcpConnection, Error}} futureConnection,

--- a/novstd/terminal.nov
+++ b/novstd/terminal.nov
@@ -72,10 +72,10 @@ act termStyle(TermStyle style) -> Option{Error}
   consoleOpen().failOnError().termStyle(style)
 
 act termStyle(Console c, TermStyle style) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())      &&
-            c.stdOut.streamWrite('[')            &&
-            c.stdOut.streamWrite(string(style))  &&
-            c.stdOut.streamWrite('m');
+  success = c.stdOut.write(termEsc())      &&
+            c.stdOut.write('[')            &&
+            c.stdOut.write(string(style))  &&
+            c.stdOut.write('m');
   success ? None() : Error("Failed to set terminal style")
 
 
@@ -95,12 +95,12 @@ act termColor(Console c, float r, float g, float b, bool background) -> Option{E
     int(clamp(v, 0.0, 1.0) * 5.0 + 0.5)
   );
   col = 16 + 36 * toDiscrete(r) + 6 * toDiscrete(g) + toDiscrete(b);
-  success = c.stdOut.streamWrite(termEsc())                  &&
-            c.stdOut.streamWrite('[')                        &&
-            c.stdOut.streamWrite(background ? "48" : "38")   &&
-            c.stdOut.streamWrite(";5;")                      &&
-            c.stdOut.streamWrite(string(col))                &&
-            c.stdOut.streamWrite('m');
+  success = c.stdOut.write(termEsc())                  &&
+            c.stdOut.write('[')                        &&
+            c.stdOut.write(background ? "48" : "38")   &&
+            c.stdOut.write(";5;")                      &&
+            c.stdOut.write(string(col))                &&
+            c.stdOut.write('m');
   success ? None() : Error("Failed to set terminal color")
 
 // -- Control the terminal cursor.
@@ -109,10 +109,10 @@ act termCursorMove(TermStyle s, TermDir dir, int amount) -> Option{Error}
   consoleOpen().failOnError().termCursorMove(dir, amount)
 
 act termCursorMove(Console c, TermDir dir, int amount) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())       &&
-            c.stdOut.streamWrite('[')             &&
-            c.stdOut.streamWrite(string(amount))  &&
-            c.stdOut.streamWrite(
+  success = c.stdOut.write(termEsc())       &&
+            c.stdOut.write('[')             &&
+            c.stdOut.write(string(amount))  &&
+            c.stdOut.write(
               if dir == TermDir.Up    -> 'A'
               if dir == TermDir.Down  -> 'B'
               if dir == TermDir.Right -> 'C'
@@ -123,31 +123,31 @@ act termCursorCol(int column) -> Option{Error}
   consoleOpen().failOnError().termCursorCol(column)
 
 act termCursorCol(Console c, int column) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())      &&
-            c.stdOut.streamWrite('[')            &&
-            c.stdOut.streamWrite(string(column)) &&
-            c.stdOut.streamWrite('G');
+  success = c.stdOut.write(termEsc())      &&
+            c.stdOut.write('[')            &&
+            c.stdOut.write(string(column)) &&
+            c.stdOut.write('G');
   success ? None() : Error("Failed to set terminal cursor column")
 
 act termCursorPos(int row, int column) -> Option{Error}
   consoleOpen().failOnError().termCursorPos(row, column)
 
 act termCursorPos(Console c, int row, int column) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())       &&
-            c.stdOut.streamWrite('[')             &&
-            c.stdOut.streamWrite(string(row))     &&
-            c.stdOut.streamWrite(';')             &&
-            c.stdOut.streamWrite(string(column))  &&
-            c.stdOut.streamWrite('H');
+  success = c.stdOut.write(termEsc())       &&
+            c.stdOut.write('[')             &&
+            c.stdOut.write(string(row))     &&
+            c.stdOut.write(';')             &&
+            c.stdOut.write(string(column))  &&
+            c.stdOut.write('H');
   success ? None() : Error("Failed to set terminal cursor position")
 
 act termCursorShow(bool show) -> Option{Error}
   consoleOpen().failOnError().termCursorShow(show)
 
 act termCursorShow(Console c, bool show) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())         &&
-            c.stdOut.streamWrite("[?25")            &&
-            c.stdOut.streamWrite(show ? 'h' : 'l');
+  success = c.stdOut.write(termEsc())         &&
+            c.stdOut.write("[?25")            &&
+            c.stdOut.write(show ? 'h' : 'l');
   success ? None() : Error(show ? "Failed to show terminal cursor" : "Failed to hide terminal cursor")
 
 // -- Control alternate screen-buffer.
@@ -156,9 +156,9 @@ act termAltScreen(bool active) -> Option{Error}
   consoleOpen().failOnError().termAltScreen(active)
 
 act termAltScreen(Console c, bool active) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())          &&
-            c.stdOut.streamWrite("[?1049")           &&
-            c.stdOut.streamWrite(active ? 'h' : 'l');
+  success = c.stdOut.write(termEsc())          &&
+            c.stdOut.write("[?1049")           &&
+            c.stdOut.write(active ? 'h' : 'l');
   success ? None() : Error(active ? "Failed to activate terminal alternative-screen"
                                   : "Failed to disable terminal alternative-screen")
 
@@ -174,20 +174,20 @@ act termClearScreen(TermClearMode mode) -> Option{Error}
   consoleOpen().failOnError().termClearScreen(mode)
 
 act termClearScreen(Console c, TermClearMode mode) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())      &&
-            c.stdOut.streamWrite('[')            &&
-            c.stdOut.streamWrite(string(mode))   &&
-            c.stdOut.streamWrite('J');
+  success = c.stdOut.write(termEsc())      &&
+            c.stdOut.write('[')            &&
+            c.stdOut.write(string(mode))   &&
+            c.stdOut.write('J');
   success ? None() : Error("Failed to clear the terminal screen")
 
 act termClearLine(TermClearMode mode) -> Option{Error}
   consoleOpen().failOnError().termClearLine(mode)
 
 act termClearLine(Console c, TermClearMode mode) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc())      &&
-            c.stdOut.streamWrite('[')            &&
-            c.stdOut.streamWrite(string(mode))   &&
-            c.stdOut.streamWrite('K');
+  success = c.stdOut.write(termEsc())      &&
+            c.stdOut.write('[')            &&
+            c.stdOut.write(string(mode))   &&
+            c.stdOut.write('K');
   success ? None() : Error("Failed to clear the terminal line")
 
 // -- Reset the terminal.
@@ -196,8 +196,8 @@ act termReset() -> Option{Error}
   consoleOpen().failOnError().termReset()
 
 act termReset(Console c) -> Option{Error}
-  success = c.stdOut.streamWrite(termEsc()) &&
-            c.stdOut.streamWrite('c');
+  success = c.stdOut.write(termEsc()) &&
+            c.stdOut.write('c');
   success ? None() : Error("Failed to reset the terminal")
 
 // -- Set terminal control options
@@ -221,7 +221,7 @@ act termUnsetOptions(Console c, TermOptions opts) -> Option{Error}
 act print{T}(T x, TermStyle style) -> Option{Error}
   c       = consoleOpen().failOnError();
   success =   c.stdOut.termStyle(style)               &&
-              c.stdOut.streamWrite(x.string() + '\n') &&
+              c.stdOut.write(x.string() + '\n') &&
               c.stdOut.termStyle(TermStyle.Reset)     &&
               c.stdOut.streamFlush();
   success ? None() : Error("Failed to write to the stdOut stream of the console")
@@ -229,7 +229,7 @@ act print{T}(T x, TermStyle style) -> Option{Error}
 act printErr{T}(T x, TermStyle style) -> Option{Error}
   c       = consoleOpen().failOnError();
   success =   c.stdErr.termStyle(style)               &&
-              c.stdErr.streamWrite(x.string() + '\n') &&
+              c.stdErr.write(x.string() + '\n') &&
               c.stdErr.termStyle(TermStyle.Reset)     &&
               c.stdErr.streamFlush();
   success ? None() : Error("Failed to write to the stdErr stream of the console")

--- a/novstd/terminal.nov
+++ b/novstd/terminal.nov
@@ -66,6 +66,14 @@ fun string(TermOptions o)
   ((o & TermOptions.NoEcho)   != 0 ? "[NoEcho]"   : "") +
   ((o & TermOptions.NoBuffer) != 0 ? "[NoBuffer]" : "")
 
+// -- Get terminal size
+
+act termGetWidth() -> int
+  intrinsic{term_getwidth}()
+
+act termGetHeight() -> int
+  intrinsic{term_getheight}()
+
 // -- Update the current style on the terminal.
 
 act termStyle(TermStyle style) -> Option{Error}
@@ -206,14 +214,14 @@ act termSetOptions(TermOptions opts) -> Option{Error}
   consoleOpen().failOnError().termSetOptions(opts)
 
 act termSetOptions(Console c, TermOptions opts) -> Option{Error}
-  success = termSetOptions(int(opts));
+  success = intrinsic{term_setoptions}(int(opts));
   success ? None() : Error("Failed to set terminal options: " + opts.string())
 
 act termUnsetOptions(TermOptions opts) -> Option{Error}
   consoleOpen().failOnError().termUnsetOptions(opts)
 
 act termUnsetOptions(Console c, TermOptions opts) -> Option{Error}
-  success = termUnsetOptions(int(opts));
+  success = intrinsic{term_unsetoptions}(int(opts));
   success ? None() : Error("Failed to clear terminal options: " + opts.string())
 
 // -- Convenience overloads for print that set a style before and reset after printing.

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -324,8 +324,8 @@ Program::Program() :
   m_funcDecls.registerIntrinsicAction(
       *this, Fk::ActionFileRemove, "file_remove", sym::TypeSet{m_string}, m_bool);
 
-  m_funcDecls.registerAction(
-      *this, Fk::ActionConsoleOpenStream, "consoleOpenStream", sym::TypeSet{m_int}, m_stream);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionConsoleOpenStream, "console_openstream", sym::TypeSet{m_int}, m_stream);
 
   m_funcDecls.registerAction(
       *this,

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -319,10 +319,10 @@ Program::Program() :
       sym::TypeSet{m_process, m_int},
       m_bool);
 
-  m_funcDecls.registerAction(
-      *this, Fk::ActionFileOpenStream, "fileOpenStream", sym::TypeSet{m_string, m_int}, m_stream);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionFileRemove, "fileRemove", sym::TypeSet{m_string}, m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionFileOpenStream, "file_openstream", sym::TypeSet{m_string, m_int}, m_stream);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionFileRemove, "file_remove", sym::TypeSet{m_string}, m_bool);
 
   m_funcDecls.registerAction(
       *this, Fk::ActionConsoleOpenStream, "consoleOpenStream", sym::TypeSet{m_int}, m_stream);

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -300,22 +300,22 @@ Program::Program() :
       sym::TypeSet{m_stream, m_int},
       m_bool);
 
-  m_funcDecls.registerAction(
-      *this, Fk::ActionProcessStart, "processStart", sym::TypeSet{m_string}, m_process);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionProcessBlock, "processBlock", sym::TypeSet{m_process}, m_int);
-  m_funcDecls.registerAction(
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionProcessStart, "process_start", sym::TypeSet{m_string}, m_process);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionProcessBlock, "process_block", sym::TypeSet{m_process}, m_int);
+  m_funcDecls.registerIntrinsicAction(
       *this,
       Fk::ActionProcessOpenStream,
-      "processOpenStream",
+      "process_openstream",
       sym::TypeSet{m_process, m_int},
       m_stream);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionProcessGetId, "processGetId", sym::TypeSet{m_process}, m_long);
-  m_funcDecls.registerAction(
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionProcessGetId, "process_getid", sym::TypeSet{m_process}, m_long);
+  m_funcDecls.registerIntrinsicAction(
       *this,
       Fk::ActionProcessSendSignal,
-      "processSendSignal",
+      "process_sendsignal",
       sym::TypeSet{m_process, m_int},
       m_bool);
 

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -325,9 +325,6 @@ Program::Program() :
       *this, Fk::ActionFileRemove, "file_remove", sym::TypeSet{m_string}, m_bool);
 
   m_funcDecls.registerIntrinsicAction(
-      *this, Fk::ActionConsoleOpenStream, "console_openstream", sym::TypeSet{m_int}, m_stream);
-
-  m_funcDecls.registerIntrinsicAction(
       *this,
       Fk::ActionTcpOpenCon,
       "tcp_connection_open",
@@ -350,13 +347,17 @@ Program::Program() :
       sym::TypeSet{m_string, m_int},
       m_string);
 
-  m_funcDecls.registerAction(
-      *this, Fk::ActionTermSetOptions, "termSetOptions", sym::TypeSet{m_int}, m_bool);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionTermUnsetOptions, "termUnsetOptions", sym::TypeSet{m_int}, m_bool);
-  m_funcDecls.registerAction(*this, Fk::ActionTermGetWidth, "termGetWidth", sym::TypeSet{}, m_int);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionTermGetHeight, "termGetHeight", sym::TypeSet{}, m_int);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionConsoleOpenStream, "console_openstream", sym::TypeSet{m_int}, m_stream);
+
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionTermSetOptions, "term_setoptions", sym::TypeSet{m_int}, m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionTermUnsetOptions, "term_unsetoptions", sym::TypeSet{m_int}, m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionTermGetWidth, "term_getwidth", sym::TypeSet{}, m_int);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionTermGetHeight, "term_getheight", sym::TypeSet{}, m_int);
 
   m_funcDecls.registerAction(
       *this, Fk::ActionEnvGetArg, "envGetArg", sym::TypeSet{m_int}, m_string);

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -263,24 +263,40 @@ Program::Program() :
   m_funcDecls.registerIntrinsicAction(
       *this, Fk::ActionEndiannessNative, "platform_endianness_native", sym::TypeSet{}, m_int);
 
-  m_funcDecls.registerAction(
-      *this, Fk::ActionStreamCheckValid, "streamCheckValid", sym::TypeSet{m_stream}, m_bool);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionStreamReadString, "streamRead", sym::TypeSet{m_stream, m_int}, m_string);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionStreamReadChar, "streamRead", sym::TypeSet{m_stream}, m_char);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionStreamWriteString, "streamWrite", sym::TypeSet{m_stream, m_string}, m_bool);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionStreamWriteChar, "streamWrite", sym::TypeSet{m_stream, m_char}, m_bool);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionStreamFlush, "streamFlush", sym::TypeSet{m_stream}, m_bool);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionStreamSetOptions, "streamSetOptions", sym::TypeSet{m_stream, m_int}, m_bool);
-  m_funcDecls.registerAction(
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionStreamCheckValid, "stream_checkvalid", sym::TypeSet{m_stream}, m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this,
+      Fk::ActionStreamReadString,
+      "stream_read_string",
+      sym::TypeSet{m_stream, m_int},
+      m_string);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionStreamReadChar, "stream_read_char", sym::TypeSet{m_stream}, m_char);
+  m_funcDecls.registerIntrinsicAction(
+      *this,
+      Fk::ActionStreamWriteString,
+      "stream_write_string",
+      sym::TypeSet{m_stream, m_string},
+      m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this,
+      Fk::ActionStreamWriteChar,
+      "stream_write_char",
+      sym::TypeSet{m_stream, m_char},
+      m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionStreamFlush, "stream_flush", sym::TypeSet{m_stream}, m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this,
+      Fk::ActionStreamSetOptions,
+      "stream_setoptions",
+      sym::TypeSet{m_stream, m_int},
+      m_bool);
+  m_funcDecls.registerIntrinsicAction(
       *this,
       Fk::ActionStreamUnsetOptions,
-      "streamUnsetOptions",
+      "stream_unsetoptions",
       sym::TypeSet{m_stream, m_int},
       m_bool);
 

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -327,24 +327,28 @@ Program::Program() :
   m_funcDecls.registerIntrinsicAction(
       *this, Fk::ActionConsoleOpenStream, "console_openstream", sym::TypeSet{m_int}, m_stream);
 
-  m_funcDecls.registerAction(
+  m_funcDecls.registerIntrinsicAction(
       *this,
       Fk::ActionTcpOpenCon,
-      "tcpOpenConnection",
+      "tcp_connection_open",
       sym::TypeSet{m_string, m_int, m_int},
       m_stream);
-  m_funcDecls.registerAction(
+  m_funcDecls.registerIntrinsicAction(
       *this,
       Fk::ActionTcpStartServer,
-      "tcpStartServer",
+      "tcp_server_start",
       sym::TypeSet{m_int, m_int, m_int},
       m_stream);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionTcpAcceptCon, "tcpAcceptConnection", sym::TypeSet{m_stream}, m_stream);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionTcpShutdown, "tcpShutdown", sym::TypeSet{m_stream}, m_bool);
-  m_funcDecls.registerAction(
-      *this, Fk::ActionIpLookupAddress, "ipLookupAddress", sym::TypeSet{m_string, m_int}, m_string);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionTcpAcceptCon, "tcp_server_accept", sym::TypeSet{m_stream}, m_stream);
+  m_funcDecls.registerIntrinsicAction(
+      *this, Fk::ActionTcpShutdown, "tcp_shutdown", sym::TypeSet{m_stream}, m_bool);
+  m_funcDecls.registerIntrinsicAction(
+      *this,
+      Fk::ActionIpLookupAddress,
+      "ip_lookupaddress",
+      sym::TypeSet{m_string, m_int},
+      m_string);
 
   m_funcDecls.registerAction(
       *this, Fk::ActionTermSetOptions, "termSetOptions", sym::TypeSet{m_int}, m_bool);

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -30,7 +30,9 @@ TEST_CASE("Analyzing execute statements", "[frontend]") {
 
   SECTION("Define exec statement with conversion") {
     const auto& output = ANALYZE("enum ConsoleKind = StdIn, StdOut, StdErr "
-                                 "consoleOpenStream(ConsoleKind.StdOut)");
+                                 "act openConsole(int i) -> sys_stream "
+                                 "  intrinsic{console_openstream}(i)"
+                                 "openConsole(ConsoleKind.StdOut)");
     REQUIRE(output.isSuccess());
 
     auto execsBegin     = output.getProg().beginExecStmts();
@@ -44,7 +46,7 @@ TEST_CASE("Analyzing execute statements", "[frontend]") {
         prog::expr::litEnumNode(output.getProg(), GET_TYPE_ID(output, "ConsoleKind"), "StdOut")));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
-        GET_FUNC_ID(output, "consoleOpenStream", GET_TYPE_ID(output, "int")),
+        GET_FUNC_ID(output, "openConsole", GET_TYPE_ID(output, "int")),
         std::move(args));
 
     CHECK(execsBegin->getExpr() == *callExpr);


### PR DESCRIPTION
This pr converts most build-in platform functions to intrinsics.

Note: `assert` and `failfast` are not yet converted as both require special handling in the frontend.