### PR TITLE
Flexible root calls

### DIFF
--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -151,7 +151,7 @@ auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchP
   }
 
   // Define execute statements from the main-source.
-  auto defineExecStmts = internal::DefineExecStmts{&allContexts[0]};
+  auto defineExecStmts = internal::DefineExecStmts{allContexts.data()};
   mainSrc.accept(&defineExecStmts);
   if (!diags.empty()) {
     return buildOutput(nullptr, std::move(importedSources), diags);

--- a/src/frontend/internal/define_exec_stmts.cpp
+++ b/src/frontend/internal/define_exec_stmts.cpp
@@ -18,12 +18,13 @@ auto DefineExecStmts::visit(const parse::ExecStmtNode& n) -> void {
   auto visibleConsts = std::vector<prog::sym::ConstId>{};
 
   auto constBinder = ConstBinder{&consts, &visibleConsts, nullptr};
-  auto getExpr     = GetExpr{m_ctx,
-                         nullptr,
-                         &constBinder,
-                         prog::sym::TypeId::inferType(),
-                         std::nullopt,
-                         GetExpr::Flags::AllowActionCalls};
+  auto getExpr     = GetExpr{
+      m_ctx,
+      nullptr,
+      &constBinder,
+      prog::sym::TypeId::inferType(),
+      std::nullopt,
+      GetExpr::Flags::AllowPureFuncCalls | GetExpr::Flags::AllowActionCalls};
   n[0].accept(&getExpr);
   if (!getExpr.getValue()) {
     assert(m_ctx->hasErrors());

--- a/src/parse/node_stmt_func_decl.cpp
+++ b/src/parse/node_stmt_func_decl.cpp
@@ -59,7 +59,7 @@ auto FuncDeclStmtNode::getRetType() const -> const std::optional<RetTypeSpec>& {
 auto FuncDeclStmtNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
 auto FuncDeclStmtNode::print(std::ostream& out) const -> std::ostream& {
-  out << "fun-";
+  out << (isAction() ? "act-" : "fun-");
   if (m_id.getKind() == lex::TokenKind::Identifier) {
     out << getIdOrErr(m_id);
   } else {
@@ -87,12 +87,13 @@ auto funcDeclStmtNode(
   if (body == nullptr) {
     throw std::invalid_argument{"Body cannot be null"};
   }
-  return std::unique_ptr<FuncDeclStmtNode>{new FuncDeclStmtNode{std::move(kw),
-                                                                std::move(id),
-                                                                std::move(typeSubs),
-                                                                std::move(argList),
-                                                                std::move(retType),
-                                                                std::move(body)}};
+  return std::unique_ptr<FuncDeclStmtNode>{new FuncDeclStmtNode{
+      std::move(kw),
+      std::move(id),
+      std::move(typeSubs),
+      std::move(argList),
+      std::move(retType),
+      std::move(body)}};
 }
 
 } // namespace parse

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -229,7 +229,7 @@ auto ParserImpl::nextStmtEnumDecl() -> NodePtr {
   return errInvalidStmtEnumDecl(kw, std::move(id), eq, entries, std::move(commas));
 }
 
-auto ParserImpl::nextStmtExec() -> NodePtr { return execStmtNode(nextExprCall(nextExprId())); }
+auto ParserImpl::nextStmtExec() -> NodePtr { return execStmtNode(nextExprCall(nextExprPrimary())); }
 
 auto ParserImpl::nextExpr(const int minPrecedence, const int maxPrecedence) -> NodePtr {
   if (++m_exprRecursionDepth >= g_maxRecursionDepth) {

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -80,15 +80,11 @@ TEST_CASE("[frontend] Analyzing execute statements", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG("things()", errUndeclaredAction(src, "things", {}, input::Span{0, 7}));
+    CHECK_DIAG("things()", errUndeclaredFuncOrAction(src, "things", {}, input::Span{0, 7}));
     CHECK_DIAG(
         "assert(1, 1)",
-        errUndeclaredAction(
+        errUndeclaredFuncOrAction(
             src, "assert", std::vector<std::string>{"int", "int"}, input::Span{0, 11}));
-    CHECK_DIAG(
-        "fun f() -> int 1 "
-        "f()",
-        errUndeclaredAction(src, "f", {}, input::Span{17, 19}));
     CHECK_DIAG("assert(test())", errUndeclaredFuncOrAction(src, "test", {}, input::Span{7, 12}));
   }
 }

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -72,7 +72,7 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
     CHECK_DIAG(
         "act a() -> int f{int}()",
         errNoFuncOrActionFoundToInstantiate(src, "f", 1, input::Span{15, 22}));
-    CHECK_DIAG("f{int}()", errNoActionFoundToInstantiate(src, "f", 1, input::Span{0, 7}));
+    CHECK_DIAG("f{int}()", errNoFuncOrActionFoundToInstantiate(src, "f", 1, input::Span{0, 7}));
     CHECK_DIAG(
         "fun f1() -> int 1 "
         "fun f2() -> int f1{int}()",

--- a/tests/parse/expr_call_test.cpp
+++ b/tests/parse/expr_call_test.cpp
@@ -3,6 +3,7 @@
 #include "parse/error.hpp"
 #include "parse/node_expr_call.hpp"
 #include "parse/node_expr_group.hpp"
+#include "parse/node_expr_intrinsic.hpp"
 #include "parse/type_param_list.hpp"
 #include <optional>
 
@@ -97,6 +98,15 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
           {},
           ID_EXPR_PARAM(
               "a", TypeParamList(OCURLY, {TYPE("T"), TYPE("U"), TYPE("W")}, COMMAS(2), CCURLY)),
+          OPAREN,
+          NODES(),
+          COMMAS(0),
+          CPAREN));
+  CHECK_EXPR(
+      "intrinsic{a}()",
+      callExprNode(
+          {},
+          intrinsicExprNode(INTRINSIC, OCURLY, ID("a"), CCURLY),
           OPAREN,
           NODES(),
           COMMAS(0),

--- a/tests/parse/iterator_test.cpp
+++ b/tests/parse/iterator_test.cpp
@@ -6,11 +6,12 @@
 namespace parse {
 
 TEST_CASE("[parse] Iterating the parser", "parse") {
-  const std::string input = "conWrite(1) conWrite(x * y)";
-  auto lexer              = lex::Lexer{input.begin(), input.end()};
-  auto parser             = parse::Parser{lexer.begin(), lexer.end()};
+  const std::string input = "print(1) print(x * y)";
 
   SECTION("Range for") {
+    auto lexer  = lex::Lexer{input.begin(), input.end()};
+    auto parser = parse::Parser{lexer.begin(), lexer.end()};
+
     std::vector<NodePtr> nodes;
     for (auto&& node : parser) {
       nodes.push_back(std::move(node));
@@ -19,6 +20,9 @@ TEST_CASE("[parse] Iterating the parser", "parse") {
   }
 
   SECTION("While loop") {
+    auto lexer  = lex::Lexer{input.begin(), input.end()};
+    auto parser = parse::Parser{lexer.begin(), lexer.end()};
+
     auto i = 0;
     while (parser.next() != nullptr) {
       ++i;
@@ -27,6 +31,9 @@ TEST_CASE("[parse] Iterating the parser", "parse") {
   }
 
   SECTION("Iterator") {
+    auto lexer  = lex::Lexer{input.begin(), input.end()};
+    auto parser = parse::Parser{lexer.begin(), lexer.end()};
+
     auto i       = 0;
     auto nodeItr = parser.begin();
     auto endItr  = parser.end();
@@ -37,6 +44,8 @@ TEST_CASE("[parse] Iterating the parser", "parse") {
   }
 
   SECTION("ParseAll") {
+    auto lexer = lex::Lexer{input.begin(), input.end()};
+
     auto vec = parseAll(lexer.begin(), lexer.end());
     REQUIRE(vec.size() == 2);
   }

--- a/tests/parse/stmt_exec_test.cpp
+++ b/tests/parse/stmt_exec_test.cpp
@@ -3,6 +3,7 @@
 #include "parse/error.hpp"
 #include "parse/node_expr_call.hpp"
 #include "parse/node_expr_group.hpp"
+#include "parse/node_expr_intrinsic.hpp"
 #include "parse/node_stmt_exec.hpp"
 
 namespace parse {
@@ -12,6 +13,15 @@ TEST_CASE("[parse] Parsing execute statements", "parse") {
   CHECK_STMT(
       "exec()",
       execStmtNode(callExprNode({}, ID_EXPR("exec"), OPAREN, NODES(), COMMAS(0), CPAREN)));
+  CHECK_STMT(
+      "intrinsic{exec}()",
+      execStmtNode(callExprNode(
+          {},
+          intrinsicExprNode(INTRINSIC, OCURLY, ID("exec"), CCURLY),
+          OPAREN,
+          NODES(),
+          COMMAS(0),
+          CPAREN)));
   CHECK_STMT(
       "exec(1,2)",
       execStmtNode(
@@ -54,6 +64,11 @@ TEST_CASE("[parse] Parsing execute statements", "parse") {
           NODES(),
           COMMAS(0),
           CPAREN)));
+  CHECK_STMT(
+      "(exec)()",
+      execStmtNode(callExprNode(
+          {}, parenExprNode(OPAREN, ID_EXPR("exec"), CPAREN), OPAREN, NODES(), COMMAS(0), CPAREN)));
+  CHECK_STMT("1()", execStmtNode(callExprNode({}, INT(1), OPAREN, NODES(), COMMAS(0), CPAREN)));
 
   SECTION("Errors") {
     CHECK_STMT(


### PR DESCRIPTION
Support more kinds of call statements as root statements. The following statements are now legal as root calls:
```c
import "std/console.nov"
import "std/lazy.nov"

print{string}("Hello World")

(print{string})("Hello World")

print("Hello World")

intrinsic{stream_write_string}(intrinsic{console_openstream}(1), "Hello World\n")

act getStream() -> sys_stream
  intrinsic{console_openstream}(2)

act customPrint(sys_stream stream, string message)
  intrinsic{stream_write_string}(stream, message);
  intrinsic{stream_write_char}(stream, '\n');
  intrinsic{stream_flush}(stream)

customPrint(getStream(), "Hello World")

actSeq(
  lazy print("Hello"),
  lazy print("World")
)
```
Also this PR adds support for calling pure functions in root statements. Even though its not really useful to call a pure
function from the root (as it wont have any output) there is no real reason to disallow it and can be useful for testing.
