### PR TITLE
Test filtering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 
+# Note: Eventually we want to opt into the new behaviour for test names, but because thats only
+# introduced in 3.19 we stick to the old behaviour until that is commonly available.
+cmake_policy(SET CMP0110 OLD)
+
 project(
   Novus
   VERSION 0.6.2

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,34 @@ build:
 test: build
 	./scripts/test.sh
 
+.PHONY: test.lex
+test.lex: build
+	./scripts/test.sh --filter "^\[lex\]"
+
+.PHONY: test.parse
+test.parse: build
+	./scripts/test.sh --filter "^\[parse\]"
+
+.PHONY: test.frontend
+test.frontend: build
+	./scripts/test.sh --filter "^\[frontend\]"
+
+.PHONY: test.backend
+test.backend: build
+	./scripts/test.sh --filter "^\[backend\]"
+
+.PHONY: test.opt
+test.opt: build
+	./scripts/test.sh --filter "^\[opt\]"
+
+.PHONY: test.vm
+test.vm: build
+	./scripts/test.sh --filter "^\[vm\]"
+
+.PHONY: test.novstd
+test.novstd: build
+	./scripts/test.sh --filter "^\[novstd\]"
+
 .PHONY: clean
 clean:
 	rm -rf build

--- a/novstd/CMakeLists.txt
+++ b/novstd/CMakeLists.txt
@@ -4,8 +4,9 @@
 set(stdHeader ${EXECUTABLE_OUTPUT_PATH}/std.nov)
 
 function(add_nov_test filePath)
-  get_filename_component(testName ${filePath} NAME)
-  add_test(test_novstd_${testName} ${EXECUTABLE_OUTPUT_PATH}/nove ${filePath})
+  get_filename_component(fileName ${filePath} NAME)
+  set(testName "[novstd]\\ ${fileName}")
+  add_test("${testName}" ${EXECUTABLE_OUTPUT_PATH}/nove ${filePath})
 endfunction(add_nov_test)
 
 function(configure_novstd_file file)

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -7,10 +7,14 @@
 .PARAMETER Dir
   Default: build
   Build directory.
+.PARAMETER Filter
+  Default: '.+'
+  Regex pattern to select the tests to run.
 #>
 [cmdletbinding()]
 param(
-  [string]$Dir = "build"
+  [string]$Dir = "build",
+  [string]$Filter = ".+"
 )
 
 Set-StrictMode -Version Latest
@@ -49,10 +53,10 @@ function TestProj([string] $dir) {
     Fail "'ctest.exe' not found on path, please install cmake (https://cmake.org)"
   }
 
-  PInfo "Begin testing using ctest"
+  PInfo "Begin testing using ctest (filter: ${filter})"
 
   Push-Location "$dir"
-  & ctest.exe --output-on-failure
+  & ctest.exe --tests-regex "$filter" --output-on-failure
   $ctestResult = $LASTEXITCODE
   Pop-Location
 

--- a/tests/backend/call_dyn_expr_test.cpp
+++ b/tests/backend/call_dyn_expr_test.cpp
@@ -4,7 +4,7 @@
 
 namespace backend {
 
-TEST_CASE("Generate assembly for call dynamic expressions", "[backend]") {
+TEST_CASE("[backend] Generate assembly for dynamic call expressions", "backend") {
 
   SECTION("User functions") {
     CHECK_PROG(

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generate assembly for call expressions", "[backend]") {
+TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
 
   SECTION("Int operations") {
     CHECK_EXPR("-42", [](novasm::Assembler* asmb) -> void {

--- a/tests/backend/call_self_expr_test.cpp
+++ b/tests/backend/call_self_expr_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generate assembly for self call expressions", "[backend]") {
+TEST_CASE("[backend] Generate assembly for self call expressions", "backend") {
 
   SECTION("Function") {
     CHECK_PROG("fun f(int i) i < 0 ? self(0) : i ", [](novasm::Assembler* asmb) -> void {

--- a/tests/backend/constants_test.cpp
+++ b/tests/backend/constants_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generate assembly for storing and loading constants", "[backend]") {
+TEST_CASE("[backend] Generate assembly for storing and loading constants", "backend") {
 
   CHECK_EXPR("x = 42; x", [](novasm::Assembler* asmb) -> void {
     asmb->addStackAlloc(1);

--- a/tests/backend/enum_test.cpp
+++ b/tests/backend/enum_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generating assembly for enums", "[backend]") {
+TEST_CASE("[backend] Generate assembly for enums", "backend") {
 
   SECTION("Create and convert to int") {
     CHECK_PROG(

--- a/tests/backend/group_expr_test.cpp
+++ b/tests/backend/group_expr_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generating assembly for group expressions", "[backend]") {
+TEST_CASE("[backend] Generate assembly for group expressions", "backend") {
 
   CHECK_EXPR("x = 42; x", [](novasm::Assembler* asmb) -> void {
     asmb->addStackAlloc(1);

--- a/tests/backend/lazy_calls_test.cpp
+++ b/tests/backend/lazy_calls_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generate assembly for lazy calls", "[backend]") {
+TEST_CASE("[backend] Generate assembly for lazy calls", "backend") {
 
   SECTION("Lazy call to static function") {
     CHECK_PROG(

--- a/tests/backend/literals_test.cpp
+++ b/tests/backend/literals_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generate assembly for literals", "[backend]") {
+TEST_CASE("[backend] Generate assembly for literals", "backend") {
 
   SECTION("Int literals") {
     CHECK_EXPR("42", [](novasm::Assembler* asmb) -> void { asmb->addLoadLitInt(42); });

--- a/tests/backend/struct_test.cpp
+++ b/tests/backend/struct_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generating assembly for structs", "[backend]") {
+TEST_CASE("[backend] Generate assembly for structs", "backend") {
 
   SECTION("Normal struct") {
     CHECK_PROG(

--- a/tests/backend/switch_expr_test.cpp
+++ b/tests/backend/switch_expr_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generating assembly for switch expressions", "[backend]") {
+TEST_CASE("[backend] Generate assembly for switch expressions", "backend") {
 
   CHECK_EXPR(
       "if true -> 10 "

--- a/tests/backend/tail_calls_test.cpp
+++ b/tests/backend/tail_calls_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generate assembly for tail calls", "[backend]") {
+TEST_CASE("[backend] Generate assembly for tail calls", "backend") {
 
   SECTION("Tail recursion") {
     CHECK_PROG(

--- a/tests/backend/union_test.cpp
+++ b/tests/backend/union_test.cpp
@@ -3,7 +3,7 @@
 
 namespace backend {
 
-TEST_CASE("Generating assembly for unions", "[backend]") {
+TEST_CASE("[backend] Generate assembly for unions", "backend") {
 
   SECTION("Normal union") {
     CHECK_PROG(

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -9,7 +9,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing anonymous functions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
 
   SECTION("Return anonymous function") {
     const auto& output = ANALYZE("fun f() -> function{int} "

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -7,7 +7,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing user-function declarations", "[frontend]") {
+TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
 
   SECTION("Pure functions") {
 

--- a/tests/frontend/declare_user_types_test.cpp
+++ b/tests/frontend/declare_user_types_test.cpp
@@ -4,7 +4,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing user-type declarations", "[frontend]") {
+TEST_CASE("[frontend] Analyzing user-type declarations", "frontend") {
 
   SECTION("Declare basic struct") {
     const auto& output = ANALYZE("struct s = int i");

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -8,7 +8,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing execute statements", "[frontend]") {
+TEST_CASE("[frontend] Analyzing execute statements", "frontend") {
 
   SECTION("Define exec statement") {
     const auto& output = ANALYZE("assert(true, \"hello world\")");

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -6,7 +6,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing user-function definitions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
 
   SECTION("Define basic function") {
     const auto& output = ANALYZE("fun f(int a) -> int 42");

--- a/tests/frontend/define_user_types_test.cpp
+++ b/tests/frontend/define_user_types_test.cpp
@@ -4,7 +4,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing user-type definitions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing user-type definitions", "frontend") {
 
   SECTION("Define struct") {
     const auto& output = ANALYZE("struct s = int a, bool b");

--- a/tests/frontend/get_binary_expr_test.cpp
+++ b/tests/frontend/get_binary_expr_test.cpp
@@ -11,7 +11,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing binary expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
 
   SECTION("Get basic binary expression") {
     const auto& output = ANALYZE("fun f(int a) -> int 1 * a");

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -10,7 +10,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing call dynamic expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
 
   SECTION("Get delegate call without args") {
     const auto& output = ANALYZE("fun f1() -> int 1 "

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -9,7 +9,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing call expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
 
   SECTION("Get basic call") {
     const auto& output = ANALYZE("fun f1() -> int 1 "

--- a/tests/frontend/get_call_self_expr_test.cpp
+++ b/tests/frontend/get_call_self_expr_test.cpp
@@ -8,7 +8,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing self call expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing self call expressions", "frontend") {
 
   SECTION("Get basic self call") {
     const auto& output = ANALYZE("fun f() false ? self() : 1 ");

--- a/tests/frontend/get_conditional_expr_test.cpp
+++ b/tests/frontend/get_conditional_expr_test.cpp
@@ -11,7 +11,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing conditional expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
 
   SECTION("Get basic conditional expression") {
     const auto& output = ANALYZE("fun f() -> int "

--- a/tests/frontend/get_const_expr_test.cpp
+++ b/tests/frontend/get_const_expr_test.cpp
@@ -8,7 +8,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing constant expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
 
   SECTION("Access function input") {
     const auto& output = ANALYZE("fun f(int a) a");

--- a/tests/frontend/get_enum_expr_test.cpp
+++ b/tests/frontend/get_enum_expr_test.cpp
@@ -5,7 +5,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing enum expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing enum expressions", "frontend") {
 
   SECTION("Get enum entry") {
     const auto& output = ANALYZE("enum E = a, b "

--- a/tests/frontend/get_field_expr_test.cpp
+++ b/tests/frontend/get_field_expr_test.cpp
@@ -7,7 +7,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing field expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing field expressions", "frontend") {
 
   SECTION("Get basic field expression") {
     const auto& output = ANALYZE("struct S = int a, bool b "

--- a/tests/frontend/get_group_expr_test.cpp
+++ b/tests/frontend/get_group_expr_test.cpp
@@ -9,7 +9,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing group expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing group expressions", "frontend") {
 
   SECTION("Get basic group expression") {
     const auto& output = ANALYZE("fun f() b = 1; c = 2; b * c");

--- a/tests/frontend/get_index_expr_test.cpp
+++ b/tests/frontend/get_index_expr_test.cpp
@@ -7,7 +7,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing index expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
 
   SECTION("Get single argument index operator") {
     const auto& output = ANALYZE("struct Pair = int a, int b "

--- a/tests/frontend/get_intrinsic_expr_test.cpp
+++ b/tests/frontend/get_intrinsic_expr_test.cpp
@@ -5,7 +5,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing intrinsic expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing intrinsic expressions", "frontend") {
 
   SECTION("Call intrinsic expression") {
     const auto& output = ANALYZE("fun f() -> float intrinsic{float_sin}(42.0)");

--- a/tests/frontend/get_is_expr_test.cpp
+++ b/tests/frontend/get_is_expr_test.cpp
@@ -9,7 +9,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing 'is' / 'as' expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing 'is' / 'as' expressions", "frontend") {
 
   SECTION("Get 'as' expression") {
     const auto& output = ANALYZE("union Val = int, bool "

--- a/tests/frontend/get_lit_expr_test.cpp
+++ b/tests/frontend/get_lit_expr_test.cpp
@@ -11,7 +11,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing literal expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing literal expressions", "frontend") {
 
   SECTION("Get int literal expression") {
     const auto& output = ANALYZE("fun f() -> int 42");

--- a/tests/frontend/get_paren_expr_test.cpp
+++ b/tests/frontend/get_paren_expr_test.cpp
@@ -6,7 +6,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing parenthesized expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing parenthesized expressions", "frontend") {
 
   SECTION("Get basic paren expression") {
     const auto& output = ANALYZE("fun f(int a, int b) ((a) + (b))");

--- a/tests/frontend/get_switch_expr_test.cpp
+++ b/tests/frontend/get_switch_expr_test.cpp
@@ -14,7 +14,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing switch expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing switch expressions", "frontend") {
 
   SECTION("Get basic switch expression") {
     const auto& output = ANALYZE("fun f() -> int "

--- a/tests/frontend/get_unary_expr_test.cpp
+++ b/tests/frontend/get_unary_expr_test.cpp
@@ -7,7 +7,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing unary expressions", "[frontend]") {
+TEST_CASE("[frontend] Analyzing unary expressions", "frontend") {
 
   SECTION("Get basic unary expression") {
     const auto& output = ANALYZE("fun f(int a) -> int -a");

--- a/tests/frontend/import_test.cpp
+++ b/tests/frontend/import_test.cpp
@@ -4,7 +4,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing import statements", "[frontend]") {
+TEST_CASE("[frontend] Analyzing import statements", "frontend") {
 
   SECTION("Diagnostics") {
     CHECK_DIAG(

--- a/tests/frontend/overload_test.cpp
+++ b/tests/frontend/overload_test.cpp
@@ -3,7 +3,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing overloads", "[frontend]") {
+TEST_CASE("[frontend] Analyzing overloads", "frontend") {
 
   SECTION("Allow conversion") {
     const auto& output = ANALYZE("fun f1(float a, float b) a + b "

--- a/tests/frontend/parse_diags_test.cpp
+++ b/tests/frontend/parse_diags_test.cpp
@@ -3,7 +3,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing parse diagnostics", "[frontend]") {
+TEST_CASE("[frontend] Analyzing parse diagnostics", "frontend") {
 
   CHECK_DIAG("conWrite(1 + `)", error(src, "Invalid character '`'", input::Span{13, 13}));
 }

--- a/tests/frontend/source_test.cpp
+++ b/tests/frontend/source_test.cpp
@@ -5,7 +5,7 @@
 
 namespace frontend {
 
-TEST_CASE("Source representation", "[frontend]") {
+TEST_CASE("[frontend] Source representation", "frontend") {
 
   SECTION("Build") {
     const auto input = std::string{"conWrite(1)\nconWrite(2)"};

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -4,7 +4,7 @@
 
 namespace frontend {
 
-TEST_CASE("Infer return type of user functions", "[frontend]") {
+TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
 
   SECTION("Int literal") {
     const auto& output = ANALYZE("fun f() 1");

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -9,7 +9,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing user-function templates", "[frontend]") {
+TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
 
   SECTION("Recursive templated call") {
     const auto& output = ANALYZE("fun ft{T}(T a) -> T a != 0 ? ft{T}(a) : a "

--- a/tests/frontend/user_type_templates_test.cpp
+++ b/tests/frontend/user_type_templates_test.cpp
@@ -8,7 +8,7 @@
 
 namespace frontend {
 
-TEST_CASE("Analyzing user-type templates", "[frontend]") {
+TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
 
   SECTION("Construct templated struct") {
     const auto& output = ANALYZE("struct tuple{T1, T2} = T1 a, T2 b "

--- a/tests/input/char_escape_test.cpp
+++ b/tests/input/char_escape_test.cpp
@@ -3,7 +3,7 @@
 
 namespace input {
 
-TEST_CASE("Escaping characters", "[input]") {
+TEST_CASE("[input] Escaping characters", "input") {
   CHECK(escape("\n") == "\\n");
   CHECK(escape("hello\n\tworld") == "hello\\n\\tworld");
 }

--- a/tests/input/info_test.cpp
+++ b/tests/input/info_test.cpp
@@ -5,7 +5,7 @@
 
 namespace input {
 
-TEST_CASE("Input info", "[input]") {
+TEST_CASE("[input] Input info", "input") {
 
   SECTION("Find text pos (lf)") {
     const auto input = std::string{"Hello\nBeautifull\nworld"};

--- a/tests/input/span_test.cpp
+++ b/tests/input/span_test.cpp
@@ -4,7 +4,7 @@
 
 namespace input {
 
-TEST_CASE("Input span utilities", "[input]") {
+TEST_CASE("[input] Input span utilities", "input") {
 
   SECTION("Combine spans") {
     // NOLINTNEXTLINE: Magic numbers

--- a/tests/lex/category_test.cpp
+++ b/tests/lex/category_test.cpp
@@ -3,7 +3,7 @@
 
 namespace lex {
 
-TEST_CASE("Retreiving token categories", "[lex]") {
+TEST_CASE("[lex] Retreiving token categories", "lex") {
 
   SECTION("Every token-kind has a category") {
     const int kindBegin = static_cast<int>(TokenKind::End) + 1;

--- a/tests/lex/comment_test.cpp
+++ b/tests/lex/comment_test.cpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing comments", "[lex]") {
+TEST_CASE("[lex] Lexing comments", "lex") {
 
   SECTION("Valid") {
     CHECK_TOKENS("//hello world", lineCommentToken("hello world"));

--- a/tests/lex/identifier_test.cpp
+++ b/tests/lex/identifier_test.cpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing identifiers", "[lex]") {
+TEST_CASE("[lex] Lexing identifiers", "lex") {
 
   SECTION("Valid") {
     CHECK_TOKENS("hello", identiferToken("hello"));

--- a/tests/lex/iterator_test.cpp
+++ b/tests/lex/iterator_test.cpp
@@ -5,7 +5,7 @@
 
 namespace lex {
 
-TEST_CASE("Iterating the lexer", "[lex]") {
+TEST_CASE("[lex] Iterating the lexer", "lex") {
   const std::string input = "x + y / z";
   auto lexer              = Lexer{input.begin(), input.end()};
 

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -3,7 +3,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing keywords", "[lex]") {
+TEST_CASE("[lex] Lexing keywords", "lex") {
   CHECK_TOKENS("intrinsic", keywordToken(Keyword::Intrinsic));
   CHECK_TOKENS("import", keywordToken(Keyword::Import));
   CHECK_TOKENS("fun", keywordToken(Keyword::Fun));

--- a/tests/lex/litbool_test.cpp
+++ b/tests/lex/litbool_test.cpp
@@ -3,7 +3,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing boolean literals", "[lex]") {
+TEST_CASE("[lex] Lexing boolean literals", "lex") {
 
   SECTION("Single values") {
     CHECK_TOKENS("true", litBoolToken(true));

--- a/tests/lex/litchar_test.cpp
+++ b/tests/lex/litchar_test.cpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing character literals", "[lex]") {
+TEST_CASE("[lex] Lexing character literals", "lex") {
 
   SECTION("Single values") {
     CHECK_TOKENS("'a'", litCharToken('a'));

--- a/tests/lex/litfloat_test.cpp
+++ b/tests/lex/litfloat_test.cpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing float literals", "[lex]") {
+TEST_CASE("[lex] Lexing float literals", "lex") {
 
   SECTION("Single values") {
     CHECK_TOKENS("0.0", litFloatToken(.0F));

--- a/tests/lex/litint_test.cpp
+++ b/tests/lex/litint_test.cpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing integer literals", "[lex]") {
+TEST_CASE("[lex] Lexing integer literals", "lex") {
 
   SECTION("Single values") {
     CHECK_TOKENS("0", litIntToken(0));

--- a/tests/lex/litlong_test.cpp
+++ b/tests/lex/litlong_test.cpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing long literals", "[lex]") {
+TEST_CASE("[lex] Lexing long literals", "lex") {
 
   SECTION("Single values") {
     CHECK_TOKENS("0l", litLongToken(0));

--- a/tests/lex/litstr_test.cpp
+++ b/tests/lex/litstr_test.cpp
@@ -4,7 +4,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing string literals", "[lex]") {
+TEST_CASE("[lex] Lexing string literals", "lex") {
 
   SECTION("Single values") {
     CHECK_TOKENS("\"hello\"", litStrToken("hello"));

--- a/tests/lex/operators_test.cpp
+++ b/tests/lex/operators_test.cpp
@@ -3,7 +3,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing operators", "[lex]") {
+TEST_CASE("[lex] Lexing operators", "lex") {
   CHECK_TOKENS("+", basicToken(TokenKind::OpPlus));
   CHECK_TOKENS("++", basicToken(TokenKind::OpPlusPlus));
   CHECK_TOKENS("-", basicToken(TokenKind::OpMinus));

--- a/tests/lex/seperators_test.cpp
+++ b/tests/lex/seperators_test.cpp
@@ -3,7 +3,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexing seperators", "[lex]") {
+TEST_CASE("[lex] Lexing seperators", "lex") {
   CHECK_TOKENS("(", basicToken(TokenKind::SepOpenParen));
   CHECK_TOKENS(")", basicToken(TokenKind::SepCloseParen));
   CHECK_TOKENS("{", basicToken(TokenKind::SepOpenCurly));

--- a/tests/lex/utilities_test.cpp
+++ b/tests/lex/utilities_test.cpp
@@ -5,7 +5,7 @@
 
 namespace lex {
 
-TEST_CASE("Lexer utilities", "[lex]") {
+TEST_CASE("[lex] Lexer utilities", "lex") {
 
   SECTION("Find token by position") {
     const std::string input = "\"Hello world\" + 1_000 * true";

--- a/tests/novasm/serialization_test.cpp
+++ b/tests/novasm/serialization_test.cpp
@@ -17,7 +17,7 @@ static auto testSerializeAndDeserializeAsm(Assembly a) {
   CHECK(*deserializedAssembly == a);
 }
 
-TEST_CASE("Assembly serialization", "[novasm]") {
+TEST_CASE("[novasm] Assembly serialization", "novasm") {
 
   SECTION("Basic program") {
     testSerializeAndDeserializeAsm(GEN_ASM("act main(int i, float f) -> float"

--- a/tests/opt/call_inline_test.cpp
+++ b/tests/opt/call_inline_test.cpp
@@ -7,7 +7,7 @@
 
 namespace opt {
 
-TEST_CASE("Call inline", "[opt]") {
+TEST_CASE("[opt] Call inline", "opt") {
 
   SECTION("Inline basic call") {
 

--- a/tests/opt/const_elimination_test.cpp
+++ b/tests/opt/const_elimination_test.cpp
@@ -4,7 +4,7 @@
 
 namespace opt {
 
-TEST_CASE("Constants elimination", "[opt]") {
+TEST_CASE("[opt] Constants elimination", "opt") {
 
   SECTION("Eliminate one-time use constants") {
 

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -7,7 +7,7 @@ namespace opt {
 
 using namespace prog::expr;
 
-TEST_CASE("Precompute literals", "[opt]") {
+TEST_CASE("[opt] Precompute literals", "opt") {
   SECTION("switch expression") {
     ASSERT_EXPR(
         precomputeLiterals,

--- a/tests/opt/synergy_test.cpp
+++ b/tests/opt/synergy_test.cpp
@@ -4,7 +4,7 @@
 
 namespace opt {
 
-TEST_CASE("Optimization synergy", "[opt]") {
+TEST_CASE("[opt] Optimization synergy", "opt") {
 
   SECTION("Dynamic calls to function literals are inlined") {
 

--- a/tests/opt/treeshake_test.cpp
+++ b/tests/opt/treeshake_test.cpp
@@ -6,7 +6,7 @@
 
 namespace opt {
 
-TEST_CASE("Treeshake", "[opt]") {
+TEST_CASE("[opt] Treeshake", "opt") {
 
   SECTION("Unused func") {
     auto prog   = prog::Program{};

--- a/tests/parse/comment_test.cpp
+++ b/tests/parse/comment_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing comments", "[parse]") {
+TEST_CASE("[parse] Parsing comments", "parse") {
 
   CHECK_STMT("// Hello world", commentNode(COMMENT(" Hello world")));
   CHECK_STMT(

--- a/tests/parse/error_test.cpp
+++ b/tests/parse/error_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing errors", "[parse]") {
+TEST_CASE("[parse] Parsing errors", "parse") {
 
   CHECK_EXPR("123a", errLexError(lex::errLitNumberInvalidChar()));
   CHECK_EXPR("123a.", errLexError(lex::errLitNumberInvalidChar()));

--- a/tests/parse/expr_anon_func_test.cpp
+++ b/tests/parse/expr_anon_func_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing anonymous functions", "[parse]") {
+TEST_CASE("[parse] Parsing anonymous functions", "parse") {
 
   CHECK_EXPR(
       "lambda () 1",

--- a/tests/parse/expr_binary_test.cpp
+++ b/tests/parse/expr_binary_test.cpp
@@ -4,7 +4,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing binary operators", "[parse]") {
+TEST_CASE("[parse] Parsing binary operators", "parse") {
 
   CHECK_EXPR("-1 + 2", binaryExprNode(unaryExprNode(MINUS, INT(1)), PLUS, INT(2)));
   CHECK_EXPR("y == false", binaryExprNode(ID_EXPR("y"), EQEQ, BOOL(false)));

--- a/tests/parse/expr_call_test.cpp
+++ b/tests/parse/expr_call_test.cpp
@@ -8,7 +8,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing call expressions", "[parse]") {
+TEST_CASE("[parse] Parsing call expressions", "parse") {
 
   CHECK_EXPR("a()", callExprNode({}, ID_EXPR("a"), OPAREN, NODES(), COMMAS(0), CPAREN));
   CHECK_EXPR("1()", callExprNode({}, INT(1), OPAREN, NODES(), COMMAS(0), CPAREN));

--- a/tests/parse/expr_condtional_test.cpp
+++ b/tests/parse/expr_condtional_test.cpp
@@ -6,7 +6,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing conditional expressions", "[parse]") {
+TEST_CASE("[parse] Parsing conditional expressions", "parse") {
 
   CHECK_EXPR(
       "x ? y : z", conditionalExprNode(ID_EXPR("x"), QMARK, ID_EXPR("y"), COLON, ID_EXPR("z")));

--- a/tests/parse/expr_field_test.cpp
+++ b/tests/parse/expr_field_test.cpp
@@ -8,7 +8,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing field expressions", "[parse]") {
+TEST_CASE("[parse] Parsing field expressions", "parse") {
 
   CHECK_EXPR("x.a", fieldExprNode(ID_EXPR("x"), DOT, ID("a")));
   CHECK_EXPR("-x.a", unaryExprNode(MINUS, fieldExprNode(ID_EXPR("x"), DOT, ID("a"))));

--- a/tests/parse/expr_group_test.cpp
+++ b/tests/parse/expr_group_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing group expressions", "[parse]") {
+TEST_CASE("[parse] Parsing group expressions", "parse") {
 
   CHECK_EXPR("1;2;3", groupExprNode(NODES(INT(1), INT(2), INT(3)), SEMIS(2)));
   CHECK_EXPR(

--- a/tests/parse/expr_index_test.cpp
+++ b/tests/parse/expr_index_test.cpp
@@ -6,7 +6,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing index expressions", "[parse]") {
+TEST_CASE("[parse] Parsing index expressions", "parse") {
 
   CHECK_EXPR("a[1]", indexExprNode(ID_EXPR("a"), OSQUARE, NODES(INT(1)), COMMAS(0), CSQUARE));
   CHECK_EXPR(

--- a/tests/parse/expr_intrinsic_test.cpp
+++ b/tests/parse/expr_intrinsic_test.cpp
@@ -6,7 +6,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing intrinsic expressions", "[parse]") {
+TEST_CASE("[parse] Parsing intrinsic expressions", "parse") {
 
   CHECK_EXPR("intrinsic{test}", intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY));
   CHECK_EXPR("intrinsic {test}", intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY));

--- a/tests/parse/expr_is_test.cpp
+++ b/tests/parse/expr_is_test.cpp
@@ -8,7 +8,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing is / as expressions", "[parse]") {
+TEST_CASE("[parse] Parsing is / as expressions", "parse") {
 
   CHECK_EXPR("x as int i", isExprNode(ID_EXPR("x"), AS, TYPE("int"), ID("i")));
   CHECK_EXPR("x as int _", isExprNode(ID_EXPR("x"), AS, TYPE("int"), DISCARD));

--- a/tests/parse/expr_misc_test.cpp
+++ b/tests/parse/expr_misc_test.cpp
@@ -16,7 +16,7 @@ auto nestedInvalidParenExpr(int depth, parse::NodePtr node) -> parse::NodePtr {
 
 namespace parse {
 
-TEST_CASE("Parsing miscellaneous expressions", "[parse]") {
+TEST_CASE("[parse] Parsing miscellaneous expressions", "parse") {
 
   SECTION("Max recursion depth") {
     CHECK_EXPR(

--- a/tests/parse/expr_paren_test.cpp
+++ b/tests/parse/expr_paren_test.cpp
@@ -4,7 +4,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing parenthesized expressions", "[parse]") {
+TEST_CASE("[parse] Parsing parenthesized expressions", "parse") {
 
   CHECK_EXPR(
       "-(-1)", unaryExprNode(MINUS, parenExprNode(OPAREN, unaryExprNode(MINUS, INT(1)), CPAREN)));

--- a/tests/parse/expr_primary_test.cpp
+++ b/tests/parse/expr_primary_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing primary expressions", "[parse]") {
+TEST_CASE("[parse] Parsing primary expressions", "parse") {
 
   CHECK_EXPR("1 true \"hello world\" 42", INT(1), BOOL(true), STR("hello world"), INT(42));
   CHECK_EXPR("x y z", ID_EXPR("x"), ID_EXPR("y"), ID_EXPR("z"));

--- a/tests/parse/expr_switch_test.cpp
+++ b/tests/parse/expr_switch_test.cpp
@@ -9,7 +9,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing switch expressions", "[parse]") {
+TEST_CASE("[parse] Parsing switch expressions", "parse") {
 
   CHECK_EXPR(
       "if x -> 1 "

--- a/tests/parse/expr_unary_test.cpp
+++ b/tests/parse/expr_unary_test.cpp
@@ -4,7 +4,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing unary operators", "[parse]") {
+TEST_CASE("[parse] Parsing unary operators", "parse") {
 
   CHECK_EXPR("-1", unaryExprNode(MINUS, INT(1)));
   CHECK_EXPR("+1", unaryExprNode(PLUS, INT(1)));

--- a/tests/parse/iterator_test.cpp
+++ b/tests/parse/iterator_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Iterating the parser", "[parse]") {
+TEST_CASE("[parse] Iterating the parser", "parse") {
   const std::string input = "conWrite(1) conWrite(x * y)";
   auto lexer              = lex::Lexer{input.begin(), input.end()};
   auto parser             = parse::Parser{lexer.begin(), lexer.end()};

--- a/tests/parse/stmt_enum_decl_test.cpp
+++ b/tests/parse/stmt_enum_decl_test.cpp
@@ -6,7 +6,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing enum declaration statements", "[parse]") {
+TEST_CASE("[parse] Parsing enum declaration statements", "parse") {
 
   CHECK_STMT(
       "enum e = a",
@@ -78,8 +78,8 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
           ENUM,
           ID("e"),
           EQ,
-          {EnumDeclStmtNode::EntrySpec{ID("a"),
-                                       EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(1)}},
+          {EnumDeclStmtNode::EntrySpec{
+               ID("a"), EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(1)}},
            EnumDeclStmtNode::EntrySpec{ID("b"), std::nullopt}},
           COMMAS(1)));
   CHECK_STMT(
@@ -88,10 +88,10 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
           ENUM,
           ID("e"),
           EQ,
-          {EnumDeclStmtNode::EntrySpec{ID("a"),
-                                       EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(1)}},
-           EnumDeclStmtNode::EntrySpec{ID("b"),
-                                       EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(999)}}},
+          {EnumDeclStmtNode::EntrySpec{
+               ID("a"), EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(1)}},
+           EnumDeclStmtNode::EntrySpec{
+               ID("b"), EnumDeclStmtNode::ValueSpec{COLON, MINUS, INT_TOK(999)}}},
           COMMAS(1)));
 
   SECTION("Errors") {
@@ -108,8 +108,8 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
             ENUM,
             ID("e"),
             EQ,
-            {EnumDeclStmtNode::EntrySpec{ID("a"),
-                                         EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, END}}},
+            {EnumDeclStmtNode::EntrySpec{
+                ID("a"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, END}}},
             COMMAS(0)));
     CHECK_STMT(
         "enum e = a : 1, b :",
@@ -119,8 +119,8 @@ TEST_CASE("Parsing enum declaration statements", "[parse]") {
             EQ,
             {EnumDeclStmtNode::EntrySpec{
                  ID("a"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, INT_TOK(1)}},
-             EnumDeclStmtNode::EntrySpec{ID("b"),
-                                         EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, END}}},
+             EnumDeclStmtNode::EntrySpec{
+                 ID("b"), EnumDeclStmtNode::ValueSpec{COLON, std::nullopt, END}}},
             COMMAS(1)));
   }
 

--- a/tests/parse/stmt_exec_test.cpp
+++ b/tests/parse/stmt_exec_test.cpp
@@ -7,7 +7,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing execute statements", "[parse]") {
+TEST_CASE("[parse] Parsing execute statements", "parse") {
 
   CHECK_STMT(
       "exec()",

--- a/tests/parse/stmt_func_decl_test.cpp
+++ b/tests/parse/stmt_func_decl_test.cpp
@@ -8,7 +8,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing function declaration statements", "[parse]") {
+TEST_CASE("[parse] Parsing function declaration statements", "parse") {
 
   SECTION("Pure functions") {
     CHECK_STMT(

--- a/tests/parse/stmt_import_test.cpp
+++ b/tests/parse/stmt_import_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing import statements", "[parse]") {
+TEST_CASE("[parse] Parsing import statements", "parse") {
 
   CHECK_STMT("import \"test.nov\"", importStmtNode(IMPORT, STR_TOK("test.nov")));
   CHECK_STMT("import \"std/test.nov\"", importStmtNode(IMPORT, STR_TOK("std/test.nov")));

--- a/tests/parse/stmt_struct_decl_test.cpp
+++ b/tests/parse/stmt_struct_decl_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing struct declaration statements", "[parse]") {
+TEST_CASE("[parse] Parsing struct declaration statements", "parse") {
 
   CHECK_STMT(
       "struct s = int a",

--- a/tests/parse/stmt_union_decl_test.cpp
+++ b/tests/parse/stmt_union_decl_test.cpp
@@ -5,7 +5,7 @@
 
 namespace parse {
 
-TEST_CASE("Parsing union declaration statements", "[parse]") {
+TEST_CASE("[parse] Parsing union declaration statements", "parse") {
 
   CHECK_STMT(
       "union u = int, float",

--- a/tests/prog/copy_test.cpp
+++ b/tests/prog/copy_test.cpp
@@ -6,7 +6,7 @@
 
 namespace prog {
 
-TEST_CASE("Copy", "[prog]") {
+TEST_CASE("[prog] Copy", "prog") {
 
   SECTION("Copy type") {
     auto progA         = Program{};

--- a/tests/vm/call_test.cpp
+++ b/tests/vm/call_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute calls", "[vm]") {
+TEST_CASE("[vm] Execute calls", "vm") {
 
   CHECK_PROG(
       [](novasm::Assembler* asmb) -> void {

--- a/tests/vm/consts_test.cpp
+++ b/tests/vm/consts_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute constants", "[vm]") {
+TEST_CASE("[vm] Execute constants", "vm") {
 
   SECTION("Small stack counts") {
     CHECK_EXPR(

--- a/tests/vm/conv_test.cpp
+++ b/tests/vm/conv_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute conversions", "[vm]") {
+TEST_CASE("[vm] Execute conversions", "vm") {
 
   SECTION("Int to Float") {
     CHECK_EXPR(

--- a/tests/vm/error_test.cpp
+++ b/tests/vm/error_test.cpp
@@ -4,7 +4,7 @@
 
 namespace vm {
 
-TEST_CASE("Runtime errors", "[vm]") {
+TEST_CASE("[vm] Runtime errors", "vm") {
 
   SECTION("Fail") {
     CHECK_EXPR_RESULTCODE(

--- a/tests/vm/float_check_test.cpp
+++ b/tests/vm/float_check_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute float checks", "[vm]") {
+TEST_CASE("[vm] Execute float checks", "vm") {
 
   SECTION("Equal") {
     CHECK_EXPR(

--- a/tests/vm/float_op_test.cpp
+++ b/tests/vm/float_op_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute float operations", "[vm]") {
+TEST_CASE("[vm] Execute float operations", "vm") {
 
   SECTION("Add") {
     CHECK_EXPR(

--- a/tests/vm/fork_test.cpp
+++ b/tests/vm/fork_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute forks", "[vm]") {
+TEST_CASE("[vm] Execute forks", "vm") {
 
   SECTION("Waiting for fork results") {
     CHECK_PROG(

--- a/tests/vm/int_check_test.cpp
+++ b/tests/vm/int_check_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute integer checks", "[vm]") {
+TEST_CASE("[vm] Execute integer checks", "vm") {
 
   SECTION("Equal") {
     CHECK_EXPR(

--- a/tests/vm/int_op_test.cpp
+++ b/tests/vm/int_op_test.cpp
@@ -4,7 +4,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute integer operations", "[vm]") {
+TEST_CASE("[vm] Execute integer operations", "vm") {
 
   SECTION("Add") {
     CHECK_EXPR(

--- a/tests/vm/io_process_test.cpp
+++ b/tests/vm/io_process_test.cpp
@@ -38,7 +38,7 @@ namespace vm {
     (ASMB)->addPCall(novasm::PCallCode::StreamReadString);                                         \
   }
 
-TEST_CASE("Execute process platform-calls", "[vm]") {
+TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
   auto novePath = (input::getExecutablePath().parent_path() / "nove").string();
 

--- a/tests/vm/io_tcp_test.cpp
+++ b/tests/vm/io_tcp_test.cpp
@@ -5,7 +5,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute tcp platform-calls", "[vm]") {
+TEST_CASE("[vm] Execute tcp platform-calls", "vm") {
 
   auto loopbackAddrIpV4 = std::string{127, 0, 0, 1};
   auto loopbackAddrIpV6 = std::string{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};

--- a/tests/vm/io_test.cpp
+++ b/tests/vm/io_test.cpp
@@ -4,7 +4,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute input and output", "[vm]") {
+TEST_CASE("[vm] Execute input and output", "vm") {
 
   SECTION("SleepNano") {
     CHECK_PROG(

--- a/tests/vm/ip_check_test.cpp
+++ b/tests/vm/ip_check_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute instruction pointer checks", "[vm]") {
+TEST_CASE("[vm] Execute instruction pointer checks", "vm") {
 
   SECTION("Equal") {
     CHECK_EXPR(

--- a/tests/vm/jump_test.cpp
+++ b/tests/vm/jump_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute jump", "[vm]") {
+TEST_CASE("[vm] Execute jump", "vm") {
 
   SECTION("Unconditional Jump") {
     CHECK_EXPR(

--- a/tests/vm/literal_test.cpp
+++ b/tests/vm/literal_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute literals", "[vm]") {
+TEST_CASE("[vm] Execute literals", "vm") {
 
   SECTION("Integer literals") {
     CHECK_EXPR(

--- a/tests/vm/long_check_test.cpp
+++ b/tests/vm/long_check_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute long checks", "[vm]") {
+TEST_CASE("[vm] Execute long checks", "vm") {
 
   SECTION("Equal") {
     CHECK_EXPR(

--- a/tests/vm/long_op_test.cpp
+++ b/tests/vm/long_op_test.cpp
@@ -4,7 +4,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute long operations", "[vm]") {
+TEST_CASE("[vm] Execute long operations", "vm") {
 
   SECTION("Add") {
     CHECK_EXPR(

--- a/tests/vm/misc_pcall_test.cpp
+++ b/tests/vm/misc_pcall_test.cpp
@@ -6,7 +6,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute miscellaneous pcalls", "[vm]") {
+TEST_CASE("[vm] Execute miscellaneous pcalls", "vm") {
 
   SECTION("Endianness") {
     /* This test is left for the first person to try to run this on a big-endian machine :)

--- a/tests/vm/misc_test.cpp
+++ b/tests/vm/misc_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute miscellaneous instructions", "[vm]") {
+TEST_CASE("[vm] Execute miscellaneous instructions", "vm") {
 
   SECTION("Dup") {
     CHECK_PROG(

--- a/tests/vm/string_check_test.cpp
+++ b/tests/vm/string_check_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute string checks", "[vm]") {
+TEST_CASE("[vm] Execute string checks", "vm") {
 
   SECTION("Equal") {
     CHECK_EXPR(

--- a/tests/vm/string_op_test.cpp
+++ b/tests/vm/string_op_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute string operations", "[vm]") {
+TEST_CASE("[vm] Execute string operations", "vm") {
 
   SECTION("Add") {
     CHECK_EXPR(

--- a/tests/vm/struct_op_test.cpp
+++ b/tests/vm/struct_op_test.cpp
@@ -3,7 +3,7 @@
 
 namespace vm {
 
-TEST_CASE("Execute struct operations", "[vm]") {
+TEST_CASE("[vm] Execute struct operations", "vm") {
 
   SECTION("Create struct") {
     CHECK_EXPR(


### PR DESCRIPTION
Support running only a subset of the tests, useful for faster iteration times during development.

Also renames all tests to add a `[LIBRARY]` prefix to allow easier filtering, also it looks pretty :)
```
 86/145 Test  #86: [parse] Parsing struct declaration statements ...................   Passed    0.00 sec
        Start  87: [parse] Parsing union declaration statements
 87/145 Test  #87: [parse] Parsing union declaration statements ....................   Passed    0.00 sec
        Start  88: [prog] Copy
 88/145 Test  #88: [prog] Copy .....................................................   Passed    0.01 sec
        Start  89: [vm] Execute calls
 89/145 Test  #89: [vm] Execute calls ..............................................   Passed    0.01 sec
        Start  90: [vm] Execute constants
 90/145 Test  #90: [vm] Execute constants ..........................................   Passed    0.01 sec
 ```
 
 