### PR TITLE
Optional arguments

### DIFF
--- a/apps/novc/compiler.cpp
+++ b/apps/novc/compiler.cpp
@@ -67,12 +67,12 @@ auto compile(Options options) -> bool {
     return false;
   }
 
+  const auto numFiles = 1u +
+      std::distance(frontendOut.getImportedSources().begin(),
+                    frontendOut.getImportedSources().end());
+
   msgHeader(std::cout) << "Analyzed program in: " << compileDur << '\n';
-  infHeader(std::cout) << "Files: "
-                       << std::distance(
-                              frontendOut.getImportedSources().begin(),
-                              frontendOut.getImportedSources().end())
-                       << '\n';
+  infHeader(std::cout) << "Files: " << numFiles << '\n';
   infHeader(std::cout) << "Types: " << frontendOut.getProg().getTypeCount() << '\n';
   infHeader(std::cout) << "Functions: " << frontendOut.getProg().getFuncCount() << '\n';
   infHeader(std::cout) << "Execute statements: " << frontendOut.getProg().getExecStmtCount()

--- a/apps/novdiag-prog/main.cpp
+++ b/apps/novdiag-prog/main.cpp
@@ -208,7 +208,7 @@ auto printFuncDefs(const prog::Program& prog) -> void {
     }
 
     std::cout << rang::style::italic << "  Body:\n" << rang::style::reset;
-    printExpr(funcDef.getExpr(), "   ");
+    printExpr(funcDef.getBody(), "   ");
   }
 }
 

--- a/examples/raytracer/scene.nov
+++ b/examples/raytracer/scene.nov
@@ -82,10 +82,7 @@ fun getLightEnergy(Light l, Vec3 p) -> Color
 
 struct RaycastHit = Object obj, IntersectData d
 
-fun raycast(Scene s, Ray3 r) -> Option{RaycastHit}
-  s.raycast(r, posInfinity())
-
-fun raycast(Scene s, Ray3 r, float tMax) -> Option{RaycastHit}
+fun raycast(Scene s, Ray3 r, float tMax = posInfinity()) -> Option{RaycastHit}
   s.objects.fold(lambda (Option{RaycastHit} maybeBest, Object o)
     i = intersect(o.shape, r);
     if i is None            -> maybeBest

--- a/examples/webserver/http_response.nov
+++ b/examples/webserver/http_response.nov
@@ -42,19 +42,13 @@ fun httpRespHeader(HttpStatusCode s, string txt, HttpContentType t, List{HttpHea
     HttpHeaderField("Content-Length",     txt.length().string())  :: fields
   )
 
-fun httpResp(HttpStatusCode s, string txt, HttpContentType t)
-  httpResp(s, txt, t, List{HttpHeaderField}())
-
-fun httpResp(HttpStatusCode s, string txt, HttpContentType t, List{HttpHeaderField} fields)
+fun httpResp(HttpStatusCode s, string txt, HttpContentType t, List{HttpHeaderField} fields = List{HttpHeaderField}())
   HttpResp(
     httpRespHeader(s, txt, t, fields),
     txt
   )
 
-fun httpRespHead(HttpStatusCode s, string txt, HttpContentType t)
-  httpRespHead(s, txt, t, List{HttpHeaderField}())
-
-fun httpRespHead(HttpStatusCode s, string txt, HttpContentType t, List{HttpHeaderField} fields)
+fun httpRespHead(HttpStatusCode s, string txt, HttpContentType t, List{HttpHeaderField} fields = List{HttpHeaderField}())
   HttpResp(
     httpRespHeader(s, txt, t, fields),
     ""

--- a/examples/webserver/main.nov
+++ b/examples/webserver/main.nov
@@ -116,7 +116,7 @@ act main(int port, Content content)
       ctx       = ClientContext(content, variables, con, respWriter, reqParser);
       handleConnection(ctx)
   );
-  tcpServer(TcpServerSettings(IpFamily.V4, port, handleCon)).failOnError();
+  tcpServer(TcpServerSettings(handleCon, port)).failOnError();
   print("Server stopped")
 
 act loadContent(Path root, List{RewriteRule} rewriteUrls, List{string} files)

--- a/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
+++ b/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
@@ -33,6 +33,35 @@
 	</array>
 	<key>repository</key>
 	<dict>
+		<key>arg_initializer</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>= </string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.source.novus</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=\,|\))</string>
+					<key>name</key>
+					<string>meta.initializer.source.novus</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#code</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
 		<key>buildin_type</key>
 		<dict>
 			<key>patterns</key>
@@ -238,6 +267,10 @@
 						<dict>
 							<key>include</key>
 							<string>#buildin_type</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#arg_initializer</string>
 						</dict>
 					</array>
 				</dict>

--- a/ide/textmate/Novus.tmbundle/info.plist
+++ b/ide/textmate/Novus.tmbundle/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>contactEmailRot13</key>
-	<string>onfgvnaoybxynaq@tznvy.pbz</string>
+	<string>znvy@onfgvna.grpu</string>
 	<key>contactName</key>
 	<string>Bastian Blokland</string>
 	<key>description</key>

--- a/ide/vscode/novus/syntaxes/novus.tmLanguage.json
+++ b/ide/vscode/novus/syntaxes/novus.tmLanguage.json
@@ -19,6 +19,25 @@
     }
   ],
   "repository": {
+    "arg_initializer": {
+      "patterns": [
+        {
+          "begin": "= ",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.other.source.novus"
+            }
+          },
+          "end": "(?=\\,|\\))",
+          "name": "meta.initializer.source.novus",
+          "patterns": [
+            {
+              "include": "#code"
+            }
+          ]
+        }
+      ]
+    },
     "buildin_type": {
       "patterns": [
         {
@@ -153,6 +172,9 @@
             },
             {
               "include": "#buildin_type"
+            },
+            {
+              "include": "#arg_initializer"
             }
           ]
         }
@@ -262,5 +284,6 @@
       ]
     }
   },
-  "scopeName": "source.novus"
+  "scopeName": "source.novus",
+  "uuid": "4E3F51D5-1E08-48C3-9CA3-84769D3E9EAC"
 }

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -253,4 +253,6 @@ errUnsupportedOperator(const Source& src, const std::string& name, input::Span s
 [[nodiscard]] auto
 errUnsupportedArgInitializer(const Source& src, const std::string& name, input::Span span) -> Diag;
 
+[[nodiscard]] auto errNonOptArgFollowingOpt(const Source& src, input::Span span) -> Diag;
+
 } // namespace frontend

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -109,6 +109,12 @@ errUnableToInferFuncReturnType(const Source& src, const std::string& name, input
     const std::string& returnedType,
     input::Span span) -> Diag;
 
+[[nodiscard]] auto errNonMatchingInitializerType(
+    const Source& src,
+    const std::string& declaredType,
+    const std::string& intializerType,
+    input::Span span) -> Diag;
+
 [[nodiscard]] auto errUnableToInferLambdaReturnType(const Source& src, input::Span span) -> Diag;
 
 [[nodiscard]] auto
@@ -120,6 +126,8 @@ errConstNameConflictsWithType(const Source& src, const std::string& name, input:
 [[nodiscard]] auto
 errConstNameConflictsWithConst(const Source& src, const std::string& name, input::Span span)
     -> Diag;
+
+[[nodiscard]] auto errConstDeclareNotSupported(const Source& src, input::Span span) -> Diag;
 
 [[nodiscard]] auto errUndeclaredType(
     const Source& src, const std::string& name, unsigned int typeParams, input::Span span) -> Diag;

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -250,4 +250,7 @@ errUnsupportedOperator(const Source& src, const std::string& name, input::Span s
 
 [[nodiscard]] auto errIntrinsicFuncLiteral(const Source& src, input::Span span) -> Diag;
 
+[[nodiscard]] auto
+errUnsupportedArgInitializer(const Source& src, const std::string& name, input::Span span) -> Diag;
+
 } // namespace frontend

--- a/include/parse/argument_list_decl.hpp
+++ b/include/parse/argument_list_decl.hpp
@@ -40,6 +40,7 @@ public:
 
     auto operator==(const ArgSpec& rhs) const noexcept -> bool;
 
+    [[nodiscard]] auto getSpan() const -> input::Span;
     [[nodiscard]] auto getType() const noexcept -> const Type&;
     [[nodiscard]] auto getIdentifier() const noexcept -> const lex::Token&;
     [[nodiscard]] auto hasInitializer() const noexcept -> bool;

--- a/include/parse/argument_list_decl.hpp
+++ b/include/parse/argument_list_decl.hpp
@@ -1,28 +1,57 @@
 #pragma once
 #include "lex/token.hpp"
+#include "parse/node.hpp"
 #include "parse/type.hpp"
 #include <vector>
 
 namespace parse {
 
 // Argument list declaration.
-// Example in source: '(int i, float f)'.
+// Example in source: '(int i, float f = 42.0)'.
 class ArgumentListDecl final {
   friend auto operator<<(std::ostream& out, const ArgumentListDecl& rhs) -> std::ostream&;
 
 public:
+  // Argument initializer.
+  // Example in source: '= 42'.
+  class ArgInitializer final {
+  public:
+    ArgInitializer(lex::Token eq, NodePtr expr);
+
+    auto operator==(const ArgInitializer& rhs) const noexcept -> bool;
+
+    [[nodiscard]] auto getEq() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto getExpr() const noexcept -> const Node&;
+    [[nodiscard]] auto takeExpr() noexcept -> NodePtr;
+
+    [[nodiscard]] auto validate() const -> bool;
+
+  private:
+    lex::Token m_eq;
+    NodePtr m_expr;
+  };
+
+  // Argument specification.
+  // Example in source: 'int i = 42'.
   class ArgSpec final {
   public:
-    ArgSpec(Type type, lex::Token identifier);
+    ArgSpec(
+        Type type, lex::Token identifier, std::optional<ArgInitializer> initializer = std::nullopt);
 
     auto operator==(const ArgSpec& rhs) const noexcept -> bool;
 
     [[nodiscard]] auto getType() const noexcept -> const Type&;
     [[nodiscard]] auto getIdentifier() const noexcept -> const lex::Token&;
+    [[nodiscard]] auto hasInitializer() const noexcept -> bool;
+    [[nodiscard]] auto getInitializer() const noexcept -> const ArgInitializer&;
+    [[nodiscard]] auto getInitializer() noexcept -> ArgInitializer&;
+
+    [[nodiscard]] auto validate() const -> bool;
 
   private:
     Type m_type;
     lex::Token m_identifier;
+    std::optional<ArgInitializer> m_initializer;
   };
 
   using Iterator = typename std::vector<ArgSpec>::const_iterator;
@@ -37,6 +66,9 @@ public:
   [[nodiscard]] auto begin() const -> Iterator;
   [[nodiscard]] auto end() const -> Iterator;
   [[nodiscard]] auto getCount() const -> unsigned int;
+  [[nodiscard]] auto getInitializerCount() const -> unsigned int;
+  [[nodiscard]] auto getInitializer(unsigned int i) const -> const Node&;
+  [[nodiscard]] auto takeInitializer(unsigned int i) -> NodePtr;
 
   [[nodiscard]] auto getSpan() const -> input::Span;
   [[nodiscard]] auto getOpen() const -> const lex::Token&;

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -19,14 +19,14 @@ namespace parse {
     lex::Token kw,
     lex::Token id,
     std::optional<TypeSubstitutionList> typeSubs,
-    const ArgumentListDecl& argList,
+    ArgumentListDecl argList,
     std::optional<RetTypeSpec> retType,
     NodePtr body) -> NodePtr;
 
 [[nodiscard]] auto errInvalidAnonFuncExpr(
     std::vector<lex::Token> modifiers,
     lex::Token kw,
-    const ArgumentListDecl& argList,
+    ArgumentListDecl argList,
     std::optional<RetTypeSpec> retType,
     NodePtr body) -> NodePtr;
 

--- a/include/parse/node_expr_anon_func.hpp
+++ b/include/parse/node_expr_anon_func.hpp
@@ -30,6 +30,7 @@ public:
   [[nodiscard]] auto isImpure() const -> bool;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
   [[nodiscard]] auto getRetType() const -> const std::optional<RetTypeSpec>&;
+  [[nodiscard]] auto getBody() const -> const Node&;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 

--- a/include/parse/node_stmt_func_decl.hpp
+++ b/include/parse/node_stmt_func_decl.hpp
@@ -32,6 +32,7 @@ public:
   [[nodiscard]] auto getTypeSubs() const -> const std::optional<TypeSubstitutionList>&;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
   [[nodiscard]] auto getRetType() const -> const std::optional<RetTypeSpec>&;
+  [[nodiscard]] auto getBody() const -> const Node&;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 

--- a/include/prog/expr/node_call.hpp
+++ b/include/prog/expr/node_call.hpp
@@ -39,16 +39,28 @@ public:
   [[nodiscard]] auto getMode() const noexcept -> CallMode;
   [[nodiscard]] auto isFork() const noexcept -> bool;
   [[nodiscard]] auto isLazy() const noexcept -> bool;
+  [[nodiscard]] auto needsPatching() const noexcept -> bool;
+
+  auto applyPatches(const Program& prog) const -> void;
 
   auto accept(NodeVisitor* visitor) const -> void override;
 
 private:
   sym::FuncId m_func;
   sym::TypeId m_resultType;
-  std::vector<NodePtr> m_args;
   CallMode m_mode;
 
-  CallExprNode(sym::FuncId func, sym::TypeId resultType, std::vector<NodePtr> args, CallMode mode);
+  // NOTE: The arguments are mutable because optional arguments are applied in a separate phase
+  // after all functions have been defined.
+  mutable std::vector<NodePtr> m_args;
+  mutable bool m_needsPatching;
+
+  CallExprNode(
+      sym::FuncId func,
+      sym::TypeId resultType,
+      std::vector<NodePtr> args,
+      CallMode mode,
+      bool needsPatching);
 };
 
 // Factories.

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -150,8 +150,12 @@ public:
   auto declareDelegate(std::string name) -> sym::TypeId;
   auto declareFuture(std::string name) -> sym::TypeId;
   auto declareLazy(std::string name) -> sym::TypeId;
-  auto declarePureFunc(std::string name, sym::TypeSet input, sym::TypeId output) -> sym::FuncId;
-  auto declareAction(std::string name, sym::TypeSet input, sym::TypeId output) -> sym::FuncId;
+  auto
+  declarePureFunc(std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
+      -> sym::FuncId;
+  auto
+  declareAction(std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
+      -> sym::FuncId;
   auto declareFailIntrinsic(std::string name, sym::TypeId output) -> sym::FuncId;
 
   auto defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void;

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -114,8 +114,10 @@ public:
 
   [[nodiscard]] auto isImplicitConvertible(sym::TypeId from, sym::TypeId to) const -> bool;
 
-  [[nodiscard]] auto
-  isImplicitConvertible(const sym::TypeSet& toTypes, const sym::TypeSet& fromTypes) const -> bool;
+  [[nodiscard]] auto isImplicitConvertible(
+      const sym::TypeSet& toTypes,
+      const sym::TypeSet& fromTypes,
+      unsigned int numOptToTypes = 0u) const -> bool;
 
   [[nodiscard]] auto findCommonType(const std::vector<sym::TypeId>& types)
       -> std::optional<sym::TypeId>;
@@ -150,11 +152,11 @@ public:
   auto declareDelegate(std::string name) -> sym::TypeId;
   auto declareFuture(std::string name) -> sym::TypeId;
   auto declareLazy(std::string name) -> sym::TypeId;
-  auto
-  declarePureFunc(std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
+  auto declarePureFunc(
+      std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptInputs)
       -> sym::FuncId;
   auto
-  declareAction(std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
+  declareAction(std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptInputs)
       -> sym::FuncId;
   auto declareFailIntrinsic(std::string name, sym::TypeId output) -> sym::FuncId;
 
@@ -180,6 +182,10 @@ public:
   auto addExecStmt(sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
 
   auto updateFuncOutput(sym::FuncId funcId, sym::TypeId newOutput) -> void;
+
+  // Patch call expressions to apply the not-provided optional arguments.
+  // Should be called after all functions have been defined.
+  auto applyOptCallArgs() -> void;
 
 private:
   sym::TypeDeclTable m_typeDecls;

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -171,7 +171,11 @@ public:
   auto defineLazy(
       sym::TypeId id, sym::TypeId result, bool isAction, const std::vector<sym::TypeId>& aliases)
       -> void;
-  auto defineFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
+  auto defineFunc(
+      sym::FuncId id,
+      sym::ConstDeclTable consts,
+      expr::NodePtr body,
+      std::vector<expr::NodePtr> optArgInitializers) -> void;
 
   auto addExecStmt(sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
 

--- a/include/prog/sym/func_decl.hpp
+++ b/include/prog/sym/func_decl.hpp
@@ -26,6 +26,7 @@ public:
   [[nodiscard]] auto getName() const noexcept -> const std::string&;
   [[nodiscard]] auto getInput() const noexcept -> const TypeSet&;
   [[nodiscard]] auto getOutput() const noexcept -> TypeId;
+  [[nodiscard]] auto getNumOptArgs() const noexcept -> unsigned int;
 
   auto updateOutput(TypeId newOutput) noexcept -> void;
 
@@ -38,6 +39,7 @@ private:
   std::string m_name;
   TypeSet m_input;
   TypeId m_output;
+  unsigned int m_numOptArgs;
 
   FuncDecl(
       FuncId id,
@@ -47,7 +49,8 @@ private:
       bool isImplicitConv,
       std::string name,
       TypeSet input,
-      TypeId output);
+      TypeId output,
+      unsigned int m_numOptArgs);
 };
 
 auto operator<<(std::ostream& out, const FuncDecl& rhs) -> std::ostream&;

--- a/include/prog/sym/func_decl.hpp
+++ b/include/prog/sym/func_decl.hpp
@@ -26,7 +26,8 @@ public:
   [[nodiscard]] auto getName() const noexcept -> const std::string&;
   [[nodiscard]] auto getInput() const noexcept -> const TypeSet&;
   [[nodiscard]] auto getOutput() const noexcept -> TypeId;
-  [[nodiscard]] auto getNumOptArgs() const noexcept -> unsigned int;
+  [[nodiscard]] auto getMinInputCount() const noexcept -> unsigned int;
+  [[nodiscard]] auto getNumOptInputs() const noexcept -> unsigned int;
 
   auto updateOutput(TypeId newOutput) noexcept -> void;
 
@@ -39,7 +40,7 @@ private:
   std::string m_name;
   TypeSet m_input;
   TypeId m_output;
-  unsigned int m_numOptArgs;
+  unsigned int m_numOptInputs;
 
   FuncDecl(
       FuncId id,
@@ -50,7 +51,7 @@ private:
       std::string name,
       TypeSet input,
       TypeId output,
-      unsigned int m_numOptArgs);
+      unsigned int m_numOptInputs);
 };
 
 auto operator<<(std::ostream& out, const FuncDecl& rhs) -> std::ostream&;

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -70,7 +70,7 @@ public:
       std::string name,
       TypeSet input,
       TypeId output,
-      unsigned int numOptArgs = 0u) -> FuncId;
+      unsigned int numOptInputs = 0u) -> FuncId;
 
   auto registerAction(
       const Program& prog,
@@ -78,7 +78,7 @@ public:
       std::string name,
       TypeSet input,
       TypeId output,
-      unsigned int numOptArgs = 0u) -> FuncId;
+      unsigned int numOptInputs = 0u) -> FuncId;
 
   auto registerIntrinsic(
       const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId;
@@ -95,7 +95,7 @@ public:
       std::string name,
       TypeSet input,
       TypeId output,
-      unsigned int numOptArgs) -> void;
+      unsigned int numOptInputs) -> void;
 
   auto updateFuncOutput(FuncId id, TypeId newOutput) -> void;
 
@@ -117,7 +117,7 @@ private:
       std::string name,
       TypeSet input,
       TypeId output,
-      unsigned int numOptArgs) -> FuncId;
+      unsigned int numOptInputs) -> FuncId;
 };
 
 } // namespace sym

--- a/include/prog/sym/func_decl_table.hpp
+++ b/include/prog/sym/func_decl_table.hpp
@@ -64,13 +64,21 @@ public:
   auto registerImplicitConv(const Program& prog, FuncKind kind, TypeId input, TypeId output)
       -> FuncId;
 
-  auto
-  registerFunc(const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output)
-      -> FuncId;
+  auto registerFunc(
+      const Program& prog,
+      FuncKind kind,
+      std::string name,
+      TypeSet input,
+      TypeId output,
+      unsigned int numOptArgs = 0u) -> FuncId;
 
-  auto
-  registerAction(const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output)
-      -> FuncId;
+  auto registerAction(
+      const Program& prog,
+      FuncKind kind,
+      std::string name,
+      TypeSet input,
+      TypeId output,
+      unsigned int numOptArgs = 0u) -> FuncId;
 
   auto registerIntrinsic(
       const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId;
@@ -86,7 +94,8 @@ public:
       bool isImplicitConv,
       std::string name,
       TypeSet input,
-      TypeId output) -> void;
+      TypeId output,
+      unsigned int numOptArgs) -> void;
 
   auto updateFuncOutput(FuncId id, TypeId newOutput) -> void;
 
@@ -107,7 +116,8 @@ private:
       bool isImplicitConv,
       std::string name,
       TypeSet input,
-      TypeId output) -> FuncId;
+      TypeId output,
+      unsigned int numOptArgs) -> FuncId;
 };
 
 } // namespace sym

--- a/include/prog/sym/func_def.hpp
+++ b/include/prog/sym/func_def.hpp
@@ -22,6 +22,7 @@ public:
   [[nodiscard]] auto getId() const noexcept -> const FuncId&;
   [[nodiscard]] auto getConsts() const noexcept -> const sym::ConstDeclTable&;
   [[nodiscard]] auto getBody() const noexcept -> const expr::Node&;
+  [[nodiscard]] auto getOptArgInitializer(unsigned int i) const -> expr::NodePtr;
 
 private:
   sym::FuncId m_id;

--- a/include/prog/sym/func_def.hpp
+++ b/include/prog/sym/func_def.hpp
@@ -2,6 +2,7 @@
 #include "prog/expr/node.hpp"
 #include "prog/sym/const_decl_table.hpp"
 #include "prog/sym/func_decl_table.hpp"
+#include <vector>
 
 namespace prog::sym {
 
@@ -20,14 +21,19 @@ public:
 
   [[nodiscard]] auto getId() const noexcept -> const FuncId&;
   [[nodiscard]] auto getConsts() const noexcept -> const sym::ConstDeclTable&;
-  [[nodiscard]] auto getExpr() const noexcept -> const expr::Node&;
+  [[nodiscard]] auto getBody() const noexcept -> const expr::Node&;
 
 private:
   sym::FuncId m_id;
   sym::ConstDeclTable m_consts;
-  expr::NodePtr m_expr;
+  expr::NodePtr m_body;
+  std::vector<expr::NodePtr> m_optArgInitializers;
 
-  FuncDef(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr);
+  FuncDef(
+      sym::FuncId id,
+      sym::ConstDeclTable consts,
+      expr::NodePtr body,
+      std::vector<expr::NodePtr> optArgInitializers);
 };
 
 } // namespace prog::sym

--- a/include/prog/sym/func_def_table.hpp
+++ b/include/prog/sym/func_def_table.hpp
@@ -5,6 +5,7 @@
 #include "prog/sym/func_id_hasher.hpp"
 #include <set>
 #include <unordered_map>
+#include <vector>
 
 namespace prog::sym {
 
@@ -30,7 +31,8 @@ public:
       const sym::FuncDeclTable& funcTable,
       sym::FuncId id,
       sym::ConstDeclTable consts,
-      expr::NodePtr expr) -> void;
+      expr::NodePtr body,
+      std::vector<expr::NodePtr> optArgInitializers) -> void;
 
 private:
   std::unordered_map<FuncId, FuncDef, FuncIdHasher> m_funcDefs;

--- a/include/prog/sym/overload_options.hpp
+++ b/include/prog/sym/overload_options.hpp
@@ -8,6 +8,7 @@ enum class OverloadFlags : unsigned int {
   ExclActions      = 1U << 1U, // Exclude non-pure functions (actions).
   ExclNonUser      = 1U << 2U, // Exclude build-in functions.
   NoConvOnFirstArg = 1U << 3U, // Disallow implicit conversions on the first argument.
+  NoOptArgs        = 1U << 4U, // Disallow optional arguments (requires passing all args).
 };
 
 inline auto operator|(OverloadFlags lhs, OverloadFlags rhs) noexcept {

--- a/novstd/ascii.nov
+++ b/novstd/ascii.nov
@@ -50,7 +50,7 @@ fun escapeForPrinting(string str)
   invoke(lambda (int idx, string str)
     if idx >= str.length()      -> str
     if !str[idx].isPrintable()  -> replace = str[idx].escapeForPrinting();
-                                   self(idx + replace.length(), str.remove(idx).insert(idx, replace))
+                                   self(idx + replace.length(), str.remove(idx).insert(replace, idx))
     else                        -> self(++idx, str)
   , 0, str)
 

--- a/novstd/error.nov
+++ b/novstd/error.nov
@@ -91,16 +91,14 @@ fun map{T, TResult}(Either{T, Error} v, function{T, TResult} f) -> Either{TResul
 
 // -- Writers
 
-fun errorWriter()
-  errorWriter(ErrorWriteFlags.None)
-
 fun errorWriter(ErrorWriteFlags flags)
   errorWriter(noneWriter(), newlineWriter(), flags)
 
-fun errorWriter(Writer{None} prefixWriter, Writer{None} sepWriter)
-  errorWriter(prefixWriter, sepWriter, ErrorWriteFlags.None)
-
-fun errorWriter(Writer{None} prefixWriter, Writer{None} sepWriter, ErrorWriteFlags flags)
+fun errorWriter(
+    Writer{None}    prefixWriter  = noneWriter(),
+    Writer{None}    sepWriter     = newlineWriter(),
+    ErrorWriteFlags flags         = ErrorWriteFlags.None
+  )
   includeCodes  = (flags & ErrorWriteFlags.IncludeCodes) != 0;
   codeWriter    = litWriter('[') & txtIntWriter() & litWriter("] ");
   writer        = includeCodes  ? (codeWriter & stringWriter()) .map(lambda (Error err) makePair(err.code, err.msg))

--- a/novstd/file.nov
+++ b/novstd/file.nov
@@ -21,10 +21,7 @@ struct File =
 
 // -- Actions
 
-act fileOpen(Path p, FileMode m) -> Either{File, Error}
-  fileOpen(p, m, FileFlags.None)
-
-act fileOpen(Path p, FileMode m, FileFlags flags) -> Either{File, Error}
+act fileOpen(Path p, FileMode m, FileFlags flags = FileFlags.None) -> Either{File, Error}
   absPath     = p.getPathAbsolute();
   absPathStr  = absPath.string();
   stream      = intrinsic{file_openstream}(absPathStr, int(m) | flags << 8);

--- a/novstd/future.nov
+++ b/novstd/future.nov
@@ -17,10 +17,7 @@ act wait{T}(future{T} f, Duration d) -> bool
 act get{T}(future{T} f, Duration d) -> Option{T}
   f.wait(d) ? Option(f.get()) : None()
 
-act get{T}(future{T} f, action{bool} predicate) -> Option{T}
-  get(f, predicate, milliseconds(100))
-
-act get{T}(future{T} f, action{bool} predicate, Duration checkInternal) -> Option{T}
+act get{T}(future{T} f, action{bool} predicate, Duration checkInternal = milliseconds(100)) -> Option{T}
   if predicate() -> f.get(checkInternal) as T value ? Option(value) : self(f, predicate, checkInternal)
   else           -> None()
 

--- a/novstd/json.nov
+++ b/novstd/json.nov
@@ -41,24 +41,15 @@ fun jsonStringEscape(string str)
 
 // -- Conversions
 
-fun string(JsonObject o)
-  o.string("", WriterNewlineMode.None)
-
-fun string(JsonObject o, string indent, WriterNewlineMode newlineMode)
+fun string(JsonObject o, string indent = "", WriterNewlineMode newlineMode = WriterNewlineMode.None)
   w = jsonObjectWriter(jsonValueWriter());
   w(o, indent, newlineMode).string()
 
-fun string(JsonArray a)
-  a.string("", WriterNewlineMode.None)
-
-fun string(JsonArray a, string indent, WriterNewlineMode newlineMode)
+fun string(JsonArray a, string indent = "", WriterNewlineMode newlineMode = WriterNewlineMode.None)
   w = jsonArrayWriter(jsonValueWriter());
   w(a, indent, newlineMode).string()
 
-fun string(JsonValue v)
-  v.string("", WriterNewlineMode.None)
-
-fun string(JsonValue v, string indent, WriterNewlineMode newlineMode)
+fun string(JsonValue v, string indent = "", WriterNewlineMode newlineMode = WriterNewlineMode.None)
   w = jsonValueWriter();
   w(v, indent, newlineMode).string()
 
@@ -109,7 +100,7 @@ fun jsonStringParser() -> Parser{string}
     quote >> manyUntilParser(jsonUtf8CharParser(), quote).map(sum{string}) << quote
   ) ! Error("Invalid json string")
 
-fun jsonObjectParser(Parser{JsonValue} valParser)
+fun jsonObjectParser(Parser{JsonValue} valParser = lazyParser(lazy jsonValueParser()))
   open      = matchParser('{')    << whitespaceParser();
   key       = jsonStringParser()  << whitespaceParser() ! Error("Invalid object key");
   colon     = matchParser(':')    << whitespaceParser();
@@ -119,7 +110,7 @@ fun jsonObjectParser(Parser{JsonValue} valParser)
   keyValue  = (key << colon) & value;
   (open >> manyUntilParser(keyValue, comma, close) << close).map(construct{List{Pair{string, JsonValue}}, JsonObject})
 
-fun jsonArrayParser(Parser{JsonValue} valParser)
+fun jsonArrayParser(Parser{JsonValue} valParser = lazyParser(lazy jsonValueParser()))
   open  = matchParser('[')    << whitespaceParser();
   value = valParser           << whitespaceParser();
   comma = matchParser(',')    << whitespaceParser() !! Error("Expected comma or end of array");
@@ -127,8 +118,8 @@ fun jsonArrayParser(Parser{JsonValue} valParser)
   (open >> manyUntilParser(value, comma, close) << close).map(construct{List{JsonValue}, JsonArray})
 
 fun jsonValueParser()
-  objectP = jsonObjectParser(lazyParser(lazy jsonValueParser()));
-  arrayP  = jsonArrayParser(lazyParser(lazy jsonValueParser()));
+  objectP = jsonObjectParser();
+  arrayP  = jsonArrayParser();
   stringP = jsonStringParser();
   nullP   = jsonNullParser();
   boolP   = jsonBoolParser();

--- a/novstd/list.nov
+++ b/novstd/list.nov
@@ -46,10 +46,7 @@ fun []{T}(List{T} l, int startIdx, int endIdx) -> List{T}
 
 // -- Conversions
 
-fun string{T}(List{T} l)
-  l.string("[", ",", "]")
-
-fun string{T}(List{T} l, string start, string sep, string end)
+fun string{T}(List{T} l, string start = "[", string sep = ",", string end = "]")
   start + l.fold(lambda (string prefix, bool last, T v)
     last ? prefix + v.string() : prefix + v.string() + sep) + end
 
@@ -91,10 +88,7 @@ fun pushBack{T}(List{T} l, T val)
   if l as LNode{T} n  -> List(n.val, n.next.pushBack(val))
   if l is LEnd        -> List(val)
 
-fun pop{T}(List{T} l)
-  pop(l, 1)
-
-fun pop{T}(List{T} l, int amount)
+fun pop{T}(List{T} l, int amount = 1)
   if l as LNode{T} n  -> amount > 0 ? pop(n.next, --amount) : l
   if l is LEnd        -> l
 
@@ -102,10 +96,7 @@ fun pop{T}(List{T} l, function{T, bool} pred)
   if l as LNode{T} n  -> pred(n.val) ? pop(n.next, pred) : l
   if l is LEnd        -> l
 
-fun popBack{T}(List{T} l)
-  popBack(l, 1)
-
-fun popBack{T}(List{T} l, int amount)
+fun popBack{T}(List{T} l, int amount = 1)
   l.take(l.length() - amount)
 
 fun take{T}(List{T} l, int amount)

--- a/novstd/parser.nov
+++ b/novstd/parser.nov
@@ -29,10 +29,7 @@ fun (){T}(Parser{T} p, string str) -> ParseResult{T}
 fun (){T}(Parser{T} p, ParseState s) -> ParseResult{T}
   p.func(s)
 
-fun run{T}(Parser{T} p, string str) -> Either{T, Error}
-  p.run(str, ParseFlags.None)
-
-fun run{T}(Parser{T} p, string str, ParseFlags flags) -> Either{T, Error}
+fun run{T}(Parser{T} p, string str, ParseFlags flags = ParseFlags.None) -> Either{T, Error}
   res = p(str);
   if res as ParseSuccess{T} suc  -> suc.val
   if res as ParseFailure    fail ->
@@ -41,10 +38,7 @@ fun run{T}(Parser{T} p, string str, ParseFlags flags) -> Either{T, Error}
     txtPos = getTextPos(fail.state.str[0, fail.state.pos]);
     Error("Parsing failed, line: " + (txtPos.line + 1) + ", column: " + (txtPos.column + 1)) :: fail.err
 
-fun build{T}(Parser{T} p) -> function{string, Either{T, Error}}
-  p.build(ParseFlags.None)
-
-fun build{T}(Parser{T} p, ParseFlags flags) -> function{string, Either{T, Error}}
+fun build{T}(Parser{T} p, ParseFlags flags = ParseFlags.None) -> function{string, Either{T, Error}}
   lambda (string str)
     p.run(str, flags)
 
@@ -61,13 +55,13 @@ fun ==(ParseState s, char c)
   s.str[s.pos] == c
 
 fun ==(ParseState s, string text)
-  startsWithOffset(s.str, s.pos, text)
+  startsWith(s.str, text, s.pos)
 
 fun !=(ParseState s, char c)
   s.str[s.pos] != c
 
 fun !=(ParseState s, string text)
-  !startsWithOffset(s.str, s.pos, text)
+  !startsWith(s.str, text, s.pos)
 
 fun +(ParseState s, int amount)
   ParseState(s.str, s.pos + amount)
@@ -229,10 +223,7 @@ fun retParser{T}(T val)
 fun nopParser()
   retParser(true)
 
-fun failParser()
-  failParser(Error())
-
-fun failParser(Error error)
+fun failParser(Error error = Error())
   Parser(lambda (ParseState s) -> ParseResult{bool}
     s.failure(error)
   )
@@ -272,10 +263,7 @@ fun takeParser(int chars)
     else            -> s.failure(Error("Not enough characters remaining"))
   )
 
-fun whileParser(function{ParseState, bool} pred)
-  whileParser(pred, ParseFlags.None)
-
-fun whileParser(function{ParseState, bool} pred, ParseFlags flags)
+fun whileParser(function{ParseState, bool} pred, ParseFlags flags = ParseFlags.None)
   Parser(lambda (ParseState begin)
     impl =
     (
@@ -288,34 +276,19 @@ fun whileParser(function{ParseState, bool} pred, ParseFlags flags)
     impl(begin, flags.isOptional())
   )
 
-fun whileParser(function{char, bool} pred)
-  whileParser(pred, ParseFlags.None)
-
-fun whileParser(function{char, bool} pred, ParseFlags flags)
+fun whileParser(function{char, bool} pred, ParseFlags flags = ParseFlags.None)
   whileParser(lambda (ParseState s) pred(s[0]), flags)
 
-fun untilParser(function{char, bool} pred)
-  whileParser(!pred)
-
-fun untilParser(function{char, bool} pred, ParseFlags flags)
+fun untilParser(function{char, bool} pred, ParseFlags flags = ParseFlags.None)
   whileParser(!pred, flags)
 
-fun untilParser{T}(Parser{T} endParser)
-  untilParser(endParser, ParseFlags.None)
-
-fun untilParser{T}(Parser{T} endParser, ParseFlags flags)
+fun untilParser{T}(Parser{T} endParser, ParseFlags flags = ParseFlags.None)
   whileParser(lambda (ParseState s) endParser(s) is ParseFailure, flags)
 
-fun whitespaceParser()
-  whileParser(isWhitespace, ParseFlags.Optional)
-
-fun whitespaceParser(ParseFlags flags)
+fun whitespaceParser(ParseFlags flags = ParseFlags.Optional)
   whileParser(isWhitespace, flags)
 
-fun lineParser()
-  untilParser(isNewline)
-
-fun lineParser(ParseFlags flags)
+fun lineParser(ParseFlags flags = ParseFlags.None)
   untilParser(isNewline, flags)
 
 fun newlineParser()
@@ -378,10 +351,7 @@ fun txtIntParser()
     else            -> int(l)
   )
 
-fun txtHexParser()
-  txtHexParser(1)
-
-fun txtHexParser(int minDigits)
+fun txtHexParser(int minDigits = 1)
   Parser(lambda (ParseState s)
     invoke(
       lambda (ParseState s, int res, int digits) -> ParseResult{int}
@@ -431,10 +401,7 @@ fun manyParser{T}(Parser{T} p)
     ), begin, List{T}()).map(reverse{T})
   )
 
-fun manyParser{T, SepT}(Parser{T} p, Parser{SepT} seperator)
-  manyParser(p, seperator, ParseFlags.None)
-
-fun manyParser{T, SepT}(Parser{T} p, Parser{SepT} seperator, ParseFlags flags)
+fun manyParser{T, SepT}(Parser{T} p, Parser{SepT} seperator, ParseFlags flags = ParseFlags.None)
   Parser(lambda (ParseState begin)
     invoke(lambda (ParseState cur, List{T} result, bool required) -> ParseResult{List{T}}
     (
@@ -461,10 +428,7 @@ fun manyUntilParser{T, UntilT}(Parser{T} p, Parser{UntilT} until)
     ), begin, List{T}()).map(reverse{T})
   )
 
-fun manyUntilParser{T, SepT, UntilT}(Parser{T} p, Parser{SepT} seperator, Parser{UntilT} until)
-  manyUntilParser(p, seperator, until, ParseFlags.None)
-
-fun manyUntilParser{T, SepT, UntilT}(Parser{T} p, Parser{SepT} seperator, Parser{UntilT} until, ParseFlags flags)
+fun manyUntilParser{T, SepT, UntilT}(Parser{T} p, Parser{SepT} seperator, Parser{UntilT} until, ParseFlags flags = ParseFlags.None)
   reachedUntil = (lambda (ParseState s) until(s) is ParseSuccess{UntilT});
   Parser(lambda (ParseState begin)
     invoke(lambda (ParseState cur, List{T} result, bool required) -> ParseResult{List{T}}

--- a/novstd/path.nov
+++ b/novstd/path.nov
@@ -113,10 +113,7 @@ fun parent(Path p)
 
 // -- Parsers
 
-fun pathRelParser() -> Parser{PathRelative}
-  pathRelParser(endParser())
-
-fun pathRelParser{UntilT}(Parser{UntilT} until) -> Parser{PathRelative}
+fun pathRelParser{UntilT}(Parser{UntilT} until = endParser()) -> Parser{PathRelative}
   sepParser     = matchParser('/') | matchParser('\\');
   validateSeg   = (
     lambda (string s) !s.startsWith(" ") && !s.endsWith(" ") && !s.any(isControl)
@@ -129,10 +126,7 @@ fun pathRelParser{UntilT}(Parser{UntilT} until) -> Parser{PathRelative}
   flags         = ParseFlags.AllowTrailingSeperator;
   manyUntilParser(segParser, sepParser, until, flags).map(construct{List{string}, PathRelative})
 
-fun pathAbsParser() -> Parser{PathAbsolute}
-  pathAbsParser(endParser())
-
-fun pathAbsParser{UntilT}(Parser{UntilT} until) -> Parser{PathAbsolute}
+fun pathAbsParser{UntilT}(Parser{UntilT} until = endParser()) -> Parser{PathAbsolute}
   unixRoot    = matchParser("/");
   windowsRoot = (charParser() << (matchParser(":\\") | matchParser(":/")))
     .map(lambda (char drive) drive.toLower().string() + ":/");
@@ -140,10 +134,7 @@ fun pathAbsParser{UntilT}(Parser{UntilT} until) -> Parser{PathAbsolute}
     (unixRoot | windowsRoot) & pathRelParser(until)
   ).map(construct{string, PathRelative, PathAbsolute})
 
-fun pathParser() -> Parser{Path}
-  pathParser(endParser())
-
-fun pathParser{UntilT}(Parser{UntilT} until) -> Parser{Path}
+fun pathParser{UntilT}(Parser{UntilT} until = endParser()) -> Parser{Path}
   pathAbsParser(until).map(construct{PathAbsolute, Path}) |
   pathRelParser(until).map(construct{PathRelative, Path}) ! Error("Invalid path")
 

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -13,26 +13,25 @@ struct TcpServerState =
   int connectionCounter
 
 struct TcpServerSettings =
-  IpFamily                                              family,
-  int                                                   port,
-  int                                                   maxBacklog,
   action{TcpConnection, TcpServerState, Option{Error}}  clientHandler,
+  int                                                   port,
+  IpFamily                                              family,
+  int                                                   maxBacklog,
   action{TcpServerState, bool}                          cancelPredicate
 
 // -- Constructors
 
-fun TcpServerSettings(int port, action{TcpConnection, TcpServerState, Option{Error}} clientHandler)
-  TcpServerSettings(IpFamily.V4, port, clientHandler)
-
-fun TcpServerSettings(IpFamily family, int port, action{TcpConnection, TcpServerState, Option{Error}} clientHandler)
-  TcpServerSettings(family, port, 64, clientHandler)
-
-fun TcpServerSettings(IpFamily family, int port, int maxBacklog, action{TcpConnection, TcpServerState, Option{Error}} clientHandler)
+fun TcpServerSettings(
+    action{TcpConnection, TcpServerState, Option{Error}}  clientHandler,
+    int                                                   port            = 8080,
+    IpFamily                                              family          = IpFamily.V6,
+    int                                                   maxBacklog      = 64
+  )
   TcpServerSettings(
-    family,
-    port,
-    maxBacklog,
     clientHandler,
+    port,
+    family,
+    maxBacklog,
     impure lambda (TcpServerState state) interuptIsRequested())
 
 // -- Connection
@@ -104,21 +103,21 @@ act tcpServer(TcpServerSettings settings) -> Either{TcpServerState, Error}
 
 assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state) Option{Error}());
-  tcpServer(TcpServerSettings(IpFamily.V4, -1, 64, clientHandler))          is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V4, 65536, 64, clientHandler))       is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V4, intMax(), 64, clientHandler))    is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V4, 5000, intMax(), clientHandler))  is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V6, -1, 64, clientHandler))          is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V6, 65536, 64, clientHandler))       is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V6, intMax(), 64, clientHandler))    is Error  &&
-  tcpServer(TcpServerSettings(IpFamily.V6, 5010, intMax(), clientHandler))  is Error
+  tcpServer(TcpServerSettings(clientHandler, -1,        IpFamily.V4, 64))       is Error  &&
+  tcpServer(TcpServerSettings(clientHandler, 65536,     IpFamily.V4, 64))       is Error  &&
+  tcpServer(TcpServerSettings(clientHandler, intMax(),  IpFamily.V4, 64))       is Error  &&
+  tcpServer(TcpServerSettings(clientHandler, 5000,      IpFamily.V4, intMax())) is Error  &&
+  tcpServer(TcpServerSettings(clientHandler, -1,        IpFamily.V6, 64))       is Error  &&
+  tcpServer(TcpServerSettings(clientHandler, 65536,     IpFamily.V6, 64))       is Error  &&
+  tcpServer(TcpServerSettings(clientHandler, intMax(),  IpFamily.V6, 64))       is Error  &&
+  tcpServer(TcpServerSettings(clientHandler, 5010,      IpFamily.V6, intMax())) is Error
 )
 
 assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write(c.socket.readLine() + '\n')
   );
-  fork tcpServer(TcpServerSettings(IpFamily.V4, 5011, clientHandler));
+  fork tcpServer(TcpServerSettings(clientHandler, 5011, IpFamily.V4));
   client = (impure lambda(string message)
     c = tcpConnection(ipV4Loopback(), 5011).failOnError();
     c.write(message + '\n').failOnError();
@@ -134,7 +133,7 @@ assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write(c.socket.readLine() + '\n')
   );
-  fork tcpServer(TcpServerSettings(IpFamily.V6, 5012, clientHandler));
+  fork tcpServer(TcpServerSettings(clientHandler, 5012));
   client = (impure lambda(string message)
     c = tcpConnection(ipV6Loopback(), 5012).failOnError();
     c.write(message + '\n').failOnError();
@@ -150,7 +149,7 @@ assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     Option(Error("Did not go well"))
   );
-  res = fork tcpServer(TcpServerSettings(IpFamily.V6, 5013, clientHandler));
+  res = fork tcpServer(TcpServerSettings(clientHandler, 5013));
   client = tcpConnection(ipV6Loopback(), 5013).failOnError();
   res.get() == Error("Did not go well")
 )
@@ -162,7 +161,7 @@ assert(
   cancelPredicate = (impure lambda (TcpServerState state)
     true
   );
-  res = tcpServer(TcpServerSettings(IpFamily.V6, 5014, 64, clientHandler, cancelPredicate));
+  res = tcpServer(TcpServerSettings(clientHandler, 5014, IpFamily.V6, 64, cancelPredicate));
   if res as Error          err  -> printErr(err); false
   if res as TcpServerState s    -> s == TcpServerState(0)
 )
@@ -174,7 +173,7 @@ assert(
   clientHandler = (impure lambda (TcpConnection c, TcpServerState state)
     c.write("Hello\n")
   );
-  server = fork tcpServer(TcpServerSettings(IpFamily.V6, 5015, 64, clientHandler, cancelPredicate));
+  server = fork tcpServer(TcpServerSettings(clientHandler, 5015, IpFamily.V6, 64, cancelPredicate));
   parallelFor(25, impure lambda (int i)
     tcpConnection(ipV6Loopback(), 5015)
   );

--- a/novstd/terminal.nov
+++ b/novstd/terminal.nov
@@ -93,22 +93,13 @@ act termStyle(sys_stream s, TermStyle style) -> Option{Error}
 
 // -- Set 8-bit color (if terminal supports it).
 
-act termColor(Color color) -> Option{Error}
-  termColor(color, false)
-
-act termColor(Color color, bool background) -> Option{Error}
+act termColor(Color color, bool background = false) -> Option{Error}
   consoleOpen().map(impure lambda (Console c) c.stdOut.termColor(color, background))
 
-act termColor(Console c, Color color) -> Option{Error}
-  c.stdOut.termColor(color, false)
-
-act termColor(Console c, Color color, bool background) -> Option{Error}
+act termColor(Console c, Color color, bool background = false) -> Option{Error}
   c.stdOut.termColor(color, background)
 
-act termColor(sys_stream s, Color color) -> Option{Error}
-  s.termColor(color, false)
-
-act termColor(sys_stream s, Color color, bool background) -> Option{Error}
+act termColor(sys_stream s, Color color, bool background = false) -> Option{Error}
   toDiscrete = ( lambda (float v)
     int(clamp(v, 0.0, 1.0) * 5.0 + 0.5)
   );
@@ -188,16 +179,10 @@ act termAltScreen(Console c, bool active) -> Option{Error}
 
 // -- Clear the terminal.
 
-act termClearScreen() -> Option{Error}
-  termClearScreen(TermClearMode.All)
-
-act termClearScreen(Console c) -> Option{Error}
-  termClearScreen(c, TermClearMode.All)
-
-act termClearScreen(TermClearMode mode) -> Option{Error}
+act termClearScreen(TermClearMode mode = TermClearMode.All) -> Option{Error}
   consoleOpen().map(impure lambda (Console c) c.termClearScreen(mode))
 
-act termClearScreen(Console c, TermClearMode mode) -> Option{Error}
+act termClearScreen(Console c, TermClearMode mode = TermClearMode.All) -> Option{Error}
   actSeq(
     lazy c.stdOut.write(termEsc()),
     lazy c.stdOut.write('['),
@@ -205,10 +190,10 @@ act termClearScreen(Console c, TermClearMode mode) -> Option{Error}
     lazy c.stdOut.write('J')
   ) ! Error("Failed to clear the terminal screen")
 
-act termClearLine(TermClearMode mode) -> Option{Error}
+act termClearLine(TermClearMode mode = TermClearMode.All) -> Option{Error}
   consoleOpen().map(impure lambda (Console c) c.termClearLine(mode))
 
-act termClearLine(Console c, TermClearMode mode) -> Option{Error}
+act termClearLine(Console c, TermClearMode mode = TermClearMode.All) -> Option{Error}
   actSeq(
     lazy c.stdOut.write(termEsc()),
     lazy c.stdOut.write('['),

--- a/novstd/text.nov
+++ b/novstd/text.nov
@@ -55,42 +55,33 @@ fun contains(string str, string subStr)
 fun length(string str) -> int
   intrinsic{string_length}(str)
 
-fun indexOf(string str, string subStr)
-  indexOf(str, 0, subStr, 0)
-
-fun indexOf(string str, int idx, string subStr, int subStrIdx)
+fun indexOf(string str, string subStr, int idx = 0, int subStrIdx = 0)
   if idx >= str.length()            -> -1
   if str[idx] == subStr[subStrIdx]  -> subStrIdx >= --subStr.length() ?
                                         idx - --subStr.length() :
-                                        indexOf(str, ++idx, subStr, ++subStrIdx)
-  else                              -> indexOf(str, subStrIdx == 0 ? ++idx : idx, subStr, 0)
+                                        indexOf(str, subStr, ++idx, ++subStrIdx)
+  else                              -> indexOf(str, subStr, subStrIdx == 0 ? ++idx : idx, 0)
 
 fun indexOfLast(string str, string subStr)
-  indexOfLast(str, --str.length(), subStr, --subStr.length())
+  indexOfLast(str, subStr, str.length() - 1, subStr.length() - 1)
 
-fun indexOfLast(string str, int idx, string subStr, int subStrIdx)
+fun indexOfLast(string str, string subStr, int idx, int subStrIdx)
   if idx < 0                        -> -1
   if str[idx] == subStr[subStrIdx]  -> subStrIdx <= 0 ?
                                         idx :
-                                        indexOfLast(str, --idx, subStr, --subStrIdx)
+                                        indexOfLast(str, subStr, --idx, --subStrIdx)
   else                              -> indexOfLast(
                                           str,
-                                          subStrIdx == --subStr.length() ? --idx : idx,
                                           subStr,
+                                          subStrIdx == --subStr.length() ? --idx : idx,
                                           --subStr.length())
 
-fun indexOf(string str, function{char, bool} pred)
-  indexOf(str, 0, pred)
-
-fun indexOf(string str, int idx, function{char, bool} pred)
+fun indexOf(string str, function{char, bool} pred, int idx = 0)
   if idx >= str.length()  -> -1
   if pred(str[idx])       -> idx
-  else                    -> indexOf(str, ++idx, pred)
+  else                    -> indexOf(str, pred, ++idx)
 
-fun startsWith(string str, string subStr)
-  startsWithOffset(str, 0, subStr)
-
-fun startsWithOffset(string str, int idx, string subStr)
+fun startsWith(string str, string subStr, int idx = 0)
   invoke(
     lambda (int subStrIdx)
       if subStrIdx >= subStr.length()               -> true
@@ -131,21 +122,18 @@ fun count(string str, function{char, bool} pred)
 fun replace(string str, string old, string new)
   invoke(
     lambda (string str, int startIdx)
-      idx = str.indexOf(startIdx, old, 0);
+      idx = str.indexOf(old, startIdx);
       if idx < 0  ->  str
       else        ->  newStr = str[0, idx] + new + str[idx + old.length(), str.length()];
                       self(newStr, idx + new.length())
   , str, 0)
 
-fun insert(string str, int idx, string val)
+fun insert(string str, string val, int idx)
   if idx == 0             -> val + str
   if idx >= str.length()  -> str + val
   else                    -> str[0, idx] + val + str[idx, str.length()]
 
-fun remove(string str, int idx)
-  str.remove(idx, 1)
-
-fun remove(string str, int idx, int amount)
+fun remove(string str, int idx, int amount = 1)
   if amount <= 0                  -> str
   if idx == 0                     -> str[amount, str.length()]
   if idx == str.length() - amount -> str[0, str.length() - amount]
@@ -174,10 +162,7 @@ fun split(string str, function{char, bool} pred)
       else                    -> self(--startIdx, endIdx, result)
   , --str.length(), --str.length(), List{string}())
 
-fun trimStart(string str)
-  str.trimStart(isWhitespace)
-
-fun trimStart(string str, function{char, bool} pred)
+fun trimStart(string str, function{char, bool} pred = isWhitespace)
   invoke(
     lambda (int idx)
       c = str[idx];
@@ -185,10 +170,7 @@ fun trimStart(string str, function{char, bool} pred)
       else                    -> str[idx, str.length()]
   , 0)
 
-fun trimEnd(string str)
-  str.trimEnd(isWhitespace)
-
-fun trimEnd(string str, function{char, bool} pred)
+fun trimEnd(string str, function{char, bool} pred = isWhitespace)
   invoke(
     lambda (int idx)
       c = str[idx];
@@ -196,10 +178,7 @@ fun trimEnd(string str, function{char, bool} pred)
       else                    -> str[0, ++idx]
   , --str.length())
 
-fun trim(string str)
-  str.trim(isWhitespace)
-
-fun trim(string str, function{char, bool} pred)
+fun trim(string str, function{char, bool} pred = isWhitespace)
   str.trimStart(pred).trimEnd(pred)
 
 fun toChars(string str)
@@ -345,10 +324,10 @@ assert(
   "".replace("", "") == "")
 
 assert(
-  "helloworld".insert(0, "_") == "_helloworld" &&
-  "helloworld".insert("helloworld".length(), "_") == "helloworld_" &&
-  "helloworld".insert(1, "_") == "h_elloworld" &&
-  "helloworld".insert(5, "_") == "hello_world")
+  "helloworld".insert("_", 0) == "_helloworld" &&
+  "helloworld".insert("_", "helloworld".length()) == "helloworld_" &&
+  "helloworld".insert("_", 1) == "h_elloworld" &&
+  "helloworld".insert("_", 5) == "hello_world")
 
 assert(
   "".remove(0)            == "" &&

--- a/novstd/time.nov
+++ b/novstd/time.nov
@@ -106,10 +106,7 @@ enum Month =
   November,
   December
 
-fun string(Month m)
-  string(m, false)
-
-fun string(Month m, bool short)
+fun string(Month m, bool short = false)
   if m == Month.January   -> short ? "Jan" : "January"
   if m == Month.February  -> short ? "Feb" : "February"
   if m == Month.March     -> short ? "Mar" : "March"
@@ -142,10 +139,7 @@ fun WeekDay(Date e)
 fun WeekDay(DateTime dt)
   WeekDay((dt.daysSinceEpoch() + WeekDay.Thursday) % 7)
 
-fun string(WeekDay d)
-  string(d, false)
-
-fun string(WeekDay d, bool short)
+fun string(WeekDay d, bool short = false)
   if d ==  WeekDay.Sunday     -> short ? "Sun"  : "Sunday"
   if d ==  WeekDay.Monday     -> short ? "Mon"  : "Monday"
   if d ==  WeekDay.Tuesday    -> short ? "Tue"  : "Tuesday"

--- a/novstd/version.nov
+++ b/novstd/version.nov
@@ -55,13 +55,7 @@ fun isPrerelease(Version v)
 
 // -- Conversions
 
-fun Version(int major, int minor)
-  Version(major, minor, 0)
-
-fun Version(int major, int minor, int patch)
-  Version(major, minor, patch, List{string}(), List{string}())
-
-fun Version(int major, int minor, int patch, List{string} prereleaseTags)
+fun Version(int major, int minor, int patch = 0, List{string} prereleaseTags = List{string}())
   Version(major, minor, patch, prereleaseTags, List{string}())
 
 fun string(Version v)

--- a/novstd/writer.nov
+++ b/novstd/writer.nov
@@ -18,17 +18,14 @@ struct Writer{T} = function{WriterState, T, WriterState} func
 
 // -- Constructors
 
-fun WriterState()
-  WriterState("  ")
-
-fun WriterState(string indentStr)
+fun WriterState(string indentStr = "  ")
   WriterState(indentStr, WriterNewlineMode.Lf)
+
+fun WriterState(WriterNewlineMode newlineMode)
+  WriterState("  ", newlineMode)
 
 fun WriterState(string indentStr, WriterNewlineMode newlineMode)
   WriterState("", 0, indentStr, newlineMode)
-
-fun WriterState(WriterNewlineMode newlineMode)
-  WriterState("", 0, "  ", newlineMode)
 
 // -- Operators
 
@@ -162,10 +159,7 @@ fun txtIntWriter()
     s.write(i.string())
   )
 
-fun txtHexWriter()
-  txtHexWriter(0)
-
-fun txtHexWriter(int minDigits)
+fun txtHexWriter(int minDigits = 0)
   Writer(lambda (WriterState s, int i)
     str = i.toHexString();
     s.write(string('0', minDigits - str.length()) + str)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(prog STATIC
   prog/expr/utilities.cpp
 
   prog/internal/implicit_conv.cpp
+  prog/internal/opt_args.cpp
   prog/internal/overload.cpp
 
   prog/sym/const_decl_table.cpp

--- a/src/backend/generator.cpp
+++ b/src/backend/generator.cpp
@@ -35,7 +35,7 @@ generateFunc(novasm::Assembler* asmb, const prog::Program& program, const prog::
 
   // Generate the function body.
   auto genExpr = internal::GenExpr{program, asmb, func.getConsts(), func.getId(), true, 1};
-  func.getExpr().accept(&genExpr);
+  func.getBody().accept(&genExpr);
 
   // Root expression always has to produce a single value.
   assert(genExpr.getValuesProduced() == 1);

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -81,6 +81,10 @@ auto GenExpr::visit(const prog::expr::SwitchExprNode& n) -> void {
 }
 
 auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
+  if (n.needsPatching()) {
+    throw std::logic_error{"Call expression needs to be patched first"};
+  }
+
   const auto& funcDecl = m_prog.getFuncDecl(n.getFunc());
 
   // Special handling for union creation.

--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -155,6 +155,9 @@ auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchP
     return buildOutput(nullptr, std::move(importedSources), diags);
   }
 
+  // Patch all call expressions to apply the optional arguments if they didn't supply overrides.
+  prog->applyOptCallArgs();
+
   return buildOutput(std::move(prog), std::move(importedSources), {});
 }
 

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -625,4 +625,10 @@ auto errUnsupportedArgInitializer(const Source& src, const std::string& name, in
   return error(src, oss.str(), span);
 }
 
+auto errNonOptArgFollowingOpt(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Required argument cannot follow an optional argument";
+  return error(src, oss.str(), span);
+}
+
 } // namespace frontend

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -618,4 +618,11 @@ auto errIntrinsicFuncLiteral(const Source& src, input::Span span) -> Diag {
   return error(src, oss.str(), span);
 }
 
+auto errUnsupportedArgInitializer(const Source& src, const std::string& name, input::Span span)
+    -> Diag {
+  std::ostringstream oss;
+  oss << "Initializer for input argument '" << name << "' is unsupported in the current context";
+  return error(src, oss.str(), span);
+}
+
 } // namespace frontend

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -221,6 +221,17 @@ auto errNonMatchingFuncReturnType(
   return error(src, oss.str(), span);
 }
 
+auto errNonMatchingInitializerType(
+    const Source& src,
+    const std::string& declaredType,
+    const std::string& initializerType,
+    input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Initializer returns value of type '" << initializerType
+      << "' which is incompatible with the declared type '" << declaredType << "'";
+  return error(src, oss.str(), span);
+}
+
 auto errConstNameConflictsWithTypeSubstitution(
     const Source& src, const std::string& name, input::Span span) -> Diag {
   std::ostringstream oss;
@@ -247,6 +258,12 @@ auto errConstNameConflictsWithConst(const Source& src, const std::string& name, 
   std::ostringstream oss;
   oss << "Constant name '" << name
       << "' conflicts with an already declared constant in the same scope";
+  return error(src, oss.str(), span);
+}
+
+auto errConstDeclareNotSupported(const Source& src, input::Span span) -> Diag {
+  std::ostringstream oss;
+  oss << "Declaring constants is not supported in this context";
   return error(src, oss.str(), span);
 }
 

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -62,7 +62,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   if (!input) {
     return;
   }
-  const auto numOptArgs = getNumOptionalArgs(m_ctx, n);
+  const auto numOptInputs = getNumOptInputs(m_ctx, n);
 
   // Verify that this is not a duplicate declaration.
   if (m_ctx->getProg()->lookupFunc(name, input.value(), prog::OvOptions{0})) {
@@ -76,7 +76,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
     return;
   }
 
-  const auto isConv = isType(m_ctx, name);
+  const auto isConv = isType(m_ctx, nullptr, name);
   if (isConv && n.isAction()) {
     if (n.isAction()) {
       m_ctx->reportDiag(errNonPureConversion, n.getId().getSpan());
@@ -124,8 +124,8 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   // Declare the function in the program.
   const auto funcName = isConv ? getName(*m_ctx, *retType) : name;
   auto funcId         = n.isAction()
-      ? m_ctx->getProg()->declareAction(funcName, input.value(), retType.value(), numOptArgs)
-      : m_ctx->getProg()->declarePureFunc(funcName, input.value(), retType.value(), numOptArgs);
+      ? m_ctx->getProg()->declareAction(funcName, input.value(), retType.value(), numOptInputs)
+      : m_ctx->getProg()->declarePureFunc(funcName, input.value(), retType.value(), numOptInputs);
   m_funcDecls->emplace_back(funcId, m_ctx, name, n);
 }
 
@@ -144,7 +144,7 @@ auto DeclareUserFuncs::validateType(
 
   auto isValid    = true;
   const auto name = getName(type.getId());
-  if (!isType(m_ctx, name) &&
+  if (!isType(m_ctx, nullptr, name) &&
       std::find(typeSubParams.begin(), typeSubParams.end(), name) == typeSubParams.end()) {
 
     m_ctx->reportDiag(errUndeclaredType, name, type.getParamCount(), type.getSpan());

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -63,7 +63,6 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
     return;
   }
   const auto numOptArgs = getNumOptionalArgs(m_ctx, n);
-  (void)numOptArgs;
 
   // Verify that this is not a duplicate declaration.
   if (m_ctx->getProg()->lookupFunc(name, input.value(), prog::OvOptions{0})) {
@@ -125,8 +124,8 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   // Declare the function in the program.
   const auto funcName = isConv ? getName(*m_ctx, *retType) : name;
   auto funcId         = n.isAction()
-      ? m_ctx->getProg()->declareAction(funcName, input.value(), retType.value())
-      : m_ctx->getProg()->declarePureFunc(funcName, input.value(), retType.value());
+      ? m_ctx->getProg()->declareAction(funcName, input.value(), retType.value(), numOptArgs)
+      : m_ctx->getProg()->declarePureFunc(funcName, input.value(), retType.value(), numOptArgs);
   m_funcDecls->emplace_back(funcId, m_ctx, name, n);
 }
 

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -62,6 +62,8 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   if (!input) {
     return;
   }
+  const auto numOptArgs = getNumOptionalArgs(m_ctx, n);
+  (void)numOptArgs;
 
   // Verify that this is not a duplicate declaration.
   if (m_ctx->getProg()->lookupFunc(name, input.value(), prog::OvOptions{0})) {

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -23,7 +23,7 @@ auto defineFunc(
   auto funcSignature     = std::make_pair(funcDecl.getInput(), funcRetType);
 
   auto consts = prog::sym::ConstDeclTable{};
-  if (!declareFuncInput(ctx, typeSubTable, n, &consts)) {
+  if (!declareFuncInput(ctx, typeSubTable, n, &consts, false)) {
     return false;
   }
 

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -23,7 +23,7 @@ auto defineFunc(
   auto funcSignature     = std::make_pair(funcDecl.getInput(), funcRetType);
 
   auto consts = prog::sym::ConstDeclTable{};
-  if (!declareFuncInput(ctx, typeSubTable, n, &consts, false)) {
+  if (!declareFuncInput(ctx, typeSubTable, n, &consts, true)) {
     return false;
   }
 

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -36,7 +36,7 @@ auto defineFunc(
   }
 
   auto getExpr = GetExpr{ctx, typeSubTable, &constBinder, funcRetType, funcSignature, getExprFlags};
-  n[0].accept(&getExpr);
+  n.getBody().accept(&getExpr);
   auto expr = std::move(getExpr.getValue());
 
   // Report this diagnostic after processing the body so other errors have priority over this.
@@ -57,7 +57,7 @@ auto defineFunc(
     auto checkInfRec = CheckInfRecursion{*ctx, id};
     expr->accept(&checkInfRec);
     if (checkInfRec.isInfRecursion()) {
-      ctx->reportDiag(errPureFuncInfRecursion, n[0].getSpan());
+      ctx->reportDiag(errPureFuncInfRecursion, n.getBody().getSpan());
       return false;
     }
   }
@@ -83,7 +83,7 @@ auto defineFunc(
       funcDisplayName,
       getDisplayName(*ctx, funcRetType),
       getDisplayName(*ctx, expr->getType()),
-      n[0].getSpan());
+      n.getBody().getSpan());
   return false;
 }
 

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -280,8 +280,10 @@ auto FuncTemplate::getInputTypes(const prog::sym::TypeSet& argTypes)
 
     // Infer the type of the optional arg initializer.
     // NOTE: Will only work if the initializer does not depend on any of the type parameters.
-    const auto inferFlags =
-        m_isAction ? TypeInferExpr::Flags::AllowActionCalls : TypeInferExpr::Flags::None;
+    auto inferFlags = TypeInferExpr::Flags::NoOptArgs;
+    if (m_isAction) {
+      inferFlags = inferFlags | TypeInferExpr::Flags::AllowActionCalls;
+    }
     auto inferInitializerType = TypeInferExpr{m_ctx, nullptr, nullptr, inferFlags};
     m_parseNode->operator[](i).accept(&inferInitializerType);
 

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -6,6 +6,7 @@
 #include "internal/utilities.hpp"
 #include "parse/type_param_list.hpp"
 #include <cassert>
+#include <optional>
 
 namespace frontend::internal {
 
@@ -34,6 +35,14 @@ auto FuncTemplate::getTemplateName() const -> const std::string& { return m_name
 auto FuncTemplate::isAction() const -> bool { return m_isAction; }
 
 auto FuncTemplate::getTypeParamCount() const -> unsigned int { return m_typeSubs.size(); }
+
+auto FuncTemplate::getNumOptArgs() const -> unsigned int {
+  return m_parseNode->getArgList().getInitializerCount();
+}
+
+auto FuncTemplate::getMinArgumentCount() const -> unsigned int {
+  return getArgumentCount() - getNumOptArgs();
+}
 
 auto FuncTemplate::getArgumentCount() const -> unsigned int {
   return m_parseNode->getArgList().getCount();
@@ -84,13 +93,16 @@ auto FuncTemplate::getRetType(const prog::sym::TypeSet& typeParams)
 
 auto FuncTemplate::inferTypeParams(const prog::sym::TypeSet& argTypes)
     -> std::optional<InferResult> {
-  if (argTypes.getCount() != m_parseNode->getArgList().getCount()) {
+
+  auto inputTypes = getInputTypes(argTypes);
+  if (!inputTypes) {
     return std::nullopt;
   }
+
   auto typeParams = std::vector<prog::sym::TypeId>{};
   for (const auto& typeSub : m_typeSubs) {
     const auto inferredType =
-        inferSubTypeFromSpecs(*m_ctx, typeSub, m_parseNode->getArgList().getArgs(), argTypes);
+        inferSubTypeFromSpecs(*m_ctx, typeSub, m_parseNode->getArgList().getArgs(), *inputTypes);
     if (!inferredType || !inferredType->isConcrete()) {
       return std::nullopt;
     }
@@ -107,7 +119,8 @@ auto FuncTemplate::isCallable(
     const prog::sym::TypeSet& typeParams, const prog::sym::TypeSet& argTypes) -> bool {
   const auto subTable = createSubTable(typeParams);
   auto funcInput      = getFuncInput(m_ctx, &subTable, *m_parseNode);
-  return funcInput && m_ctx->getProg()->isImplicitConvertible(*funcInput, argTypes);
+  return funcInput &&
+      m_ctx->getProg()->isImplicitConvertible(*funcInput, argTypes, getNumOptArgs());
 }
 
 auto FuncTemplate::instantiate(const prog::sym::TypeSet& typeParams) -> const FuncTemplateInst* {
@@ -139,7 +152,7 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
     instance->m_success = false;
     return;
   }
-  const auto numOptArgs = getNumOptionalArgs(m_ctx, *m_parseNode);
+  const auto numOptInputs = getNumOptInputs(m_ctx, *m_parseNode);
 
   instance->m_retType =
       ::frontend::internal::getRetType(m_ctx, &subTable, m_parseNode->getRetType());
@@ -149,7 +162,7 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
     return;
   }
 
-  const auto isConv = isType(m_ctx, m_name);
+  const auto isConv = isType(m_ctx, nullptr, m_name);
   if (isConv && m_isAction) {
     m_ctx->reportDiag(errNonPureConversion, m_parseNode->getSpan());
     instance->m_success = false;
@@ -219,9 +232,9 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
   // Declare the function in the program.
   instance->m_func = m_isAction
       ? m_ctx->getProg()->declareAction(
-            funcName, std::move(*funcInput), *instance->m_retType, numOptArgs)
+            funcName, std::move(*funcInput), *instance->m_retType, numOptInputs)
       : m_ctx->getProg()->declarePureFunc(
-            funcName, std::move(*funcInput), *instance->m_retType, numOptArgs);
+            funcName, std::move(*funcInput), *instance->m_retType, numOptInputs);
 
   // Define the function.
   instance->m_success = defineFunc(
@@ -240,6 +253,43 @@ auto FuncTemplate::createSubTable(const prog::sym::TypeSet& typeParams) const
     subTable.declare(m_typeSubs[i], typeParams[i]);
   }
   return subTable;
+}
+
+auto FuncTemplate::getInputTypes(const prog::sym::TypeSet& argTypes)
+    -> std::optional<prog::sym::TypeSet> {
+
+  const auto maxInputs    = m_parseNode->getArgList().getCount();
+  const auto numOptInputs = getNumOptInputs(m_ctx, *m_parseNode);
+  const auto minInputs    = maxInputs - numOptInputs;
+
+  if (argTypes.getCount() < minInputs || argTypes.getCount() > maxInputs) {
+    return std::nullopt;
+  }
+
+  auto inputTypes = std::vector<prog::sym::TypeId>{};
+  inputTypes.reserve(maxInputs);
+
+  // Add the provided inputs.
+  for (auto argType : argTypes) {
+    inputTypes.push_back(argType);
+  }
+
+  // Add the types for the optional inputs.
+  // TODO: These initializer types could be cached.
+  for (auto i = argTypes.getCount() - minInputs; i != numOptInputs; ++i) {
+
+    // Infer the type of the optional arg initializer.
+    // NOTE: Will only work if the initializer does not depend on any of the type parameters.
+    const auto inferFlags =
+        m_isAction ? TypeInferExpr::Flags::AllowActionCalls : TypeInferExpr::Flags::None;
+    auto inferInitializerType = TypeInferExpr{m_ctx, nullptr, nullptr, inferFlags};
+    m_parseNode->operator[](i).accept(&inferInitializerType);
+
+    // NOTE: Can fail to infer the type, in which case the type is 'inferType'.
+    inputTypes.push_back(inferInitializerType.getInferredType());
+  }
+
+  return prog::sym::TypeSet{std::move(inputTypes)};
 }
 
 } // namespace frontend::internal

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -136,16 +136,16 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
   auto funcInput      = getFuncInput(m_ctx, &subTable, *m_parseNode);
   if (!funcInput) {
     assert(m_ctx->hasErrors());
-
     instance->m_success = false;
     return;
   }
+  const auto numOptArgs = getNumOptionalArgs(m_ctx, *m_parseNode);
+  (void)numOptArgs;
 
   instance->m_retType =
       ::frontend::internal::getRetType(m_ctx, &subTable, m_parseNode->getRetType());
   if (!instance->m_retType) {
     assert(m_ctx->hasErrors());
-
     instance->m_success = false;
     return;
   }

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -140,7 +140,6 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
     return;
   }
   const auto numOptArgs = getNumOptionalArgs(m_ctx, *m_parseNode);
-  (void)numOptArgs;
 
   instance->m_retType =
       ::frontend::internal::getRetType(m_ctx, &subTable, m_parseNode->getRetType());
@@ -219,8 +218,10 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
 
   // Declare the function in the program.
   instance->m_func = m_isAction
-      ? m_ctx->getProg()->declareAction(funcName, std::move(*funcInput), *instance->m_retType)
-      : m_ctx->getProg()->declarePureFunc(funcName, std::move(*funcInput), *instance->m_retType);
+      ? m_ctx->getProg()->declareAction(
+            funcName, std::move(*funcInput), *instance->m_retType, numOptArgs)
+      : m_ctx->getProg()->declarePureFunc(
+            funcName, std::move(*funcInput), *instance->m_retType, numOptArgs);
 
   // Define the function.
   instance->m_success = defineFunc(

--- a/src/frontend/internal/func_template.hpp
+++ b/src/frontend/internal/func_template.hpp
@@ -28,7 +28,11 @@ public:
   [[nodiscard]] auto getTemplateName() const -> const std::string&;
   [[nodiscard]] auto isAction() const -> bool;
   [[nodiscard]] auto getTypeParamCount() const -> unsigned int;
+
+  [[nodiscard]] auto getNumOptArgs() const -> unsigned int;
+  [[nodiscard]] auto getMinArgumentCount() const -> unsigned int;
   [[nodiscard]] auto getArgumentCount() const -> unsigned int;
+
   [[nodiscard]] auto getRetType(const prog::sym::TypeSet& typeParams)
       -> std::optional<prog::sym::TypeId>;
 
@@ -62,6 +66,9 @@ private:
 
   [[nodiscard]] auto createSubTable(const prog::sym::TypeSet& typeParams) const
       -> TypeSubstitutionTable;
+
+  [[nodiscard]] auto getInputTypes(const prog::sym::TypeSet& argTypes)
+      -> std::optional<prog::sym::TypeSet>;
 };
 
 } // namespace frontend::internal

--- a/src/frontend/internal/func_template_table.cpp
+++ b/src/frontend/internal/func_template_table.cpp
@@ -149,6 +149,10 @@ auto FuncTemplateTable::inferParams(
         argTypes.getCount() > funcTemplate.getArgumentCount()) {
       continue;
     }
+    if (options.hasFlag<prog::OvFlags::NoOptArgs>() &&
+        argTypes.getCount() != funcTemplate.getArgumentCount()) {
+      continue;
+    }
 
     if (satisfiesOptions(funcTemplate, options)) {
 

--- a/src/frontend/internal/func_template_table.cpp
+++ b/src/frontend/internal/func_template_table.cpp
@@ -145,8 +145,12 @@ auto FuncTemplateTable::inferParams(
   auto result              = std::vector<std::pair<FuncTemplate*, prog::sym::TypeSet>>{};
 
   for (auto& funcTemplate : itr->second) {
-    if (satisfiesOptions(funcTemplate, options) &&
-        funcTemplate.getArgumentCount() == argTypes.getCount()) {
+    if (argTypes.getCount() < funcTemplate.getMinArgumentCount() ||
+        argTypes.getCount() > funcTemplate.getArgumentCount()) {
+      continue;
+    }
+
+    if (satisfiesOptions(funcTemplate, options)) {
 
       const auto inferResult = funcTemplate.inferTypeParams(argTypes);
       if (inferResult && funcTemplate.isCallable(inferResult->types, argTypes)) {

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -104,7 +104,7 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
       *retType,
       selfSignature,
       isAction ? (Flags::AllowActionCalls | Flags::AllowPureFuncCalls) : Flags::AllowPureFuncCalls};
-  n[0].accept(&getExpr);
+  n.getBody().accept(&getExpr);
   if (!getExpr.m_expr) {
     assert(m_ctx->hasErrors());
     return;

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -55,7 +55,7 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
   auto consts = prog::sym::ConstDeclTable{};
 
   // Declare the input types in the cost table.
-  if (!declareFuncInput(m_ctx, m_typeSubTable, n, &consts)) {
+  if (!declareFuncInput(m_ctx, m_typeSubTable, n, &consts, false)) {
     assert(m_ctx->hasErrors());
     return;
   }

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -139,7 +139,7 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
             nameoss.str(), prog::sym::TypeSet{inputTypes}, *retType, 0u);
 
   // Define the function in the program.
-  m_ctx->getProg()->defineFunc(funcId, std::move(consts), std::move(expr));
+  m_ctx->getProg()->defineFunc(funcId, std::move(consts), std::move(expr), {});
 
   // Either create a function literal or a closure, depending on if the anonymous func binds any
   // consts from the parent.

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -134,8 +134,9 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
 
   // Declare the function in the program.
   const auto funcId = isAction
-      ? m_ctx->getProg()->declareAction(nameoss.str(), prog::sym::TypeSet{inputTypes}, *retType)
-      : m_ctx->getProg()->declarePureFunc(nameoss.str(), prog::sym::TypeSet{inputTypes}, *retType);
+      ? m_ctx->getProg()->declareAction(nameoss.str(), prog::sym::TypeSet{inputTypes}, *retType, 0u)
+      : m_ctx->getProg()->declarePureFunc(
+            nameoss.str(), prog::sym::TypeSet{inputTypes}, *retType, 0u);
 
   // Define the function in the program.
   m_ctx->getProg()->defineFunc(funcId, std::move(consts), std::move(expr));

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -21,6 +21,7 @@ public:
 
     AllowPureFuncCalls = 1U << 2U,
     AllowActionCalls   = 1U << 3U,
+    NoOptArgs          = 1U << 4U, // Disallow optional arguments (requires passing all args).
   };
 
   GetExpr() = delete;
@@ -144,6 +145,9 @@ private:
     }
     if (!hasFlag<Flags::AllowActionCalls>()) {
       ovFlags = ovFlags | prog::OvFlags::ExclActions;
+    }
+    if (hasFlag<Flags::NoOptArgs>()) {
+      ovFlags = ovFlags | prog::OvFlags::NoOptArgs;
     }
     if (excludeNonUser) {
       ovFlags = ovFlags | prog::OvFlags::ExclNonUser;

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -72,6 +72,10 @@ private:
 
   prog::expr::NodePtr m_expr;
 
+  [[nodiscard]] auto getVisibleConsts() -> std::vector<prog::sym::ConstId>*;
+
+  [[nodiscard]] auto getVisibleConstsCopy() -> std::vector<prog::sym::ConstId>;
+
   [[nodiscard]] auto getChildExprs(const parse::Node& n, unsigned int skipAmount = 0U)
       -> std::unique_ptr<ExprSetData>;
 

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -27,11 +27,11 @@ TypeInferExpr::TypeInferExpr(
 
 auto TypeInferExpr::getInferredType() const noexcept -> prog::sym::TypeId { return m_type; }
 
-auto TypeInferExpr::visit(const parse::CommentNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::CommentNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ErrorNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ErrorNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
@@ -142,10 +142,8 @@ auto TypeInferExpr::visit(const parse::CallExprNode& n) -> void {
     if (!typeSet) {
       return;
     }
-    auto ovOptions = prog::OvOptions{
-        hasFlag<Flags::AllowActionCalls>() ? prog::OvFlags::None : prog::OvFlags::ExclActions};
     if (const auto callInfo =
-            m_ctx->getFuncTemplates()->getCallInfo(funcName, *typeSet, ovOptions)) {
+            m_ctx->getFuncTemplates()->getCallInfo(funcName, *typeSet, getOvOptions())) {
       if (n.isFork()) {
         m_type = asFuture(m_ctx, callInfo->resultType);
       } else if (n.isLazy()) {
@@ -219,8 +217,7 @@ auto TypeInferExpr::visit(const parse::IdExprNode& n) -> void {
     if (!typeSet) {
       return;
     }
-    const auto instances =
-        m_ctx->getFuncTemplates()->instantiate(name, *typeSet, prog::OvOptions{});
+    const auto instances = m_ctx->getFuncTemplates()->instantiate(name, *typeSet, getOvOptions());
     if (!instances.empty() && !m_ctx->hasErrors()) {
       m_type = getDelegate(m_ctx, *instances[0]->getFunc());
     }
@@ -228,8 +225,7 @@ auto TypeInferExpr::visit(const parse::IdExprNode& n) -> void {
   }
 
   // Non-templated function literal.
-  const auto funcs =
-      m_ctx->getProg()->lookupFunc(name, prog::OvOptions{prog::OvFlags::ExclNonUser});
+  const auto funcs = m_ctx->getProg()->lookupFunc(name, getOvOptions(true));
   if (!funcs.empty() && !m_ctx->hasErrors()) {
     m_type = getDelegate(m_ctx, funcs[0]);
     return;
@@ -290,7 +286,7 @@ auto TypeInferExpr::visit(const parse::IndexExprNode& n) -> void {
   }
 }
 
-auto TypeInferExpr::visit(const parse::IntrinsicExprNode& /*ununsed*/) -> void {}
+auto TypeInferExpr::visit(const parse::IntrinsicExprNode & /*ununsed*/) -> void {}
 
 auto TypeInferExpr::visit(const parse::IsExprNode& n) -> void {
   if (n.hasId()) {
@@ -332,11 +328,11 @@ auto TypeInferExpr::visit(const parse::LitExprNode& n) -> void {
 
 auto TypeInferExpr::visit(const parse::ParenExprNode& n) -> void { m_type = inferSubExpr(n[0]); }
 
-auto TypeInferExpr::visit(const parse::SwitchExprElseNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::SwitchExprElseNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::SwitchExprIfNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::SwitchExprIfNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
@@ -381,27 +377,27 @@ auto TypeInferExpr::visit(const parse::UnaryExprNode& n) -> void {
   }
 }
 
-auto TypeInferExpr::visit(const parse::EnumDeclStmtNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::EnumDeclStmtNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ExecStmtNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ExecStmtNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::FuncDeclStmtNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::FuncDeclStmtNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ImportStmtNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ImportStmtNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::StructDeclStmtNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::StructDeclStmtNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::UnionDeclStmtNode& /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::UnionDeclStmtNode & /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
@@ -458,13 +454,8 @@ auto TypeInferExpr::inferFuncCall(const std::string& funcName, const prog::sym::
     }
   }
 
-  auto ovFlags = prog::OvFlags::None;
-  if (!hasFlag<Flags::AllowActionCalls>()) {
-    ovFlags = ovFlags | prog::OvFlags::ExclActions;
-  }
-
   // Attempt to get a return-type for a non-templated function.
-  auto func = m_ctx->getProg()->lookupFunc(funcName, argTypes, prog::OvOptions{ovFlags});
+  auto func = m_ctx->getProg()->lookupFunc(funcName, argTypes, getOvOptions());
   if (func) {
     const auto& funcDecl = m_ctx->getProg()->getFuncDecl(*func);
     if (funcDecl.getOutput().isInfer()) {
@@ -474,8 +465,8 @@ auto TypeInferExpr::inferFuncCall(const std::string& funcName, const prog::sym::
   }
 
   // Attempt to get a return-type for a inferred templated function.
-  auto inferredTemplFuncCallInfo = m_ctx->getFuncTemplates()->inferParamsAndGetCallInfo(
-      funcName, argTypes, prog::OvOptions{ovFlags});
+  auto inferredTemplFuncCallInfo =
+      m_ctx->getFuncTemplates()->inferParamsAndGetCallInfo(funcName, argTypes, getOvOptions());
   if (inferredTemplFuncCallInfo) {
     return CallInfo{inferredTemplFuncCallInfo->resultType, inferredTemplFuncCallInfo->isAction};
   }

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -14,6 +14,7 @@ public:
     Aggressive = 1U << 1U,
 
     AllowActionCalls = 1U << 2U,
+    NoOptArgs        = 1U << 3U, // Disallow optional arguments (requires passing all args).
   };
 
   TypeInferExpr() = delete;
@@ -75,6 +76,20 @@ private:
   [[nodiscard]] inline auto hasFlag() const noexcept {
     return (static_cast<unsigned int>(m_flags) & static_cast<unsigned int>(F)) ==
         static_cast<unsigned int>(F);
+  }
+
+  [[nodiscard]] inline auto getOvOptions(bool excludeNonUser = false) const noexcept {
+    auto ovFlags = prog::OvFlags::None;
+    if (!hasFlag<Flags::AllowActionCalls>()) {
+      ovFlags = ovFlags | prog::OvFlags::ExclActions;
+    }
+    if (hasFlag<Flags::NoOptArgs>()) {
+      ovFlags = ovFlags | prog::OvFlags::NoOptArgs;
+    }
+    if (excludeNonUser) {
+      ovFlags = ovFlags | prog::OvFlags::ExclNonUser;
+    }
+    return prog::OvOptions{ovFlags};
   }
 };
 

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -443,6 +443,22 @@ auto getFuncInput(
 }
 
 template <typename FuncParseNode>
+auto getNumOptionalArgs(Context* ctx, const FuncParseNode& parseNode) -> unsigned int {
+  auto result = 0u;
+  for (const auto& arg : parseNode.getArgList()) {
+    if (arg.hasInitializer()) {
+      ++result;
+      continue;
+    }
+    if (result) {
+      ctx->reportDiag(errNonOptArgFollowingOpt, arg.getSpan());
+      return 0u;
+    }
+  }
+  return result;
+}
+
+template <typename FuncParseNode>
 auto declareFuncInput(
     Context* ctx,
     const TypeSubstitutionTable* subTable,
@@ -626,6 +642,9 @@ template std::optional<prog::sym::TypeSet>
 getFuncInput(Context* ctx, const TypeSubstitutionTable* subTable, const parse::FuncDeclStmtNode& n);
 template std::optional<prog::sym::TypeSet>
 getFuncInput(Context* ctx, const TypeSubstitutionTable* subTable, const parse::AnonFuncExprNode& n);
+
+template unsigned int getNumOptionalArgs(Context* ctx, const parse::FuncDeclStmtNode& n);
+template unsigned int getNumOptionalArgs(Context* ctx, const parse::AnonFuncExprNode& n);
 
 template bool declareFuncInput(
     Context* ctx,

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -363,7 +363,7 @@ auto inferRetType(
   }
 
   auto inferBodyType = TypeInferExpr{ctx, subTable, &constTypes, flags};
-  parseNode[0].accept(&inferBodyType);
+  parseNode.getBody().accept(&inferBodyType);
   return inferBodyType.getInferredType();
 }
 

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -447,11 +447,17 @@ auto declareFuncInput(
     Context* ctx,
     const TypeSubstitutionTable* subTable,
     const FuncParseNode& n,
-    prog::sym::ConstDeclTable* consts) -> bool {
+    prog::sym::ConstDeclTable* consts,
+    bool allowArgInitializer) -> bool {
   bool isValid = true;
   for (const auto& arg : n.getArgList()) {
     const auto constName = getConstName(ctx, subTable, *consts, arg.getIdentifier());
     if (!constName) {
+      isValid = false;
+      continue;
+    }
+    if (arg.hasInitializer() && !allowArgInitializer) {
+      ctx->reportDiag(errUnsupportedArgInitializer, *constName, arg.getSpan());
       isValid = false;
       continue;
     }
@@ -625,11 +631,13 @@ template bool declareFuncInput(
     Context* ctx,
     const TypeSubstitutionTable* subTable,
     const parse::FuncDeclStmtNode& n,
-    prog::sym::ConstDeclTable* consts);
+    prog::sym::ConstDeclTable* consts,
+    bool allowArgInitializer);
 template bool declareFuncInput(
     Context* ctx,
     const TypeSubstitutionTable* subTable,
     const parse::AnonFuncExprNode& n,
-    prog::sym::ConstDeclTable* consts);
+    prog::sym::ConstDeclTable* consts,
+    bool allowArgInitializer);
 
 } // namespace frontend::internal

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -74,7 +74,8 @@ template <typename FuncParseNode>
     Context* ctx,
     const TypeSubstitutionTable* subTable,
     const FuncParseNode& n,
-    prog::sym::ConstDeclTable* consts) -> bool;
+    prog::sym::ConstDeclTable* consts,
+    bool allowArgInitializer) -> bool;
 
 [[nodiscard]] auto getSubstitutionParams(Context* ctx, const parse::TypeSubstitutionList& subList)
     -> std::optional<std::vector<std::string>>;

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -70,7 +70,7 @@ getFuncInput(Context* ctx, const TypeSubstitutionTable* subTable, const FuncPars
     -> std::optional<prog::sym::TypeSet>;
 
 template <typename FuncParseNode>
-[[nodiscard]] auto getNumOptionalArgs(Context* ctx, const FuncParseNode& parseNode) -> unsigned int;
+[[nodiscard]] auto getNumOptInputs(Context* ctx, const FuncParseNode& parseNode) -> unsigned int;
 
 template <typename FuncParseNode>
 [[nodiscard]] auto declareFuncInput(
@@ -113,9 +113,11 @@ mangleName(Context* ctx, const std::string& name, const prog::sym::TypeSet& type
 [[nodiscard]] auto delegateOutAsLazy(Context* ctx, prog::sym::TypeId delegate)
     -> std::optional<prog::sym::TypeId>;
 
-[[nodiscard]] auto isType(Context* ctx, const std::string& name) -> bool;
+[[nodiscard]] auto
+isType(Context* ctx, const TypeSubstitutionTable* subTable, const std::string& name) -> bool;
 
-[[nodiscard]] auto isFuncOrConv(Context* ctx, const std::string& name) -> bool;
+[[nodiscard]] auto
+isFuncOrConv(Context* ctx, const TypeSubstitutionTable* subTable, const std::string& name) -> bool;
 
 [[nodiscard]] auto isPure(const Context* ctx, prog::sym::FuncId func) -> bool;
 

--- a/src/frontend/internal/utilities.hpp
+++ b/src/frontend/internal/utilities.hpp
@@ -70,6 +70,9 @@ getFuncInput(Context* ctx, const TypeSubstitutionTable* subTable, const FuncPars
     -> std::optional<prog::sym::TypeSet>;
 
 template <typename FuncParseNode>
+[[nodiscard]] auto getNumOptionalArgs(Context* ctx, const FuncParseNode& parseNode) -> unsigned int;
+
+template <typename FuncParseNode>
 [[nodiscard]] auto declareFuncInput(
     Context* ctx,
     const TypeSubstitutionTable* subTable,

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -56,6 +56,12 @@ auto inlineCalls(const prog::Program& prog, bool& modified) -> prog::Program {
 auto CallInlineRewriter::isInlinable(const prog::expr::CallExprNode* callExpr) -> bool {
   const auto funcId = callExpr->getFunc();
 
+  if (callExpr->needsPatching()) {
+    // This is not a valid state and means the frontend had an internal error and the backend will
+    // crash when trying to genenerate assembly.
+    return false;
+  }
+
   // Non-normal (fork or lazy) calls or calls to non-user funcs are not inlinable.
   if (callExpr->getMode() != prog::expr::CallMode::Normal ||
       !internal::isUserFunc(m_prog, funcId)) {

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -108,7 +108,7 @@ auto CallInlineRewriter::inlineCall(const prog::expr::CallExprNode* callExpr)
 
   // Remap the constants to point to the newly registered constants.
   auto remapper     = internal::ConstRemapper{m_prog, *m_consts, constMapping};
-  auto remappedExpr = remapper.rewrite(tgtFuncDef.getExpr());
+  auto remappedExpr = remapper.rewrite(tgtFuncDef.getBody());
 
   // Run another 'rewrite' pass on the remapped expression so we can also inline calls inside the
   // inlined function body.

--- a/src/opt/const_elimination.cpp
+++ b/src/opt/const_elimination.cpp
@@ -71,7 +71,7 @@ auto eliminateConsts(const prog::Program& prog, bool& modified) -> prog::Program
         // Create a map of how many times constants are used.
         auto constUsageMap  = ConstUsageMap{};
         auto findUsedConsts = internal::FindUsedConsts{&constUsageMap};
-        funcDef.getExpr().accept(&findUsedConsts);
+        funcDef.getBody().accept(&findUsedConsts);
 
         return std::make_unique<ConstEliminatorRewriter>(
             prog, funcId, consts, std::move(constUsageMap));

--- a/src/opt/internal/expr_matchers.cpp
+++ b/src/opt/internal/expr_matchers.cpp
@@ -29,7 +29,7 @@ auto isRecursive(const prog::Program& prog, prog::sym::FuncId funcId) -> bool {
   // Gather all the functions this function (indirectly) calls.
   auto calledFuncs     = std::unordered_set<prog::sym::FuncId, prog::sym::FuncIdHasher>{};
   auto findCalledFuncs = FindCalledFuncs{prog, &calledFuncs};
-  funcDef.getExpr().accept(&findCalledFuncs);
+  funcDef.getBody().accept(&findCalledFuncs);
 
   // Check if this function ever (indirectly) calls itself.
   return calledFuncs.find(funcId) != calledFuncs.end();

--- a/src/opt/internal/expr_matchers.hpp
+++ b/src/opt/internal/expr_matchers.hpp
@@ -38,7 +38,7 @@ auto matchesExpr(const prog::Program& prog, prog::sym::FuncId funcId, UnaryPredi
 
   const auto& funcDef = prog.getFuncDef(funcId);
   auto matcher        = ExprMatcher{predicate};
-  funcDef.getExpr().accept(&matcher);
+  funcDef.getBody().accept(&matcher);
 
   return matcher.isFound();
 }

--- a/src/opt/internal/find_called_funcs.cpp
+++ b/src/opt/internal/find_called_funcs.cpp
@@ -24,7 +24,7 @@ auto FindCalledFuncs::markFunc(prog::sym::FuncId func) -> void {
   const auto& funcDecl = m_prog.getFuncDecl(func);
   if (funcDecl.getKind() == prog::sym::FuncKind::User) {
     const auto& funcDef = m_prog.getFuncDef(func);
-    funcDef.getExpr().accept(this);
+    funcDef.getBody().accept(this);
   }
 }
 

--- a/src/opt/internal/find_used_funcs.cpp
+++ b/src/opt/internal/find_used_funcs.cpp
@@ -34,7 +34,7 @@ auto FindUsedFuncs::markFunc(prog::sym::FuncId func) -> void {
   const auto& funcDecl = m_prog.getFuncDecl(func);
   if (funcDecl.getKind() == prog::sym::FuncKind::User) {
     const auto& funcDef = m_prog.getFuncDef(func);
-    funcDef.getExpr().accept(this);
+    funcDef.getBody().accept(this);
   }
 }
 

--- a/src/opt/precompute_literals.cpp
+++ b/src/opt/precompute_literals.cpp
@@ -88,6 +88,12 @@ auto precomputeLiterals(const prog::Program& prog, bool& modified) -> prog::Prog
 auto PrecomputeRewriter::precomputeCall(const prog::expr::CallExprNode& callExpr)
     -> prog::expr::NodePtr {
 
+  if (callExpr.needsPatching()) {
+    // This is not a valid state and means the frontend had an internal error and the backend will
+    // crash when trying to genenerate assembly.
+    return callExpr.clone(this);
+  }
+
   if (callExpr.isFork()) {
     // Unable to precompute forked calls.
     return callExpr.clone(this);

--- a/src/opt/treeshake.cpp
+++ b/src/opt/treeshake.cpp
@@ -39,7 +39,7 @@ auto treeshake(const prog::Program& prog) -> prog::Program {
       for (const auto& constDecl : def.getConsts()) {
         findTypes.markType(constDecl.getType());
       }
-      def.getExpr().accept(&findTypes);
+      def.getBody().accept(&findTypes);
     }
   }
 

--- a/src/parse/argument_list_decl.cpp
+++ b/src/parse/argument_list_decl.cpp
@@ -37,6 +37,13 @@ auto ArgumentListDecl::ArgSpec::operator==(const ArgSpec& rhs) const noexcept ->
   return m_type == rhs.m_type && m_identifier == rhs.m_identifier;
 }
 
+auto ArgumentListDecl::ArgSpec::getSpan() const -> input::Span {
+  if (m_initializer) {
+    return input::Span::combine(m_type.getSpan(), m_initializer->getExpr().getSpan());
+  }
+  return input::Span::combine(m_type.getSpan(), m_identifier.getSpan());
+}
+
 auto ArgumentListDecl::ArgSpec::getType() const noexcept -> const Type& { return m_type; }
 
 auto ArgumentListDecl::ArgSpec::getIdentifier() const noexcept -> const lex::Token& {

--- a/src/parse/node_expr_anon_func.cpp
+++ b/src/parse/node_expr_anon_func.cpp
@@ -26,13 +26,19 @@ auto AnonFuncExprNode::operator!=(const Node& rhs) const noexcept -> bool {
 }
 
 auto AnonFuncExprNode::operator[](unsigned int i) const -> const Node& {
-  if (i == 0) {
+  const auto initializerCount = m_argList.getInitializerCount();
+  if (i < initializerCount) {
+    return m_argList.getInitializer(i);
+  }
+  if (i == initializerCount) {
     return *m_body;
   }
   throw std::out_of_range{"No child at given index"};
 }
 
-auto AnonFuncExprNode::getChildCount() const -> unsigned int { return 1; }
+auto AnonFuncExprNode::getChildCount() const -> unsigned int {
+  return m_argList.getInitializerCount() + 1;
+}
 
 auto AnonFuncExprNode::getSpan() const -> input::Span {
   if (!m_modifiers.empty()) {
@@ -50,6 +56,8 @@ auto AnonFuncExprNode::isImpure() const -> bool {
 auto AnonFuncExprNode::getArgList() const -> const ArgumentListDecl& { return m_argList; }
 
 auto AnonFuncExprNode::getRetType() const -> const std::optional<RetTypeSpec>& { return m_retType; }
+
+auto AnonFuncExprNode::getBody() const -> const Node& { return *m_body; }
 
 auto AnonFuncExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 
@@ -77,11 +85,12 @@ auto anonFuncExprNode(
   if (body == nullptr) {
     throw std::invalid_argument{"Body cannot be null"};
   }
-  return std::unique_ptr<AnonFuncExprNode>{new AnonFuncExprNode{std::move(modifiers),
-                                                                std::move(kw),
-                                                                std::move(argList),
-                                                                std::move(retType),
-                                                                std::move(body)}};
+  return std::unique_ptr<AnonFuncExprNode>{new AnonFuncExprNode{
+      std::move(modifiers),
+      std::move(kw),
+      std::move(argList),
+      std::move(retType),
+      std::move(body)}};
 }
 
 } // namespace parse

--- a/src/parse/node_stmt_func_decl.cpp
+++ b/src/parse/node_stmt_func_decl.cpp
@@ -32,13 +32,19 @@ auto FuncDeclStmtNode::operator!=(const Node& rhs) const noexcept -> bool {
 }
 
 auto FuncDeclStmtNode::operator[](unsigned int i) const -> const Node& {
-  if (i == 0) {
+  const auto initializerCount = m_argList.getInitializerCount();
+  if (i < initializerCount) {
+    return m_argList.getInitializer(i);
+  }
+  if (i == initializerCount) {
     return *m_body;
   }
   throw std::out_of_range{"No child at given index"};
 }
 
-auto FuncDeclStmtNode::getChildCount() const -> unsigned int { return 1; }
+auto FuncDeclStmtNode::getChildCount() const -> unsigned int {
+  return m_argList.getInitializerCount() + 1;
+}
 
 auto FuncDeclStmtNode::getSpan() const -> input::Span {
   return input::Span::combine(m_kw.getSpan(), m_body->getSpan());
@@ -55,6 +61,8 @@ auto FuncDeclStmtNode::getTypeSubs() const -> const std::optional<TypeSubstituti
 auto FuncDeclStmtNode::getArgList() const -> const ArgumentListDecl& { return m_argList; }
 
 auto FuncDeclStmtNode::getRetType() const -> const std::optional<RetTypeSpec>& { return m_retType; }
+
+auto FuncDeclStmtNode::getBody() const -> const Node& { return *m_body; }
 
 auto FuncDeclStmtNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }
 

--- a/src/prog/copy.cpp
+++ b/src/prog/copy.cpp
@@ -46,9 +46,9 @@ auto copyFunc(
 
   auto& toDefTable = internal::getFuncDefTable(to);
 
-  // NOTE: Optional arguments are not copied at this time.
-  const auto numOptArgs   = 0u;
-  auto optArgInitializers = std::vector<expr::NodePtr>{};
+  // NOTE: Optional input initializers are not copied at this time.
+  const auto numOptInputs   = 0u;
+  auto optInputInitializers = std::vector<expr::NodePtr>{};
 
   // Declare function in the 'to' program.
   toDeclTable.insertFunc(
@@ -60,7 +60,7 @@ auto copyFunc(
       fromDecl.getName(),
       fromDecl.getInput(),
       fromDecl.getOutput(),
-      numOptArgs);
+      numOptInputs);
 
   // Define function in the 'to' program, optionally rewriting the expresion.
   if (fromDecl.getKind() == sym::FuncKind::User) {
@@ -73,7 +73,7 @@ auto copyFunc(
     modified = rewriter && rewriter->hasModified();
 
     toDefTable.registerFunc(
-        toDeclTable, id, std::move(consts), std::move(newBody), std::move(optArgInitializers));
+        toDeclTable, id, std::move(consts), std::move(newBody), std::move(optInputInitializers));
   }
   return true;
 }

--- a/src/prog/copy.cpp
+++ b/src/prog/copy.cpp
@@ -46,6 +46,10 @@ auto copyFunc(
 
   auto& toDefTable = internal::getFuncDefTable(to);
 
+  // NOTE: Optional arguments are not copied at this time.
+  const auto numOptArgs   = 0u;
+  auto optArgInitializers = std::vector<expr::NodePtr>{};
+
   // Declare function in the 'to' program.
   toDeclTable.insertFunc(
       id,
@@ -56,7 +60,7 @@ auto copyFunc(
       fromDecl.getName(),
       fromDecl.getInput(),
       fromDecl.getOutput(),
-      fromDecl.getNumOptArgs());
+      numOptArgs);
 
   // Define function in the 'to' program, optionally rewriting the expresion.
   if (fromDecl.getKind() == sym::FuncKind::User) {
@@ -64,11 +68,12 @@ auto copyFunc(
     auto consts   = fromDef.getConsts();
     auto rewriter =
         rewriterFactory ? rewriterFactory(from, id, &consts) : std::unique_ptr<expr::Rewriter>{};
-    auto newExpr =
-        rewriter ? rewriter->rewrite(fromDef.getExpr()) : fromDef.getExpr().clone(nullptr);
+    auto newBody =
+        rewriter ? rewriter->rewrite(fromDef.getBody()) : fromDef.getBody().clone(nullptr);
     modified = rewriter && rewriter->hasModified();
 
-    toDefTable.registerFunc(toDeclTable, id, std::move(consts), std::move(newExpr));
+    toDefTable.registerFunc(
+        toDeclTable, id, std::move(consts), std::move(newBody), std::move(optArgInitializers));
   }
   return true;
 }

--- a/src/prog/copy.cpp
+++ b/src/prog/copy.cpp
@@ -55,7 +55,8 @@ auto copyFunc(
       fromDecl.isImplicitConv(),
       fromDecl.getName(),
       fromDecl.getInput(),
-      fromDecl.getOutput());
+      fromDecl.getOutput(),
+      fromDecl.getNumOptArgs());
 
   // Define function in the 'to' program, optionally rewriting the expresion.
   if (fromDecl.getKind() == sym::FuncKind::User) {

--- a/src/prog/internal/implicit_conv.cpp
+++ b/src/prog/internal/implicit_conv.cpp
@@ -71,9 +71,11 @@ auto isImplicitConvertible(
     const Program& prog,
     const sym::TypeSet& toTypes,
     const sym::TypeSet& fromTypes,
-    int maxConversions) -> bool {
+    int maxConversions,
+    unsigned int numOptToTypes) -> bool {
 
-  if (toTypes.getCount() != fromTypes.getCount()) {
+  const auto minToTypesCount = toTypes.getCount() - numOptToTypes;
+  if (fromTypes.getCount() < minToTypesCount || fromTypes.getCount() > toTypes.getCount()) {
     return false;
   }
   auto convAmount   = 0;
@@ -105,9 +107,12 @@ auto applyImplicitConversions(
   if (!fromArgs) {
     throw std::invalid_argument{"Null fromArgs pointer provided"};
   }
-  if (toTypes.getCount() != fromArgs->size()) {
-    throw std::invalid_argument{"Number of arguments does not match toTypes argument count"};
+  if (fromArgs->size() > toTypes.getCount()) {
+    throw std::invalid_argument{"Too many arguments provided"};
   }
+
+  // Note: Its a valid scenario to pass less arguments then there are types in 'toTypes', reason is
+  // the other types could be for optional arguments.
 
   auto fromArgsItr = fromArgs->begin();
   auto toTypesItr  = toTypes.begin();

--- a/src/prog/internal/implicit_conv.hpp
+++ b/src/prog/internal/implicit_conv.hpp
@@ -19,7 +19,8 @@ namespace prog::internal {
     const Program& prog,
     const sym::TypeSet& toTypes,
     const sym::TypeSet& fromTypes,
-    int maxConversions = -1) -> bool;
+    int maxConversions         = -1,
+    unsigned int numOptToTypes = 0U) -> bool;
 
 // Apply conversions to the fromArgs so are matches the toTypes.
 auto applyImplicitConversions(

--- a/src/prog/internal/opt_args.cpp
+++ b/src/prog/internal/opt_args.cpp
@@ -1,0 +1,75 @@
+#include "internal/opt_args.hpp"
+#include "prog/expr/node_call.hpp"
+#include "prog/expr/node_visitor_deep.hpp"
+#include "prog/program.hpp"
+
+namespace prog::internal {
+
+namespace {
+
+class ApplyAllOptArgsVisitor final : public prog::expr::DeepNodeVisitor {
+public:
+  ApplyAllOptArgsVisitor(const Program& prog) : m_prog{prog} {}
+
+  auto visit(const prog::expr::CallExprNode& n) -> void override;
+
+private:
+  const Program& m_prog;
+};
+
+auto ApplyAllOptArgsVisitor::visit(const prog::expr::CallExprNode& n) -> void {
+
+  n.applyPatches(m_prog);
+
+  // Also apply optional arguments for any nested calls.
+  visitNode(&n);
+}
+
+} // namespace
+
+auto applyOptArgIntializers(const Program& prog, sym::FuncId func, std::vector<expr::NodePtr>* args)
+    -> void {
+
+  if (!args) {
+    throw std::invalid_argument{"Null args pointer provided"};
+  }
+
+  const auto& funcDecl = prog.getFuncDecl(func);
+  if (args->size() == funcDecl.getInput().getCount()) {
+    return; // No need to apply any optional initializers.
+  }
+
+  if (funcDecl.getKind() != sym::FuncKind::User) {
+    throw std::invalid_argument{"Optional arguments are only supported on user functions"};
+  }
+
+  const auto& funcDef = prog.getFuncDef(func);
+
+  const auto numOptInputsToApply = funcDecl.getInput().getCount() - args->size();
+  if (numOptInputsToApply > funcDecl.getNumOptInputs()) {
+    throw std::invalid_argument{"Too little parameters provided"};
+  }
+
+  const auto numOptInputsToSkip = funcDecl.getNumOptInputs() - numOptInputsToApply;
+  for (auto i = 0u; i != numOptInputsToApply; ++i) {
+    args->push_back(funcDef.getOptArgInitializer(numOptInputsToSkip + i));
+  }
+}
+
+auto applyOptArgIntializers(const Program& prog) -> void {
+
+  auto visitor = ApplyAllOptArgsVisitor{prog};
+
+  for (auto itr = prog.beginFuncDefs(); itr != prog.endFuncDefs(); ++itr) {
+    auto funcId         = *itr;
+    const auto& funcDef = prog.getFuncDef(funcId);
+    funcDef.getBody().accept(&visitor);
+  }
+
+  for (auto itr = prog.beginExecStmts(); itr != prog.endExecStmts(); ++itr) {
+    const auto& execStmt = *itr;
+    execStmt.getExpr().accept(&visitor);
+  }
+}
+
+} // namespace prog::internal

--- a/src/prog/internal/opt_args.hpp
+++ b/src/prog/internal/opt_args.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "prog/program.hpp"
+
+namespace prog::internal {
+
+// Add optional argument intializers to the given args to make func callable.
+auto applyOptArgIntializers(const Program& prog, sym::FuncId func, std::vector<expr::NodePtr>* args)
+    -> void;
+
+// Add optional argument intializers to all calls that do not provide overrides.
+auto applyOptArgIntializers(const Program& prog) -> void;
+
+} // namespace prog::internal

--- a/src/prog/internal/overload.cpp
+++ b/src/prog/internal/overload.cpp
@@ -15,9 +15,10 @@ auto findOverload(
   auto resultConvAmount                        = std::numeric_limits<int>::max();
 
   for (const auto& overload : overloads) {
-    const auto ovInput = declTable[overload].getInput();
-    if (ovInput.getCount() != input.getCount()) {
-      continue; // Argument count has to match.
+    const auto& overloadDecl = declTable[overload];
+    if (input.getCount() < overloadDecl.getMinInputCount() ||
+        input.getCount() > overloadDecl.getInput().getCount()) {
+      continue;
     }
 
     // Check if this overload satisfies the given options.
@@ -32,11 +33,15 @@ auto findOverload(
         declTable[overload].getKind() != sym::FuncKind::User) {
       continue;
     }
+    if (options.hasFlag<Flags::NoOptArgs>() &&
+        input.getCount() != overloadDecl.getInput().getCount()) {
+      continue;
+    }
 
     auto convAmount = 0;
     auto valid      = true;
     auto inputItr   = input.begin();
-    auto ovInputItr = ovInput.begin();
+    auto ovInputItr = overloadDecl.getInput().begin();
     for (; inputItr != input.end(); ++inputItr, ++ovInputItr) {
       if (*inputItr == *ovInputItr) {
         continue;

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -726,8 +726,13 @@ auto Program::defineLazy(
   m_typeDefs.registerLazy(m_typeDecls, id, result, isAction);
 }
 
-auto Program::defineFunc(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) -> void {
-  m_funcDefs.registerFunc(m_funcDecls, id, std::move(consts), std::move(expr));
+auto Program::defineFunc(
+    sym::FuncId id,
+    sym::ConstDeclTable consts,
+    expr::NodePtr body,
+    std::vector<expr::NodePtr> optArgInitializers) -> void {
+  m_funcDefs.registerFunc(
+      m_funcDecls, id, std::move(consts), std::move(body), std::move(optArgInitializers));
 }
 
 auto Program::addExecStmt(sym::ConstDeclTable consts, expr::NodePtr expr) -> void {

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -1,5 +1,6 @@
 #include "prog/program.hpp"
 #include "internal/implicit_conv.hpp"
+#include "internal/opt_args.hpp"
 #include "internal/overload.hpp"
 #include "prog/operator.hpp"
 
@@ -441,8 +442,9 @@ auto Program::isImplicitConvertible(sym::TypeId from, sym::TypeId to) const -> b
 }
 
 auto Program::isImplicitConvertible(
-    const sym::TypeSet& toTypes, const sym::TypeSet& fromTypes) const -> bool {
-  return internal::isImplicitConvertible(*this, toTypes, fromTypes);
+    const sym::TypeSet& toTypes, const sym::TypeSet& fromTypes, unsigned int numOptToTypes) const
+    -> bool {
+  return internal::isImplicitConvertible(*this, toTypes, fromTypes, -1, numOptToTypes);
 }
 
 auto Program::findCommonType(const std::vector<sym::TypeId>& types) -> std::optional<sym::TypeId> {
@@ -556,17 +558,17 @@ auto Program::declareLazy(std::string name) -> sym::TypeId {
 }
 
 auto Program::declarePureFunc(
-    std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
+    std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptInputs)
     -> sym::FuncId {
   return m_funcDecls.registerFunc(
-      *this, sym::FuncKind::User, std::move(name), std::move(input), output, numOptArgs);
+      *this, sym::FuncKind::User, std::move(name), std::move(input), output, numOptInputs);
 }
 
 auto Program::declareAction(
-    std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
+    std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptInputs)
     -> sym::FuncId {
   return m_funcDecls.registerAction(
-      *this, sym::FuncKind::User, std::move(name), std::move(input), output, numOptArgs);
+      *this, sym::FuncKind::User, std::move(name), std::move(input), output, numOptInputs);
 }
 
 auto Program::declareFailIntrinsic(std::string name, sym::TypeId output) -> sym::FuncId {
@@ -742,5 +744,7 @@ auto Program::addExecStmt(sym::ConstDeclTable consts, expr::NodePtr expr) -> voi
 auto Program::updateFuncOutput(sym::FuncId funcId, sym::TypeId newOutput) -> void {
   m_funcDecls.updateFuncOutput(funcId, newOutput);
 }
+
+auto Program::applyOptCallArgs() -> void { internal::applyOptArgIntializers(*this); }
 
 } // namespace prog

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -555,16 +555,18 @@ auto Program::declareLazy(std::string name) -> sym::TypeId {
   return m_typeDecls.registerType(sym::TypeKind::Lazy, std::move(name));
 }
 
-auto Program::declarePureFunc(std::string name, sym::TypeSet input, sym::TypeId output)
+auto Program::declarePureFunc(
+    std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
     -> sym::FuncId {
   return m_funcDecls.registerFunc(
-      *this, sym::FuncKind::User, std::move(name), std::move(input), output);
+      *this, sym::FuncKind::User, std::move(name), std::move(input), output, numOptArgs);
 }
 
-auto Program::declareAction(std::string name, sym::TypeSet input, sym::TypeId output)
+auto Program::declareAction(
+    std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptArgs)
     -> sym::FuncId {
   return m_funcDecls.registerAction(
-      *this, sym::FuncKind::User, std::move(name), std::move(input), output);
+      *this, sym::FuncKind::User, std::move(name), std::move(input), output, numOptArgs);
 }
 
 auto Program::declareFailIntrinsic(std::string name, sym::TypeId output) -> sym::FuncId {

--- a/src/prog/sym/func_decl.cpp
+++ b/src/prog/sym/func_decl.cpp
@@ -11,7 +11,7 @@ FuncDecl::FuncDecl(
     std::string name,
     TypeSet input,
     TypeId output,
-    unsigned int numOptArgs) :
+    unsigned int numOptInputs) :
     m_id{id},
     m_kind{kind},
     m_isAction{isAction},
@@ -20,7 +20,7 @@ FuncDecl::FuncDecl(
     m_name{std::move(name)},
     m_input{std::move(input)},
     m_output{output},
-    m_numOptArgs{numOptArgs} {}
+    m_numOptInputs{numOptInputs} {}
 
 auto FuncDecl::operator==(const FuncDecl& rhs) const noexcept -> bool { return m_id == rhs.m_id; }
 
@@ -42,9 +42,13 @@ auto FuncDecl::getName() const noexcept -> const std::string& { return m_name; }
 
 auto FuncDecl::getInput() const noexcept -> const TypeSet& { return m_input; }
 
-auto FuncDecl::getNumOptArgs() const noexcept -> unsigned int { return m_numOptArgs; }
-
 auto FuncDecl::getOutput() const noexcept -> TypeId { return m_output; }
+
+auto FuncDecl::getNumOptInputs() const noexcept -> unsigned int { return m_numOptInputs; }
+
+auto FuncDecl::getMinInputCount() const noexcept -> unsigned int {
+  return m_input.getCount() - m_numOptInputs;
+}
 
 auto FuncDecl::updateOutput(TypeId newOutput) noexcept -> void { m_output = newOutput; }
 

--- a/src/prog/sym/func_decl.cpp
+++ b/src/prog/sym/func_decl.cpp
@@ -10,7 +10,8 @@ FuncDecl::FuncDecl(
     bool isImplicitConv,
     std::string name,
     TypeSet input,
-    TypeId output) :
+    TypeId output,
+    unsigned int numOptArgs) :
     m_id{id},
     m_kind{kind},
     m_isAction{isAction},
@@ -18,7 +19,8 @@ FuncDecl::FuncDecl(
     m_isImplicitConv{isImplicitConv},
     m_name{std::move(name)},
     m_input{std::move(input)},
-    m_output{output} {}
+    m_output{output},
+    m_numOptArgs{numOptArgs} {}
 
 auto FuncDecl::operator==(const FuncDecl& rhs) const noexcept -> bool { return m_id == rhs.m_id; }
 
@@ -39,6 +41,8 @@ auto FuncDecl::isImplicitConv() const noexcept -> bool { return m_isImplicitConv
 auto FuncDecl::getName() const noexcept -> const std::string& { return m_name; }
 
 auto FuncDecl::getInput() const noexcept -> const TypeSet& { return m_input; }
+
+auto FuncDecl::getNumOptArgs() const noexcept -> unsigned int { return m_numOptArgs; }
 
 auto FuncDecl::getOutput() const noexcept -> TypeId { return m_output; }
 

--- a/src/prog/sym/func_decl_table.cpp
+++ b/src/prog/sym/func_decl_table.cpp
@@ -68,9 +68,9 @@ auto FuncDeclTable::registerFunc(
     std::string name,
     TypeSet input,
     TypeId output,
-    unsigned int numOptArgs) -> FuncId {
+    unsigned int numOptInputs) -> FuncId {
   return registerFunc(
-      prog, kind, false, false, false, std::move(name), std::move(input), output, numOptArgs);
+      prog, kind, false, false, false, std::move(name), std::move(input), output, numOptInputs);
 }
 
 auto FuncDeclTable::registerAction(
@@ -79,9 +79,9 @@ auto FuncDeclTable::registerAction(
     std::string name,
     TypeSet input,
     TypeId output,
-    unsigned int numOptArgs) -> FuncId {
+    unsigned int numOptInputs) -> FuncId {
   return registerFunc(
-      prog, kind, true, false, false, std::move(name), std::move(input), output, numOptArgs);
+      prog, kind, true, false, false, std::move(name), std::move(input), output, numOptInputs);
 }
 
 auto FuncDeclTable::registerIntrinsic(
@@ -104,7 +104,7 @@ auto FuncDeclTable::insertFunc(
     std::string name,
     TypeSet input,
     TypeId output,
-    unsigned int numOptArgs) -> void {
+    unsigned int numOptInputs) -> void {
 
   if (name.empty()) {
     throw std::invalid_argument{"Name has to contain aleast 1 char"};
@@ -112,7 +112,15 @@ auto FuncDeclTable::insertFunc(
 
   // Insert into function map.
   auto funcDecl = FuncDecl{
-      id, kind, isAction, isIntrinsic, isImplicitConv, name, std::move(input), output, numOptArgs};
+      id,
+      kind,
+      isAction,
+      isIntrinsic,
+      isImplicitConv,
+      name,
+      std::move(input),
+      output,
+      numOptInputs};
   if (!m_funcs.insert({id, std::move(funcDecl)}).second) {
     throw std::invalid_argument{"There is already a function registered with the same id"};
   }
@@ -163,7 +171,7 @@ auto FuncDeclTable::registerFunc(
     std::string name,
     TypeSet input,
     TypeId output,
-    unsigned int numOptArgs) -> FuncId {
+    unsigned int numOptInputs) -> FuncId {
 
   if (name.empty()) {
     throw std::invalid_argument{"Name has to contain aleast 1 char"};
@@ -192,7 +200,7 @@ auto FuncDeclTable::registerFunc(
       std::move(name),
       std::move(input),
       output,
-      numOptArgs};
+      numOptInputs};
   m_funcs.insert({id, std::move(funcDecl)});
   return id;
 }

--- a/src/prog/sym/func_decl_table.cpp
+++ b/src/prog/sym/func_decl_table.cpp
@@ -54,31 +54,45 @@ auto FuncDeclTable::lookupIntrinsic(
     OverloadOptions options) const -> std::optional<FuncId> {
   return internal::findOverload(prog, *this, lookupByName(name, true, options), input, options);
 }
+
 auto FuncDeclTable::registerImplicitConv(
     const Program& prog, FuncKind kind, TypeId input, TypeId output) -> FuncId {
 
   auto name = prog.getTypeDecl(output).getName();
-  return registerFunc(prog, kind, false, false, true, std::move(name), TypeSet{input}, output);
+  return registerFunc(prog, kind, false, false, true, std::move(name), TypeSet{input}, output, 0u);
 }
 
 auto FuncDeclTable::registerFunc(
-    const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId {
-  return registerFunc(prog, kind, false, false, false, std::move(name), std::move(input), output);
+    const Program& prog,
+    FuncKind kind,
+    std::string name,
+    TypeSet input,
+    TypeId output,
+    unsigned int numOptArgs) -> FuncId {
+  return registerFunc(
+      prog, kind, false, false, false, std::move(name), std::move(input), output, numOptArgs);
 }
 
 auto FuncDeclTable::registerAction(
-    const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId {
-  return registerFunc(prog, kind, true, false, false, std::move(name), std::move(input), output);
+    const Program& prog,
+    FuncKind kind,
+    std::string name,
+    TypeSet input,
+    TypeId output,
+    unsigned int numOptArgs) -> FuncId {
+  return registerFunc(
+      prog, kind, true, false, false, std::move(name), std::move(input), output, numOptArgs);
 }
 
 auto FuncDeclTable::registerIntrinsic(
     const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId {
-  return registerFunc(prog, kind, false, true, false, std::move(name), std::move(input), output);
+  return registerFunc(
+      prog, kind, false, true, false, std::move(name), std::move(input), output, 0u);
 }
 
 auto FuncDeclTable::registerIntrinsicAction(
     const Program& prog, FuncKind kind, std::string name, TypeSet input, TypeId output) -> FuncId {
-  return registerFunc(prog, kind, true, true, false, std::move(name), std::move(input), output);
+  return registerFunc(prog, kind, true, true, false, std::move(name), std::move(input), output, 0u);
 }
 
 auto FuncDeclTable::insertFunc(
@@ -89,15 +103,16 @@ auto FuncDeclTable::insertFunc(
     bool isImplicitConv,
     std::string name,
     TypeSet input,
-    TypeId output) -> void {
+    TypeId output,
+    unsigned int numOptArgs) -> void {
 
   if (name.empty()) {
     throw std::invalid_argument{"Name has to contain aleast 1 char"};
   }
 
   // Insert into function map.
-  auto funcDecl =
-      FuncDecl{id, kind, isAction, isIntrinsic, isImplicitConv, name, std::move(input), output};
+  auto funcDecl = FuncDecl{
+      id, kind, isAction, isIntrinsic, isImplicitConv, name, std::move(input), output, numOptArgs};
   if (!m_funcs.insert({id, std::move(funcDecl)}).second) {
     throw std::invalid_argument{"There is already a function registered with the same id"};
   }
@@ -147,7 +162,8 @@ auto FuncDeclTable::registerFunc(
     bool isImplicitConv,
     std::string name,
     TypeSet input,
-    TypeId output) -> FuncId {
+    TypeId output,
+    unsigned int numOptArgs) -> FuncId {
 
   if (name.empty()) {
     throw std::invalid_argument{"Name has to contain aleast 1 char"};
@@ -168,7 +184,15 @@ auto FuncDeclTable::registerFunc(
   (isIntrinsic ? m_intrinsicLookup : m_normalLookup).insert({name, id});
 
   auto funcDecl = FuncDecl{
-      id, kind, isAction, isIntrinsic, isImplicitConv, std::move(name), std::move(input), output};
+      id,
+      kind,
+      isAction,
+      isIntrinsic,
+      isImplicitConv,
+      std::move(name),
+      std::move(input),
+      output,
+      numOptArgs};
   m_funcs.insert({id, std::move(funcDecl)});
   return id;
 }

--- a/src/prog/sym/func_def.cpp
+++ b/src/prog/sym/func_def.cpp
@@ -2,13 +2,20 @@
 
 namespace prog::sym {
 
-FuncDef::FuncDef(sym::FuncId id, sym::ConstDeclTable consts, expr::NodePtr expr) :
-    m_id{id}, m_consts{std::move(consts)}, m_expr{std::move(expr)} {}
+FuncDef::FuncDef(
+    sym::FuncId id,
+    sym::ConstDeclTable consts,
+    expr::NodePtr body,
+    std::vector<expr::NodePtr> optArgInitializers) :
+    m_id{id},
+    m_consts{std::move(consts)},
+    m_body{std::move(body)},
+    m_optArgInitializers{std::move(optArgInitializers)} {}
 
 auto FuncDef::getId() const noexcept -> const FuncId& { return m_id; }
 
 auto FuncDef::getConsts() const noexcept -> const sym::ConstDeclTable& { return m_consts; }
 
-auto FuncDef::getExpr() const noexcept -> const expr::Node& { return *m_expr; }
+auto FuncDef::getBody() const noexcept -> const expr::Node& { return *m_body; }
 
 } // namespace prog::sym

--- a/src/prog/sym/func_def.cpp
+++ b/src/prog/sym/func_def.cpp
@@ -1,4 +1,5 @@
 #include "prog/sym/func_def.hpp"
+#include <cassert>
 
 namespace prog::sym {
 
@@ -17,5 +18,10 @@ auto FuncDef::getId() const noexcept -> const FuncId& { return m_id; }
 auto FuncDef::getConsts() const noexcept -> const sym::ConstDeclTable& { return m_consts; }
 
 auto FuncDef::getBody() const noexcept -> const expr::Node& { return *m_body; }
+
+auto FuncDef::getOptArgInitializer(unsigned int i) const -> expr::NodePtr {
+  assert(i < m_optArgInitializers.size());
+  return m_optArgInitializers[i]->clone(nullptr);
+}
 
 } // namespace prog::sym

--- a/src/prog/sym/func_def_table.cpp
+++ b/src/prog/sym/func_def_table.cpp
@@ -36,9 +36,10 @@ auto FuncDefTable::registerFunc(
   if (optArgInitializers.size() != funcTable[id].getNumOptArgs()) {
     throw std::invalid_argument{"Incorrect number of optional argument initializers provided"};
   }
-  const auto inputConsts = consts.getInputs();
+  const auto inputConsts      = consts.getInputs();
+  const auto nonOptInputCount = inputConsts.size() - funcTable[id].getNumOptArgs();
   for (auto i = 0u; i != optArgInitializers.size(); ++i) {
-    const auto inputConstId = inputConsts[inputConsts.size() - i];
+    const auto inputConstId = inputConsts[nonOptInputCount + i];
     if (consts[inputConstId].getType() != optArgInitializers[i]->getType()) {
       throw std::invalid_argument{"Optional argument initializer returns an incorrext type"};
     }

--- a/src/prog/sym/func_def_table.cpp
+++ b/src/prog/sym/func_def_table.cpp
@@ -33,15 +33,15 @@ auto FuncDefTable::registerFunc(
   if (expr::anyNodeNull(optArgInitializers)) {
     throw std::invalid_argument{"Optional argument intializer cannot be null"};
   }
-  if (optArgInitializers.size() != funcTable[id].getNumOptArgs()) {
+  if (optArgInitializers.size() != funcTable[id].getNumOptInputs()) {
     throw std::invalid_argument{"Incorrect number of optional argument initializers provided"};
   }
   const auto inputConsts      = consts.getInputs();
-  const auto nonOptInputCount = inputConsts.size() - funcTable[id].getNumOptArgs();
+  const auto nonOptInputCount = inputConsts.size() - funcTable[id].getNumOptInputs();
   for (auto i = 0u; i != optArgInitializers.size(); ++i) {
     const auto inputConstId = inputConsts[nonOptInputCount + i];
     if (consts[inputConstId].getType() != optArgInitializers[i]->getType()) {
-      throw std::invalid_argument{"Optional argument initializer returns an incorrext type"};
+      throw std::invalid_argument{"Optional argument initializer returns an incorrect type"};
     }
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(novtests
   frontend/get_switch_expr_test.cpp
   frontend/get_unary_expr_test.cpp
   frontend/import_test.cpp
+  frontend/opt_args_test.cpp
   frontend/overload_test.cpp
   frontend/parse_diags_test.cpp
   frontend/source_test.cpp

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -252,6 +252,9 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
         "act a1() -> int 42 "
         "act a2() lambda () a1()",
         errUndeclaredPureFunc(src, "a1", {}, input::Span{38, 41}));
+    CHECK_DIAG(
+        "fun f() lambda (int i = 0) i",
+        errUnsupportedArgInitializer(src, "i", input::Span{16, 24}));
   }
 }
 

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -16,9 +16,9 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
                                  "  lambda () 42");
     REQUIRE(output.isSuccess());
 
-    CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 42));
+    CHECK(findAnonFuncDef(output, 0).getBody() == *prog::expr::litIntNode(output.getProg(), 42));
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::litFuncNode(
             output.getProg(), GET_TYPE_ID(output, "__function_int"), findAnonFunc(output, 0)));
   }
@@ -28,9 +28,9 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
                                  "  impure lambda () 42");
     REQUIRE(output.isSuccess());
 
-    CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 42));
+    CHECK(findAnonFuncDef(output, 0).getBody() == *prog::expr::litIntNode(output.getProg(), 42));
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::litFuncNode(
             output.getProg(), GET_TYPE_ID(output, "__action_int"), findAnonFunc(output, 0)));
   }
@@ -40,9 +40,9 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
                                  "  lambda () 42");
     REQUIRE(output.isSuccess());
 
-    CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 42));
+    CHECK(findAnonFuncDef(output, 0).getBody() == *prog::expr::litIntNode(output.getProg(), 42));
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::litFuncNode(
             output.getProg(), GET_TYPE_ID(output, "__function_int"), findAnonFunc(output, 0)));
   }
@@ -52,9 +52,9 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
                                  "  (lambda () 1)()");
     REQUIRE(output.isSuccess());
 
-    CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 1));
+    CHECK(findAnonFuncDef(output, 0).getBody() == *prog::expr::litIntNode(output.getProg(), 1));
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::litFuncNode(
@@ -67,9 +67,9 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
                                  "  (impure lambda () 1)()");
     REQUIRE(output.isSuccess());
 
-    CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 1));
+    CHECK(findAnonFuncDef(output, 0).getBody() == *prog::expr::litIntNode(output.getProg(), 1));
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::litFuncNode(
@@ -82,9 +82,9 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
                                  "  (lambda () 1)()");
     REQUIRE(output.isSuccess());
 
-    CHECK(findAnonFuncDef(output, 0).getExpr() == *prog::expr::litIntNode(output.getProg(), 1));
+    CHECK(findAnonFuncDef(output, 0).getBody() == *prog::expr::litIntNode(output.getProg(), 1));
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::litFuncNode(
@@ -100,7 +100,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
     // Check the anonymous function.
     const auto& anonDef = findAnonFuncDef(output, 0);
     CHECK(
-        anonDef.getExpr() ==
+        anonDef.getBody() ==
         *prog::expr::constExprNode(anonDef.getConsts(), *anonDef.getConsts().lookup("i")));
 
     // Check the 'f' function.
@@ -112,7 +112,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
             output.getProg(), GET_TYPE_ID(output, "__function_int_int"), findAnonFunc(output, 0)),
         std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *callExpr);
   }
 
   SECTION("Invoke anonymous function with closure") {
@@ -123,7 +123,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
     // Check the anonymous function.
     const auto& anonDef = findAnonFuncDef(output, 0);
     CHECK(
-        anonDef.getExpr() ==
+        anonDef.getBody() ==
         *prog::expr::constExprNode(anonDef.getConsts(), *anonDef.getConsts().lookup("__bound_1")));
 
     // Check the 'f' function.
@@ -143,7 +143,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
             std::move(closureArgs)),
         std::move(delArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Invoke anonymous function with nested closure") {
@@ -154,7 +154,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
     // Check the most nested anonymous function.
     const auto& anon0Def = findAnonFuncDef(output, 0);
     CHECK(
-        anon0Def.getExpr() ==
+        anon0Def.getBody() ==
         *prog::expr::constExprNode(
             anon0Def.getConsts(), *anon0Def.getConsts().lookup("__bound_0")));
 
@@ -169,7 +169,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
         findAnonFunc(output, 0),
         std::move(anon1DefClosureArgs));
 
-    CHECK(anon1Def.getExpr() == *closureExpr);
+    CHECK(anon1Def.getBody() == *closureExpr);
 
     // Check the 'f' function.
     const auto& fDef  = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "float"));
@@ -185,7 +185,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
             std::move(fClosureArgs)),
         {});
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Return templated anonymous function") {
@@ -196,18 +196,18 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
     REQUIRE(output.isSuccess());
 
     CHECK(
-        findAnonFuncDef(output, 0).getExpr() ==
+        findAnonFuncDef(output, 0).getBody() ==
         *prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "int"), {}));
     CHECK(
-        findAnonFuncDef(output, 1).getExpr() ==
+        findAnonFuncDef(output, 1).getBody() ==
         *prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "float"), {}));
 
     CHECK(
-        GET_FUNC_DEF(output, "f1__int").getExpr() ==
+        GET_FUNC_DEF(output, "f1__int").getBody() ==
         *prog::expr::litFuncNode(
             output.getProg(), GET_TYPE_ID(output, "__function_int"), findAnonFunc(output, 0)));
     CHECK(
-        GET_FUNC_DEF(output, "f1__float").getExpr() ==
+        GET_FUNC_DEF(output, "f1__float").getBody() ==
         *prog::expr::litFuncNode(
             output.getProg(), GET_TYPE_ID(output, "__function_float"), findAnonFunc(output, 1)));
   }
@@ -218,7 +218,7 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
     const auto& anonFuncDef = findAnonFuncDef(output, 0);
 
     CHECK(
-        anonFuncDef.getExpr() ==
+        anonFuncDef.getBody() ==
         *applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 2)));
   }
 

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -107,6 +107,15 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
       const auto& funcDef = GET_FUNC_DEF(output, "f");
       CHECK(funcDef.getExpr() == *callExpr);
     }
+
+    SECTION("Declare function with optional argument") {
+      const auto& output = ANALYZE("fun f(int a, bool b = false) -> bool false");
+      REQUIRE(output.isSuccess());
+      const auto& funcDecl =
+          GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "bool"));
+      CHECK(funcDecl.getNumOptArgs() == 1);
+      CHECK(funcDecl.getOutput() == GET_TYPE_ID(output, "bool"));
+    }
   }
 
   SECTION("Actions") {

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -105,7 +105,7 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
           std::move(args));
 
       const auto& funcDef = GET_FUNC_DEF(output, "f");
-      CHECK(funcDef.getExpr() == *callExpr);
+      CHECK(funcDef.getBody() == *callExpr);
     }
 
     SECTION("Declare function with optional argument") {

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -190,6 +190,7 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
         errNonPureConversion(src, input::Span{25, 47}),
         errInvalidFuncInstantiation(src, input::Span{57, 57}),
         errNoTypeOrConversionFoundToInstantiate(src, "S", 1, input::Span{57, 64}));
+    CHECK_DIAG("fun f(int a = 0, int b) a * b", errNonOptArgFollowingOpt(src, input::Span{17, 21}));
   }
 }
 

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -113,7 +113,7 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
       REQUIRE(output.isSuccess());
       const auto& funcDecl =
           GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "bool"));
-      CHECK(funcDecl.getNumOptArgs() == 1);
+      CHECK(funcDecl.getNumOptInputs() == 1);
       CHECK(funcDecl.getOutput() == GET_TYPE_ID(output, "bool"));
     }
   }
@@ -198,7 +198,7 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
         "act a() S{int}()",
         errNonPureConversion(src, input::Span{25, 47}),
         errInvalidFuncInstantiation(src, input::Span{57, 57}),
-        errNoTypeOrConversionFoundToInstantiate(src, "S", 1, input::Span{57, 64}));
+        errUndeclaredTypeOrConversion(src, "S{int}", {}, input::Span{57, 64}));
     CHECK_DIAG("fun f(int a = 0, int b) a * b", errNonOptArgFollowingOpt(src, input::Span{17, 21}));
   }
 }

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -97,15 +97,13 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
                                    "fun f() -false");
       REQUIRE(output.isSuccess());
 
-      auto args = std::vector<prog::expr::NodePtr>{};
-      args.push_back(prog::expr::litBoolNode(output.getProg(), false));
-      auto callExpr = prog::expr::callExprNode(
-          output.getProg(),
-          GET_OP_ID(output, prog::Operator::Minus, GET_TYPE_ID(output, "bool")),
-          std::move(args));
-
       const auto& funcDef = GET_FUNC_DEF(output, "f");
-      CHECK(funcDef.getBody() == *callExpr);
+      CHECK(
+          funcDef.getBody() ==
+          *prog::expr::callExprNode(
+              output.getProg(),
+              GET_OP_ID(output, prog::Operator::Minus, GET_TYPE_ID(output, "bool")),
+              EXPRS(prog::expr::litBoolNode(output.getProg(), false))));
     }
 
     SECTION("Declare function with optional argument") {

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -16,13 +16,12 @@ TEST_CASE("[frontend] Analyzing execute statements", "frontend") {
     auto execsBegin     = output.getProg().beginExecStmts();
     const auto execsEnd = output.getProg().endExecStmts();
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litBoolNode(output.getProg(), true));
-    args.push_back(prog::expr::litStringNode(output.getProg(), "hello world"));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "assert", GET_TYPE_ID(output, "bool"), GET_TYPE_ID(output, "string")),
-        std::move(args));
+        EXPRS(
+            prog::expr::litBoolNode(output.getProg(), true),
+            prog::expr::litStringNode(output.getProg(), "hello world")));
 
     CHECK(execsBegin->getExpr() == *callExpr);
     REQUIRE(++execsBegin == execsEnd);
@@ -38,16 +37,15 @@ TEST_CASE("[frontend] Analyzing execute statements", "frontend") {
     auto execsBegin     = output.getProg().beginExecStmts();
     const auto execsEnd = output.getProg().endExecStmts();
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(applyConv(
-        output,
-        "ConsoleKind",
-        "int",
-        prog::expr::litEnumNode(output.getProg(), GET_TYPE_ID(output, "ConsoleKind"), "StdOut")));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "openConsole", GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(applyConv(
+            output,
+            "ConsoleKind",
+            "int",
+            prog::expr::litEnumNode(
+                output.getProg(), GET_TYPE_ID(output, "ConsoleKind"), "StdOut"))));
 
     CHECK(execsBegin->getExpr() == *callExpr);
     REQUIRE(++execsBegin == execsEnd);

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -17,7 +17,7 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
     REQUIRE(a);
     CHECK(consts[a.value()].getKind() == prog::sym::ConstKind::Input);
     CHECK(consts[a.value()].getType() == GET_TYPE_ID(output, "int"));
-    CHECK(funcDef.getExpr() == *prog::expr::litIntNode(output.getProg(), 42));
+    CHECK(funcDef.getBody() == *prog::expr::litIntNode(output.getProg(), 42));
   }
 
   SECTION("Define function with conversion") {
@@ -26,7 +26,7 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 
     CHECK(
-        funcDef.getExpr() ==
+        funcDef.getBody() ==
         *applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 2)));
   }
 
@@ -40,7 +40,7 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
     REQUIRE(a);
     CHECK(consts[a.value()].getKind() == prog::sym::ConstKind::Input);
     CHECK(consts[a.value()].getType() == GET_TYPE_ID(output, "int"));
-    CHECK(funcDef.getExpr() == *prog::expr::constExprNode(consts, *a));
+    CHECK(funcDef.getBody() == *prog::expr::constExprNode(consts, *a));
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -128,6 +128,13 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
           " if a > b  -> f(a, 0) "
           " else      -> f(0, b)",
           errPureFuncInfRecursion(src, input::Span{28, 69}));
+      CHECK_DIAG("fun f(int a = a) a", errUndeclaredConst(src, "a", input::Span{14, 14}));
+      CHECK_DIAG("fun f(int a = b = 42) a", errConstDeclareNotSupported(src, input::Span{14, 19}));
+      CHECK_DIAG(
+          "union U = int, bool "
+          "fun getU() U(42) "
+          "fun f(int a = getU() as int i ? i : 0) a",
+          errConstDeclareNotSupported(src, input::Span{51, 65}));
     }
   }
 }

--- a/tests/frontend/get_binary_expr_test.cpp
+++ b/tests/frontend/get_binary_expr_test.cpp
@@ -28,7 +28,7 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
             output, prog::Operator::Star, GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(funcDef.getExpr() == *callExpr);
+    CHECK(funcDef.getBody() == *callExpr);
   }
 
   SECTION("Get binary expression with conversion on lhs") {
@@ -49,7 +49,7 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
             GET_TYPE_ID(output, "float")),
         std::move(args));
 
-    CHECK(funcDef.getExpr() == *callExpr);
+    CHECK(funcDef.getBody() == *callExpr);
   }
 
   SECTION("Get binary expression with conversion on rhs") {
@@ -70,7 +70,7 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
             GET_TYPE_ID(output, "float")),
         std::move(args));
 
-    CHECK(funcDef.getExpr() == *callExpr);
+    CHECK(funcDef.getBody() == *callExpr);
   }
 
   SECTION("Get logic 'and' expression") {
@@ -89,7 +89,7 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Chain 'as' checks with binary 'and' in switch") {
@@ -128,7 +128,7 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
     auto switchExpr = prog::expr::switchExprNode(
         output.getProg(), std::move(switchConditions), std::move(switchBranches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Get logic 'or' expression") {
@@ -147,7 +147,7 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
     const auto& fDef  = GET_FUNC_DEF(output, "f");
 
     CHECK(
-        f2Def.getExpr() ==
+        f2Def.getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
@@ -32,7 +32,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
     auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Get delegate call with args") {
@@ -52,7 +52,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
         std::move(f2Args));
 
-    CHECK(f2Def.getExpr() == *callExpr2);
+    CHECK(f2Def.getBody() == *callExpr2);
 
     auto fArgs = std::vector<prog::expr::NodePtr>{};
     fArgs.push_back(prog::expr::litFuncNode(
@@ -61,7 +61,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "bool"), GET_TYPE_ID(output, "float"))));
     auto callExpr1 = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr1);
+    CHECK(fDef.getBody() == *callExpr1);
   }
 
   SECTION("Get delegate call with templated function") {
@@ -73,7 +73,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
     const auto& fDef  = GET_FUNC_DEF(output, "f");
 
     CHECK(
-        f2Def.getExpr() ==
+        f2Def.getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
@@ -84,7 +84,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1__int")));
     auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Get delegate call on struct") {
@@ -95,7 +95,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
     const auto& fDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "S"));
 
     CHECK(
-        fDef.getExpr() ==
+        fDef.getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::fieldExprNode(
@@ -114,7 +114,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
     const auto& fDef  = GET_FUNC_DEF(output, "f");
 
     CHECK(
-        f2Def.getExpr() ==
+        f2Def.getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
@@ -127,7 +127,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
     auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Get lazy delegate call") {
@@ -139,7 +139,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
     const auto& fDef  = GET_FUNC_DEF(output, "f");
 
     CHECK(
-        f2Def.getExpr() ==
+        f2Def.getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
@@ -152,7 +152,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
     auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Get lazy action delegate call") {
@@ -164,7 +164,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
     const auto& aDef  = GET_FUNC_DEF(output, "a");
 
     CHECK(
-        a2Def.getExpr() ==
+        a2Def.getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::constExprNode(a2Def.getConsts(), *a2Def.getConsts().lookup("op")),
@@ -177,7 +177,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         output.getProg(), GET_TYPE_ID(output, "__action_int"), GET_FUNC_ID(output, "a1")));
     auto callExpr = prog::expr::callExprNode(output.getProg(), a2Def.getId(), std::move(fArgs));
 
-    CHECK(aDef.getExpr() == *callExpr);
+    CHECK(aDef.getBody() == *callExpr);
   }
 
   SECTION("Implicitly convert function to action") {
@@ -189,7 +189,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
     const auto& a1Def = GET_FUNC_DEF(output, "a1");
 
     CHECK(
-        a2Def.getExpr() ==
+        a2Def.getBody() ==
         *prog::expr::callDynExprNode(
             output.getProg(),
             prog::expr::constExprNode(a2Def.getConsts(), *a2Def.getConsts().lookup("op")),
@@ -204,7 +204,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
             output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1"))));
     auto callExpr = prog::expr::callExprNode(output.getProg(), a2Def.getId(), std::move(fArgs));
 
-    CHECK(a1Def.getExpr() == *callExpr);
+    CHECK(a1Def.getBody() == *callExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -27,10 +27,11 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
             prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
             {}));
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
-    auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(),
+        f2Def.getId(),
+        EXPRS(prog::expr::litFuncNode(
+            output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -44,22 +45,22 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "__function_bool_float_int"));
     const auto& fDef = GET_FUNC_DEF(output, "f");
 
-    auto f2Args = std::vector<prog::expr::NodePtr>{};
-    f2Args.push_back(prog::expr::litBoolNode(output.getProg(), false));
-    f2Args.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr2 = prog::expr::callDynExprNode(
         output.getProg(),
         prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
-        std::move(f2Args));
+        EXPRS(
+            prog::expr::litBoolNode(output.getProg(), false),
+            prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(f2Def.getBody() == *callExpr2);
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litFuncNode(
+    auto callExpr1 = prog::expr::callExprNode(
         output.getProg(),
-        GET_TYPE_ID(output, "__function_bool_float_int"),
-        GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "bool"), GET_TYPE_ID(output, "float"))));
-    auto callExpr1 = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
+        f2Def.getId(),
+        EXPRS(prog::expr::litFuncNode(
+            output.getProg(),
+            GET_TYPE_ID(output, "__function_bool_float_int"),
+            GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "bool"), GET_TYPE_ID(output, "float")))));
 
     CHECK(fDef.getBody() == *callExpr1);
   }
@@ -79,10 +80,13 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
             prog::expr::constExprNode(f2Def.getConsts(), *f2Def.getConsts().lookup("op")),
             {}));
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1__int")));
-    auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(),
+        f2Def.getId(),
+        EXPRS(prog::expr::litFuncNode(
+            output.getProg(),
+            GET_TYPE_ID(output, "__function_int"),
+            GET_FUNC_ID(output, "f1__int"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -122,10 +126,11 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
             {},
             prog::expr::CallMode::Forked));
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
-    auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(),
+        f2Def.getId(),
+        EXPRS(prog::expr::litFuncNode(
+            output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -147,10 +152,11 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
             {},
             prog::expr::CallMode::Lazy));
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1")));
-    auto callExpr = prog::expr::callExprNode(output.getProg(), f2Def.getId(), std::move(fArgs));
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(),
+        f2Def.getId(),
+        EXPRS(prog::expr::litFuncNode(
+            output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -172,10 +178,11 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
             {},
             prog::expr::CallMode::Lazy));
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litFuncNode(
-        output.getProg(), GET_TYPE_ID(output, "__action_int"), GET_FUNC_ID(output, "a1")));
-    auto callExpr = prog::expr::callExprNode(output.getProg(), a2Def.getId(), std::move(fArgs));
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(),
+        a2Def.getId(),
+        EXPRS(prog::expr::litFuncNode(
+            output.getProg(), GET_TYPE_ID(output, "__action_int"), GET_FUNC_ID(output, "a1"))));
 
     CHECK(aDef.getBody() == *callExpr);
   }
@@ -195,14 +202,17 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
             prog::expr::constExprNode(a2Def.getConsts(), *a2Def.getConsts().lookup("op")),
             {}));
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(applyConv(
-        output,
-        "__function_int",
-        "__action_int",
-        prog::expr::litFuncNode(
-            output.getProg(), GET_TYPE_ID(output, "__function_int"), GET_FUNC_ID(output, "f1"))));
-    auto callExpr = prog::expr::callExprNode(output.getProg(), a2Def.getId(), std::move(fArgs));
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(),
+        a2Def.getId(),
+        EXPRS(applyConv(
+            output,
+            "__function_int",
+            "__action_int",
+            prog::expr::litFuncNode(
+                output.getProg(),
+                GET_TYPE_ID(output, "__function_int"),
+                GET_FUNC_ID(output, "f1")))));
 
     CHECK(a1Def.getBody() == *callExpr);
   }

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -25,10 +25,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f2() -> int f1(1)");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr = prog::expr::callExprNode(
-        output.getProg(), GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int")), std::move(args));
+        output.getProg(),
+        GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int")),
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
@@ -37,14 +37,12 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     const auto& output = ANALYZE("fun f() -> int false ? f() : 1");
     REQUIRE(output.isSuccess());
 
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::litBoolNode(output.getProg(), false));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "f"), {}));
-    branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+    auto switchExpr = prog::expr::switchExprNode(
+        output.getProg(),
+        EXPRS(prog::expr::litBoolNode(output.getProg(), false)),
+        EXPRS(
+            prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "f"), {}),
+            prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(GET_FUNC_DEF(output, "f").getBody() == *switchExpr);
   }
@@ -54,10 +52,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f2() f1(1)");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 1)));
     auto callExpr = prog::expr::callExprNode(
-        output.getProg(), GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "float")), std::move(args));
+        output.getProg(),
+        GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "float")),
+        EXPRS(applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 1))));
 
     CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
@@ -67,12 +65,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f2() -> int f1{int}(1)");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "f1__int", GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
@@ -110,13 +106,11 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f() -> lazy{int} lazy 1()");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "__op_parenparen", GET_TYPE_ID(output, "int")),
         GET_TYPE_ID(output, "__lazy_int"),
-        std::move(args),
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)),
         prog::expr::CallMode::Lazy);
 
     CHECK(GET_FUNC_DEF(output, "f").getBody() == *callExpr);
@@ -127,12 +121,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f() -> int 1()");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "__op_parenparen", GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(GET_FUNC_DEF(output, "f").getBody() == *callExpr);
   }
@@ -145,12 +137,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     const auto& fDef   = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"));
     const auto& consts = fDef.getConsts();
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::constExprNode(consts, *consts.lookup("i")));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "__op_parenparen", GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(prog::expr::constExprNode(consts, *consts.lookup("i"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -163,10 +153,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     const auto& fDef   = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "int"));
     const auto& consts = fDef.getConsts();
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::constExprNode(consts, *consts.lookup("i")));
     auto callExpr = prog::expr::callExprNode(
-        output.getProg(), GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int")), std::move(args));
+        output.getProg(),
+        GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int")),
+        EXPRS(prog::expr::constExprNode(consts, *consts.lookup("i"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -179,13 +169,12 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     const auto& fDef   = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "int"));
     const auto& consts = fDef.getConsts();
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::constExprNode(consts, *consts.lookup("i")));
-    args.push_back(prog::expr::litStringNode(output.getProg(), "test"));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "string")),
-        std::move(args));
+        EXPRS(
+            prog::expr::constExprNode(consts, *consts.lookup("i")),
+            prog::expr::litStringNode(output.getProg(), "test")));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -219,21 +208,19 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f2() a1(lazy f1())");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(applyConv(
-        output,
-        "__lazy_int",
-        "__lazy_action_int",
-        prog::expr::callExprNode(
-            output.getProg(),
-            GET_FUNC_ID(output, "f1"),
-            GET_TYPE_ID(output, "__lazy_int"),
-            {},
-            prog::expr::CallMode::Lazy)));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "a1", GET_TYPE_ID(output, "__lazy_action_int")),
-        std::move(args));
+        EXPRS(applyConv(
+            output,
+            "__lazy_int",
+            "__lazy_action_int",
+            prog::expr::callExprNode(
+                output.getProg(),
+                GET_FUNC_ID(output, "f1"),
+                GET_TYPE_ID(output, "__lazy_int"),
+                {},
+                prog::expr::CallMode::Lazy))));
 
     CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
@@ -243,12 +230,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "act a2() -> int a1{int}(1)");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "a1__int", GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(GET_FUNC_DEF(output, "a2").getBody() == *callExpr);
   }
@@ -258,12 +243,10 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "act a2() -> lazy_action{int} lazy a1{int}(1)");
     REQUIRE(output.isSuccess());
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "a1__int", GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(GET_FUNC_DEF(output, "a2").getBody() == *callExpr);
   }
@@ -273,9 +256,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     REQUIRE(output.isSuccess());
 
     auto callExpr = prog::expr::callExprNode(
-        output.getProg(),
-        GET_INTRINSIC_ID(output, "__fail_int"),
-        std::vector<prog::expr::NodePtr>{});
+        output.getProg(), GET_INTRINSIC_ID(output, "__fail_int"), NO_EXPRS);
 
     CHECK(GET_FUNC_DEF(output, "a").getBody() == *callExpr);
   }

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -16,7 +16,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f2() -> int f1()");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DEF(output, "f2").getExpr() ==
+        GET_FUNC_DEF(output, "f2").getBody() ==
         *prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "f1"), {}));
   }
 
@@ -30,7 +30,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     auto callExpr = prog::expr::callExprNode(
         output.getProg(), GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int")), std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "f2").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
 
   SECTION("Get recursive call") {
@@ -46,7 +46,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *switchExpr);
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *switchExpr);
   }
 
   SECTION("Get call with conversion") {
@@ -59,7 +59,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     auto callExpr = prog::expr::callExprNode(
         output.getProg(), GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "float")), std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "f2").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
 
   SECTION("Get templated call") {
@@ -74,7 +74,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_FUNC_ID(output, "f1__int", GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "f2").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
 
   SECTION("Get forked call") {
@@ -82,7 +82,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f2() -> future{int} fork f1()");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DEF(output, "f2").getExpr() ==
+        GET_FUNC_DEF(output, "f2").getBody() ==
         *prog::expr::callExprNode(
             output.getProg(),
             GET_FUNC_ID(output, "f1"),
@@ -96,7 +96,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "fun f2() -> lazy{int} lazy f1()");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DEF(output, "f2").getExpr() ==
+        GET_FUNC_DEF(output, "f2").getBody() ==
         *prog::expr::callExprNode(
             output.getProg(),
             GET_FUNC_ID(output, "f1"),
@@ -119,7 +119,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         std::move(args),
         prog::expr::CallMode::Lazy);
 
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *callExpr);
   }
 
   SECTION("Get call to overloaded call operator on literal") {
@@ -134,7 +134,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_FUNC_ID(output, "__op_parenparen", GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *callExpr);
   }
 
   SECTION("Get call to overloaded call operator on const") {
@@ -152,7 +152,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_FUNC_ID(output, "__op_parenparen", GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Get instance call") {
@@ -168,7 +168,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     auto callExpr = prog::expr::callExprNode(
         output.getProg(), GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int")), std::move(args));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Get instance call with args") {
@@ -187,7 +187,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_FUNC_ID(output, "f1", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "string")),
         std::move(args));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Get call to action") {
@@ -195,7 +195,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "act a2() -> int a1()");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DEF(output, "a2").getExpr() ==
+        GET_FUNC_DEF(output, "a2").getBody() ==
         *prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "a1"), {}));
   }
 
@@ -204,7 +204,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
                                  "act a2() -> lazy_action{int} lazy a1()");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DEF(output, "a2").getExpr() ==
+        GET_FUNC_DEF(output, "a2").getBody() ==
         *prog::expr::callExprNode(
             output.getProg(),
             GET_FUNC_ID(output, "a1"),
@@ -235,7 +235,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_FUNC_ID(output, "a1", GET_TYPE_ID(output, "__lazy_action_int")),
         std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "f2").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "f2").getBody() == *callExpr);
   }
 
   SECTION("Get call to templated action") {
@@ -250,7 +250,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_FUNC_ID(output, "a1__int", GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "a2").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "a2").getBody() == *callExpr);
   }
 
   SECTION("Get lazy call to templated action") {
@@ -265,7 +265,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_FUNC_ID(output, "a1__int", GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(GET_FUNC_DEF(output, "a2").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "a2").getBody() == *callExpr);
   }
 
   SECTION("Get fail intrinsic action call") {
@@ -277,7 +277,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         GET_INTRINSIC_ID(output, "__fail_int"),
         std::vector<prog::expr::NodePtr>{});
 
-    CHECK(GET_FUNC_DEF(output, "a").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(output, "a").getBody() == *callExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_call_self_expr_test.cpp
+++ b/tests/frontend/get_call_self_expr_test.cpp
@@ -14,14 +14,12 @@ TEST_CASE("[frontend] Analyzing self call expressions", "frontend") {
     const auto& output = ANALYZE("fun f() false ? self() : 1 ");
     REQUIRE(output.isSuccess());
 
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::litBoolNode(output.getProg(), false));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(prog::expr::callSelfExprNode(GET_TYPE_ID(output, "int"), {}));
-    branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+    auto switchExpr = prog::expr::switchExprNode(
+        output.getProg(),
+        EXPRS(prog::expr::litBoolNode(output.getProg(), false)),
+        EXPRS(
+            prog::expr::callSelfExprNode(GET_TYPE_ID(output, "int"), {}),
+            prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(GET_FUNC_DEF(output, "f").getBody() == *switchExpr);
   }
@@ -30,14 +28,12 @@ TEST_CASE("[frontend] Analyzing self call expressions", "frontend") {
     const auto& output = ANALYZE("fun f() lambda () false ? self() : 1 ");
     REQUIRE(output.isSuccess());
 
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::litBoolNode(output.getProg(), false));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(prog::expr::callSelfExprNode(GET_TYPE_ID(output, "int"), {}));
-    branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+    auto switchExpr = prog::expr::switchExprNode(
+        output.getProg(),
+        EXPRS(prog::expr::litBoolNode(output.getProg(), false)),
+        EXPRS(
+            prog::expr::callSelfExprNode(GET_TYPE_ID(output, "int"), {}),
+            prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(findAnonFuncDef(output, 0).getBody() == *switchExpr);
   }

--- a/tests/frontend/get_call_self_expr_test.cpp
+++ b/tests/frontend/get_call_self_expr_test.cpp
@@ -23,7 +23,7 @@ TEST_CASE("[frontend] Analyzing self call expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *switchExpr);
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *switchExpr);
   }
 
   SECTION("Get anonymous function with self call") {
@@ -39,7 +39,7 @@ TEST_CASE("[frontend] Analyzing self call expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(findAnonFuncDef(output, 0).getExpr() == *switchExpr);
+    CHECK(findAnonFuncDef(output, 0).getBody() == *switchExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_conditional_expr_test.cpp
+++ b/tests/frontend/get_conditional_expr_test.cpp
@@ -19,14 +19,12 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::litBoolNode(output.getProg(), true));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    branches.push_back(prog::expr::litIntNode(output.getProg(), 3));
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+    auto switchExpr = prog::expr::switchExprNode(
+        output.getProg(),
+        EXPRS(prog::expr::litBoolNode(output.getProg(), true)),
+        EXPRS(
+            prog::expr::litIntNode(output.getProg(), 1),
+            prog::expr::litIntNode(output.getProg(), 3)));
 
     CHECK(funcDef.getBody() == *switchExpr);
   }
@@ -36,15 +34,12 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::litBoolNode(output.getProg(), true));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(
-        applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 0)));
-    branches.push_back(prog::expr::litFloatNode(output.getProg(), 1.0F));
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+    auto switchExpr = prog::expr::switchExprNode(
+        output.getProg(),
+        EXPRS(prog::expr::litBoolNode(output.getProg(), true)),
+        EXPRS(
+            applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 0)),
+            prog::expr::litFloatNode(output.getProg(), 1.0F)));
 
     CHECK(funcDef.getBody() == *switchExpr);
   }
@@ -54,15 +49,12 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::litBoolNode(output.getProg(), true));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(prog::expr::litFloatNode(output.getProg(), 1.0F));
-    branches.push_back(
-        applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 0)));
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+    auto switchExpr = prog::expr::switchExprNode(
+        output.getProg(),
+        EXPRS(prog::expr::litBoolNode(output.getProg(), true)),
+        EXPRS(
+            prog::expr::litFloatNode(output.getProg(), 1.0F),
+            applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 0))));
 
     CHECK(funcDef.getBody() == *switchExpr);
   }
@@ -74,19 +66,15 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     const auto& funcDef = GET_FUNC_DEF(output, "f");
     const auto& consts  = funcDef.getConsts();
 
-    auto condSubExprs = std::vector<prog::expr::NodePtr>{};
-    condSubExprs.push_back(prog::expr::assignExprNode(
-        consts, consts.lookup("x").value(), prog::expr::litIntNode(output.getProg(), 1)));
-    condSubExprs.push_back(prog::expr::litBoolNode(output.getProg(), true));
-
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::groupExprNode(std::move(condSubExprs)));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(prog::expr::constExprNode(consts, consts.lookup("x").value()));
-    branches.push_back(prog::expr::litIntNode(output.getProg(), 2));
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+    auto switchExpr = prog::expr::switchExprNode(
+        output.getProg(),
+        EXPRS(prog::expr::groupExprNode(EXPRS(
+            prog::expr::assignExprNode(
+                consts, consts.lookup("x").value(), prog::expr::litIntNode(output.getProg(), 1)),
+            prog::expr::litBoolNode(output.getProg(), true)))),
+        EXPRS(
+            prog::expr::constExprNode(consts, consts.lookup("x").value()),
+            prog::expr::litIntNode(output.getProg(), 2)));
 
     CHECK(funcDef.getBody() == *switchExpr);
   }

--- a/tests/frontend/get_conditional_expr_test.cpp
+++ b/tests/frontend/get_conditional_expr_test.cpp
@@ -28,7 +28,7 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Get conditional expression with conversion on the lhs branch") {
@@ -46,7 +46,7 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Get conditional expression with conversion on the rhs branch") {
@@ -64,7 +64,7 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Declare consts in condition expression conditions") {
@@ -88,7 +88,7 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_const_expr_test.cpp
+++ b/tests/frontend/get_const_expr_test.cpp
@@ -15,7 +15,7 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"));
     const auto& consts  = funcDef.getConsts();
-    CHECK(funcDef.getExpr() == *prog::expr::constExprNode(consts, consts.lookup("a").value()));
+    CHECK(funcDef.getBody() == *prog::expr::constExprNode(consts, consts.lookup("a").value()));
   }
 
   SECTION("Declare and access local const") {
@@ -37,7 +37,7 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
     exprs.push_back(prog::expr::constExprNode(consts, b.value()));
     auto groupExpr = prog::expr::groupExprNode(std::move(exprs));
 
-    CHECK(funcDef.getExpr() == *groupExpr);
+    CHECK(funcDef.getBody() == *groupExpr);
   }
 
   SECTION("Access const in anonymous function") {
@@ -55,7 +55,7 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
     exprs.push_back(prog::expr::constExprNode(consts, x.value()));
     auto groupExpr = prog::expr::groupExprNode(std::move(exprs));
 
-    CHECK(anonDef.getExpr() == *groupExpr);
+    CHECK(anonDef.getBody() == *groupExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_const_expr_test.cpp
+++ b/tests/frontend/get_const_expr_test.cpp
@@ -29,13 +29,10 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
     const auto b = consts.lookup("b");
     REQUIRE(b);
 
-    auto exprs = std::vector<prog::expr::NodePtr>{};
-    exprs.push_back(
-        prog::expr::assignExprNode(consts, a.value(), prog::expr::litIntNode(output.getProg(), 1)));
-    exprs.push_back(prog::expr::assignExprNode(
-        consts, b.value(), prog::expr::constExprNode(consts, a.value())));
-    exprs.push_back(prog::expr::constExprNode(consts, b.value()));
-    auto groupExpr = prog::expr::groupExprNode(std::move(exprs));
+    auto groupExpr = prog::expr::groupExprNode(EXPRS(
+        prog::expr::assignExprNode(consts, a.value(), prog::expr::litIntNode(output.getProg(), 1)),
+        prog::expr::assignExprNode(consts, b.value(), prog::expr::constExprNode(consts, a.value())),
+        prog::expr::constExprNode(consts, b.value())));
 
     CHECK(funcDef.getBody() == *groupExpr);
   }
@@ -49,11 +46,9 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
     const auto x = consts.lookup("x");
     REQUIRE(x);
 
-    auto exprs = std::vector<prog::expr::NodePtr>{};
-    exprs.push_back(
-        prog::expr::assignExprNode(consts, x.value(), prog::expr::litIntNode(output.getProg(), 1)));
-    exprs.push_back(prog::expr::constExprNode(consts, x.value()));
-    auto groupExpr = prog::expr::groupExprNode(std::move(exprs));
+    auto groupExpr = prog::expr::groupExprNode(EXPRS(
+        prog::expr::assignExprNode(consts, x.value(), prog::expr::litIntNode(output.getProg(), 1)),
+        prog::expr::constExprNode(consts, x.value())));
 
     CHECK(anonDef.getBody() == *groupExpr);
   }

--- a/tests/frontend/get_enum_expr_test.cpp
+++ b/tests/frontend/get_enum_expr_test.cpp
@@ -13,7 +13,7 @@ TEST_CASE("[frontend] Analyzing enum expressions", "frontend") {
     REQUIRE(output.isSuccess());
 
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::litEnumNode(output.getProg(), GET_TYPE_ID(output, "E"), "a"));
   }
 

--- a/tests/frontend/get_field_expr_test.cpp
+++ b/tests/frontend/get_field_expr_test.cpp
@@ -19,7 +19,7 @@ TEST_CASE("[frontend] Analyzing field expressions", "frontend") {
     const auto& funcConsts = funcDef.getConsts();
 
     CHECK(
-        funcDef.getExpr() ==
+        funcDef.getBody() ==
         *prog::expr::fieldExprNode(
             output.getProg(),
             prog::expr::constExprNode(funcConsts, funcConsts.lookup("s").value()),
@@ -38,7 +38,7 @@ TEST_CASE("[frontend] Analyzing field expressions", "frontend") {
     const auto& funcConsts = funcDef.getConsts();
 
     CHECK(
-        funcDef.getExpr() ==
+        funcDef.getBody() ==
         *prog::expr::fieldExprNode(
             output.getProg(),
             prog::expr::fieldExprNode(

--- a/tests/frontend/get_group_expr_test.cpp
+++ b/tests/frontend/get_group_expr_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("[frontend] Analyzing group expressions", "frontend") {
         std::move(callArgs)));
     auto groupExpr = prog::expr::groupExprNode(std::move(exprs));
 
-    CHECK(funcDef.getExpr() == *groupExpr);
+    CHECK(funcDef.getBody() == *groupExpr);
   }
 }
 

--- a/tests/frontend/get_group_expr_test.cpp
+++ b/tests/frontend/get_group_expr_test.cpp
@@ -17,21 +17,21 @@ TEST_CASE("[frontend] Analyzing group expressions", "frontend") {
     const auto& funcDef = GET_FUNC_DEF(output, "f");
     const auto& consts  = funcDef.getConsts();
 
-    auto callArgs = std::vector<prog::expr::NodePtr>{};
-    callArgs.push_back(prog::expr::constExprNode(consts, consts.lookup("b").value()));
-    callArgs.push_back(prog::expr::constExprNode(consts, consts.lookup("c").value()));
-
-    auto exprs = std::vector<prog::expr::NodePtr>{};
-    exprs.push_back(prog::expr::assignExprNode(
-        consts, consts.lookup("b").value(), prog::expr::litIntNode(output.getProg(), 1)));
-    exprs.push_back(prog::expr::assignExprNode(
-        consts, consts.lookup("c").value(), prog::expr::litIntNode(output.getProg(), 2)));
-    exprs.push_back(prog::expr::callExprNode(
-        output.getProg(),
-        GET_OP_ID(
-            output, prog::Operator::Star, GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
-        std::move(callArgs)));
-    auto groupExpr = prog::expr::groupExprNode(std::move(exprs));
+    auto groupExpr = prog::expr::groupExprNode(EXPRS(
+        prog::expr::assignExprNode(
+            consts, consts.lookup("b").value(), prog::expr::litIntNode(output.getProg(), 1)),
+        prog::expr::assignExprNode(
+            consts, consts.lookup("c").value(), prog::expr::litIntNode(output.getProg(), 2)),
+        prog::expr::callExprNode(
+            output.getProg(),
+            GET_OP_ID(
+                output,
+                prog::Operator::Star,
+                GET_TYPE_ID(output, "int"),
+                GET_TYPE_ID(output, "int")),
+            EXPRS(
+                prog::expr::constExprNode(consts, consts.lookup("b").value()),
+                prog::expr::constExprNode(consts, consts.lookup("c").value())))));
 
     CHECK(funcDef.getBody() == *groupExpr);
   }

--- a/tests/frontend/get_index_expr_test.cpp
+++ b/tests/frontend/get_index_expr_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
             output, "__op_squaresquare", GET_TYPE_ID(output, "Pair"), GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(func.getExpr() == *callExpr);
+    CHECK(func.getBody() == *callExpr);
   }
 
   SECTION("Get multi argument index operator") {
@@ -53,7 +53,7 @@ TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
             GET_TYPE_ID(output, "string")),
         std::move(args));
 
-    CHECK(func.getExpr() == *callExpr);
+    CHECK(func.getBody() == *callExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_index_expr_test.cpp
+++ b/tests/frontend/get_index_expr_test.cpp
@@ -18,14 +18,13 @@ TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& func = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "Pair"));
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::constExprNode(func.getConsts(), *func.getConsts().lookup("p")));
-    args.push_back(prog::expr::litIntNode(output.getProg(), 0));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
             output, "__op_squaresquare", GET_TYPE_ID(output, "Pair"), GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(
+            prog::expr::constExprNode(func.getConsts(), *func.getConsts().lookup("p")),
+            prog::expr::litIntNode(output.getProg(), 0)));
 
     CHECK(func.getBody() == *callExpr);
   }
@@ -39,10 +38,6 @@ TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& func = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "Pair"));
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::constExprNode(func.getConsts(), *func.getConsts().lookup("p")));
-    args.push_back(prog::expr::litIntNode(output.getProg(), 0));
-    args.push_back(prog::expr::litStringNode(output.getProg(), "hello world"));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
@@ -51,7 +46,10 @@ TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
             GET_TYPE_ID(output, "Pair"),
             GET_TYPE_ID(output, "int"),
             GET_TYPE_ID(output, "string")),
-        std::move(args));
+        EXPRS(
+            prog::expr::constExprNode(func.getConsts(), *func.getConsts().lookup("p")),
+            prog::expr::litIntNode(output.getProg(), 0),
+            prog::expr::litStringNode(output.getProg(), "hello world")));
 
     CHECK(func.getBody() == *callExpr);
   }

--- a/tests/frontend/get_intrinsic_expr_test.cpp
+++ b/tests/frontend/get_intrinsic_expr_test.cpp
@@ -12,12 +12,10 @@ TEST_CASE("[frontend] Analyzing intrinsic expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& func = GET_FUNC_DEF(output, "f");
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litFloatNode(output.getProg(), 42.0f));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_INTRINSIC_ID(output, "float_sin", GET_TYPE_ID(output, "float")),
-        std::move(args));
+        EXPRS(prog::expr::litFloatNode(output.getProg(), 42.0f)));
 
     CHECK(func.getBody() == *callExpr);
   }

--- a/tests/frontend/get_intrinsic_expr_test.cpp
+++ b/tests/frontend/get_intrinsic_expr_test.cpp
@@ -19,7 +19,7 @@ TEST_CASE("[frontend] Analyzing intrinsic expressions", "frontend") {
         GET_INTRINSIC_ID(output, "float_sin", GET_TYPE_ID(output, "float")),
         std::move(args));
 
-    CHECK(func.getExpr() == *callExpr);
+    CHECK(func.getBody() == *callExpr);
   }
 
   SECTION("Call impure intrinsic expression") {
@@ -30,7 +30,7 @@ TEST_CASE("[frontend] Analyzing intrinsic expressions", "frontend") {
     auto callExpr = prog::expr::callExprNode(
         output.getProg(), GET_INTRINSIC_ID(output, "platform_endianness_native"), {});
 
-    CHECK(func.getExpr() == *callExpr);
+    CHECK(func.getBody() == *callExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_is_expr_test.cpp
+++ b/tests/frontend/get_is_expr_test.cpp
@@ -34,7 +34,7 @@ TEST_CASE("[frontend] Analyzing 'is' / 'as' expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Check 'is' expression") {
@@ -46,7 +46,7 @@ TEST_CASE("[frontend] Analyzing 'is' / 'as' expressions", "frontend") {
     const auto& funcConsts = funcDef.getConsts();
 
     CHECK(
-        funcDef.getExpr() ==
+        funcDef.getBody() ==
         *prog::expr::unionCheckExprNode(
             output.getProg(),
             prog::expr::constExprNode(funcConsts, *funcConsts.lookup("v")),
@@ -62,7 +62,7 @@ TEST_CASE("[frontend] Analyzing 'is' / 'as' expressions", "frontend") {
     const auto& funcConsts = funcDef.getConsts();
 
     CHECK(
-        funcDef.getExpr() ==
+        funcDef.getBody() ==
         *prog::expr::unionCheckExprNode(
             output.getProg(),
             prog::expr::constExprNode(funcConsts, *funcConsts.lookup("v")),

--- a/tests/frontend/get_is_expr_test.cpp
+++ b/tests/frontend/get_is_expr_test.cpp
@@ -21,18 +21,16 @@ TEST_CASE("[frontend] Analyzing 'is' / 'as' expressions", "frontend") {
     const auto& funcDef    = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "Val"));
     const auto& funcConsts = funcDef.getConsts();
 
-    auto conditions = std::vector<prog::expr::NodePtr>{};
-    conditions.push_back(prog::expr::unionGetExprNode(
+    auto switchExpr = prog::expr::switchExprNode(
         output.getProg(),
-        prog::expr::constExprNode(funcConsts, *funcConsts.lookup("v")),
-        funcConsts,
-        *funcConsts.lookup("i")));
-
-    auto branches = std::vector<prog::expr::NodePtr>{};
-    branches.push_back(prog::expr::constExprNode(funcConsts, *funcConsts.lookup("i")));
-    branches.push_back(prog::expr::litIntNode(output.getProg(), 42)); // NOLINT: Magic numbers
-    auto switchExpr =
-        prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
+        EXPRS(prog::expr::unionGetExprNode(
+            output.getProg(),
+            prog::expr::constExprNode(funcConsts, *funcConsts.lookup("v")),
+            funcConsts,
+            *funcConsts.lookup("i"))),
+        EXPRS(
+            prog::expr::constExprNode(funcConsts, *funcConsts.lookup("i")),
+            prog::expr::litIntNode(output.getProg(), 42)));
 
     CHECK(funcDef.getBody() == *switchExpr);
   }

--- a/tests/frontend/get_lit_expr_test.cpp
+++ b/tests/frontend/get_lit_expr_test.cpp
@@ -16,41 +16,41 @@ TEST_CASE("[frontend] Analyzing literal expressions", "frontend") {
   SECTION("Get int literal expression") {
     const auto& output = ANALYZE("fun f() -> int 42");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *prog::expr::litIntNode(output.getProg(), 42));
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *prog::expr::litIntNode(output.getProg(), 42));
   }
 
   SECTION("Get long literal expression") {
     const auto& output = ANALYZE("fun f() -> long 42L");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *prog::expr::litLongNode(output.getProg(), 42L));
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *prog::expr::litLongNode(output.getProg(), 42L));
   }
 
   SECTION("Get float literal expression") {
     const auto& output = ANALYZE("fun f() -> float 42.0");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::litFloatNode(output.getProg(), 42.0F)); // NOLINT: Magic numbers
   }
 
   SECTION("Get bool literal expression") {
     const auto& output = ANALYZE("fun f() -> bool true");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *prog::expr::litBoolNode(output.getProg(), true));
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *prog::expr::litBoolNode(output.getProg(), true));
   }
 
   SECTION("Get string literal expression") {
     const auto& output = ANALYZE("fun f() -> string \"hello world\"");
     REQUIRE(output.isSuccess());
     CHECK(
-        GET_FUNC_DEF(output, "f").getExpr() ==
+        GET_FUNC_DEF(output, "f").getBody() ==
         *prog::expr::litStringNode(output.getProg(), "hello world"));
   }
 
   SECTION("Get character literal expression") {
     const auto& output = ANALYZE("fun f() -> char \'a\'");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DEF(output, "f").getExpr() == *prog::expr::litCharNode(output.getProg(), 'a'));
+    CHECK(GET_FUNC_DEF(output, "f").getBody() == *prog::expr::litCharNode(output.getProg(), 'a'));
   }
 }
 

--- a/tests/frontend/get_paren_expr_test.cpp
+++ b/tests/frontend/get_paren_expr_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE("[frontend] Analyzing parenthesized expressions", "frontend") {
             output, prog::Operator::Plus, GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(funcDef.getExpr() == *callExpr);
+    CHECK(funcDef.getBody() == *callExpr);
   }
 }
 

--- a/tests/frontend/get_paren_expr_test.cpp
+++ b/tests/frontend/get_paren_expr_test.cpp
@@ -14,16 +14,14 @@ TEST_CASE("[frontend] Analyzing parenthesized expressions", "frontend") {
     const auto& funcDef =
         GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int"));
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(
-        prog::expr::constExprNode(funcDef.getConsts(), funcDef.getConsts().lookup("a").value()));
-    args.push_back(
-        prog::expr::constExprNode(funcDef.getConsts(), funcDef.getConsts().lookup("b").value()));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_OP_ID(
             output, prog::Operator::Plus, GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(
+            prog::expr::constExprNode(funcDef.getConsts(), funcDef.getConsts().lookup("a").value()),
+            prog::expr::constExprNode(
+                funcDef.getConsts(), funcDef.getConsts().lookup("b").value())));
 
     CHECK(funcDef.getBody() == *callExpr);
   }

--- a/tests/frontend/get_switch_expr_test.cpp
+++ b/tests/frontend/get_switch_expr_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("[frontend] Analyzing switch expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Get switch expression with conversion on the branches") {
@@ -59,7 +59,7 @@ TEST_CASE("[frontend] Analyzing switch expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Declare consts in switch expression conditions") {
@@ -84,7 +84,7 @@ TEST_CASE("[frontend] Analyzing switch expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Exhaustive union check switch expression") {
@@ -114,7 +114,7 @@ TEST_CASE("[frontend] Analyzing switch expressions", "frontend") {
     auto switchExpr =
         prog::expr::switchExprNode(output.getProg(), std::move(conditions), std::move(branches));
 
-    CHECK(funcDef.getExpr() == *switchExpr);
+    CHECK(funcDef.getBody() == *switchExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/get_unary_expr_test.cpp
+++ b/tests/frontend/get_unary_expr_test.cpp
@@ -14,13 +14,11 @@ TEST_CASE("[frontend] Analyzing unary expressions", "frontend") {
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"));
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(
-        prog::expr::constExprNode(funcDef.getConsts(), funcDef.getConsts().lookup("a").value()));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_OP_ID(output, prog::Operator::Minus, GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(prog::expr::constExprNode(
+            funcDef.getConsts(), funcDef.getConsts().lookup("a").value())));
 
     CHECK(funcDef.getBody() == *callExpr);
   }

--- a/tests/frontend/get_unary_expr_test.cpp
+++ b/tests/frontend/get_unary_expr_test.cpp
@@ -22,7 +22,7 @@ TEST_CASE("[frontend] Analyzing unary expressions", "frontend") {
         GET_OP_ID(output, prog::Operator::Minus, GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(funcDef.getExpr() == *callExpr);
+    CHECK(funcDef.getBody() == *callExpr);
   }
 
   SECTION("Diagnostics") {

--- a/tests/frontend/helpers.hpp
+++ b/tests/frontend/helpers.hpp
@@ -6,6 +6,8 @@
 
 namespace frontend {
 
+#define NUM_ARGS(...) std::tuple_size<decltype(std::make_tuple(__VA_ARGS__))>::value
+
 inline auto buildSource(std::string input) {
   return buildSource("test", std::nullopt, input.begin(), input.end());
 }
@@ -86,5 +88,20 @@ inline auto applyConv(
 
   return prog::expr::callExprNode(output.getProg(), *conv, std::move(convArgs));
 }
+
+template <typename Array>
+inline auto arrayMoveToVec(Array c) {
+  auto result = std::vector<typename Array::value_type>{};
+  for (auto& elem : c) {
+    result.push_back(std::move(elem));
+  }
+  return result;
+}
+
+#define EXPRS(...)                                                                                 \
+  arrayMoveToVec<std::array<prog::expr::NodePtr, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
+
+#define NO_EXPRS                                                                                   \
+  std::vector<prog::expr::NodePtr> {}
 
 } // namespace frontend

--- a/tests/frontend/helpers.hpp
+++ b/tests/frontend/helpers.hpp
@@ -3,6 +3,8 @@
 #include "frontend/analysis.hpp"
 #include "frontend/source.hpp"
 #include "prog/expr/node_call.hpp"
+#include <array>
+#include <vector>
 
 namespace frontend {
 

--- a/tests/frontend/opt_args_test.cpp
+++ b/tests/frontend/opt_args_test.cpp
@@ -1,0 +1,275 @@
+#include "catch2/catch.hpp"
+#include "frontend/diag_defs.hpp"
+#include "helpers.hpp"
+#include "prog/expr/node_lit_char.hpp"
+#include "prog/expr/node_lit_float.hpp"
+#include "prog/expr/node_lit_int.hpp"
+#include "prog/expr/node_lit_string.hpp"
+#include "prog/operator.hpp"
+
+namespace frontend {
+
+TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
+
+  SECTION("Function") {
+
+    SECTION("Declare function with single optional argument") {
+      const auto& output = ANALYZE("fun f(int a = 0) false");
+      REQUIRE(output.isSuccess());
+
+      const auto& funcDecl = GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "int"));
+      CHECK(funcDecl.getNumOptInputs() == 1);
+      CHECK(funcDecl.getMinInputCount() == 0);
+
+      const auto& funcDef = output.getProg().getFuncDef(funcDecl.getId());
+      CHECK(*funcDef.getOptArgInitializer(0) == *prog::expr::litIntNode(output.getProg(), 0));
+    }
+
+    SECTION("Declare a function with a normal argument and a optional argument") {
+      const auto& output = ANALYZE("fun f(float a, int b = 0) a + b");
+      REQUIRE(output.isSuccess());
+
+      const auto& funcDecl =
+          GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float"), GET_TYPE_ID(output, "int"));
+      CHECK(funcDecl.getNumOptInputs() == 1);
+      CHECK(funcDecl.getMinInputCount() == 1);
+
+      const auto& funcDef = output.getProg().getFuncDef(funcDecl.getId());
+      CHECK(*funcDef.getOptArgInitializer(0) == *prog::expr::litIntNode(output.getProg(), 0));
+    }
+
+    SECTION("Declare a function with a conversion on the optional arg initializer") {
+      const auto& output = ANALYZE("fun f(float a = 2) false");
+      REQUIRE(output.isSuccess());
+
+      const auto& funcDecl = GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float"));
+      CHECK(funcDecl.getNumOptInputs() == 1);
+      CHECK(funcDecl.getMinInputCount() == 0);
+
+      const auto& funcDef = output.getProg().getFuncDef(funcDecl.getId());
+      CHECK(
+          *funcDef.getOptArgInitializer(0) ==
+          *applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 2)));
+    }
+
+    SECTION("Declare a function with a call on the initializer") {
+      const auto& output = ANALYZE("fun fa() 42 "
+                                   "fun fb(int i = fa()) i");
+      REQUIRE(output.isSuccess());
+
+      const auto& funcDecl = GET_FUNC_DECL(output, "fb", GET_TYPE_ID(output, "int"));
+      CHECK(funcDecl.getNumOptInputs() == 1);
+      CHECK(funcDecl.getMinInputCount() == 0);
+
+      const auto& funcDef = output.getProg().getFuncDef(funcDecl.getId());
+      CHECK(
+          *funcDef.getOptArgInitializer(0) ==
+          *prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "fa"), {}));
+    }
+
+    SECTION("Declare a function with an optional arg initializer that calls an intrinsic") {
+      const auto& output = ANALYZE("act a(long time = intrinsic{clock_nanosteady}()) time * 2");
+      REQUIRE(output.isSuccess());
+
+      const auto& funcDecl = GET_FUNC_DECL(output, "a", GET_TYPE_ID(output, "long"));
+      CHECK(funcDecl.getNumOptInputs() == 1);
+      CHECK(funcDecl.getMinInputCount() == 0);
+
+      const auto& funcDef = output.getProg().getFuncDef(funcDecl.getId());
+      CHECK(
+          *funcDef.getOptArgInitializer(0) ==
+          *prog::expr::callExprNode(
+              output.getProg(), GET_INTRINSIC_ID(output, "clock_nanosteady"), {}));
+    }
+
+    SECTION("Call a function with an optional argument") {
+      const auto& output = ANALYZE("fun fa(int a, int b = 1 + 2) a + b "
+                                   "fun fb() fa(2)");
+      REQUIRE(output.isSuccess());
+      CHECK(
+          GET_FUNC_DEF(output, "fb").getBody() ==
+          *prog::expr::callExprNode(
+              output.getProg(),
+              GET_FUNC_ID(output, "fa", GET_TYPE_ID(output, "int")),
+              EXPRS(
+                  prog::expr::litIntNode(output.getProg(), 2),
+                  prog::expr::callExprNode(
+                      output.getProg(),
+                      GET_OP_ID(
+                          output,
+                          prog::Operator::Plus,
+                          GET_TYPE_ID(output, "int"),
+                          GET_TYPE_ID(output, "int")),
+                      EXPRS(
+                          prog::expr::litIntNode(output.getProg(), 1),
+                          prog::expr::litIntNode(output.getProg(), 2))))));
+    }
+
+    SECTION("Call a function with an optional argument with a conversion") {
+      const auto& output = ANALYZE("fun fa(int a, float b = 2) a + b "
+                                   "fun fb() fa(2)");
+      REQUIRE(output.isSuccess());
+      CHECK(
+          GET_FUNC_DEF(output, "fb").getBody() ==
+          *prog::expr::callExprNode(
+              output.getProg(),
+              GET_FUNC_ID(output, "fa", GET_TYPE_ID(output, "int")),
+              EXPRS(
+                  prog::expr::litIntNode(output.getProg(), 2),
+                  applyConv(output, "int", "float", prog::expr::litIntNode(output.getProg(), 2)))));
+    }
+
+    SECTION("Diagnostics") {
+
+      CHECK_DIAG(
+          "fun f(int a = \"Hello World\") a",
+          errNonMatchingInitializerType(src, "int", "string", input::Span{14, 26}));
+      CHECK_DIAG(
+          "struct S{T} = T t "
+          "fun f(S{int} a = S(\"Hello World\")) a",
+          errNonMatchingInitializerType(src, "S{int}", "S{string}", input::Span{35, 50}));
+
+      CHECK_DIAG("fun f(int a = (b = 2)) a", errConstDeclareNotSupported(src, input::Span{15, 19}));
+      CHECK_DIAG(
+          "fun f(int a = (b = 2; b * 2)) a",
+          errConstDeclareNotSupported(src, input::Span{15, 19}),
+          errUndeclaredConst(src, "b", input::Span{22, 22}));
+
+      CHECK_DIAG(
+          "fun fb(int a = fb()) a", errUndeclaredPureFunc(src, "fb", {}, input::Span{15, 18}));
+      CHECK_DIAG(
+          "fun fa(int a = 0) a "
+          "fun fb(int a = fa()) a",
+          errUndeclaredPureFunc(src, "fa", {}, input::Span{35, 38}));
+      CHECK_DIAG(
+          "fun fa(int a = fb()) a "
+          "fun fb(int a = fa()) a",
+          errUndeclaredPureFunc(src, "fb", {}, input::Span{15, 18}),
+          errUndeclaredPureFunc(src, "fa", {}, input::Span{38, 41}));
+
+      CHECK_DIAG(
+          "fun f(int a = 0, int b) a + b", errNonOptArgFollowingOpt(src, input::Span{17, 21}));
+      CHECK_DIAG(
+          "fun f(int a = 0, int b, int c = 0) a + b + c",
+          errNonOptArgFollowingOpt(src, input::Span{17, 21}));
+      CHECK_DIAG(
+          "fun f(int a, int b = 0, int c) a + b + c",
+          errNonOptArgFollowingOpt(src, input::Span{24, 28}));
+
+      CHECK_DIAG(
+          "act a() 42 "
+          "fun f(int i = a()) i",
+          errUndeclaredPureFunc(src, "a", {}, input::Span{25, 27}));
+    }
+  }
+
+  SECTION("Templated function") {
+
+    SECTION("Declare a templated function with a single optional argument") {
+      const auto& output = ANALYZE("fun ft{T}(T a = 0) a "
+                                   "fun f() ft{int}()");
+      REQUIRE(output.isSuccess());
+
+      const auto& funcDecl = GET_FUNC_DECL(output, "ft__int", GET_TYPE_ID(output, "int"));
+      CHECK(funcDecl.getNumOptInputs() == 1);
+      CHECK(funcDecl.getMinInputCount() == 0);
+
+      const auto& funcDef = output.getProg().getFuncDef(funcDecl.getId());
+      CHECK(*funcDef.getOptArgInitializer(0) == *prog::expr::litIntNode(output.getProg(), 0));
+    }
+
+    SECTION("Type parameter can be inferred from an initializer") {
+      const auto& output = ANALYZE("fun ft{TX, TY}(TX a = \"World\", TY b = 'W') a + string(b) "
+                                   "fun f1() ft() "
+                                   "fun f2() ft(\"Hello\", 42) "
+                                   "fun f3() ft(\"Hello\")");
+      REQUIRE(output.isSuccess());
+
+      const auto& funcT1Decl = GET_FUNC_DECL(
+          output, "ft__string_char", GET_TYPE_ID(output, "string"), GET_TYPE_ID(output, "char"));
+      CHECK(funcT1Decl.getNumOptInputs() == 2);
+      CHECK(funcT1Decl.getMinInputCount() == 0);
+
+      const auto& funcT2Decl = GET_FUNC_DECL(
+          output, "ft__string_int", GET_TYPE_ID(output, "string"), GET_TYPE_ID(output, "int"));
+      CHECK(funcT2Decl.getNumOptInputs() == 2);
+      CHECK(funcT2Decl.getMinInputCount() == 0);
+
+      CHECK(
+          GET_FUNC_DEF(output, "f1").getBody() ==
+          *prog::expr::callExprNode(
+              output.getProg(),
+              funcT1Decl.getId(),
+              EXPRS(
+                  prog::expr::litStringNode(output.getProg(), "World"),
+                  prog::expr::litCharNode(output.getProg(), 'W'))));
+
+      CHECK(
+          GET_FUNC_DEF(output, "f2").getBody() ==
+          *prog::expr::callExprNode(
+              output.getProg(),
+              funcT2Decl.getId(),
+              EXPRS(
+                  prog::expr::litStringNode(output.getProg(), "Hello"),
+                  prog::expr::litIntNode(output.getProg(), 42))));
+
+      CHECK(
+          GET_FUNC_DEF(output, "f3").getBody() ==
+          *prog::expr::callExprNode(
+              output.getProg(),
+              funcT1Decl.getId(),
+              EXPRS(
+                  prog::expr::litStringNode(output.getProg(), "Hello"),
+                  prog::expr::litCharNode(output.getProg(), 'W'))));
+    }
+
+    SECTION("Diagnostics") {
+
+      CHECK_DIAG(
+          "fun ft{T}(T a = \"Hello World\") a "
+          "fun f() ft{int}()",
+          errNonMatchingInitializerType(src, "int", "string", input::Span{16, 28}),
+          errInvalidFuncInstantiation(src, input::Span{41, 42}),
+          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{41, 49}));
+
+      CHECK_DIAG(
+          "fun ft{T}(T a = (b = 2)) a "
+          "fun f() ft{int}()",
+          errConstDeclareNotSupported(src, input::Span{17, 21}),
+          errInvalidFuncInstantiation(src, input::Span{35, 36}),
+          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{35, 43}));
+
+      CHECK_DIAG(
+          "fun ft{T}(T a = ft()) a "
+          "fun f() ft{int}()",
+          errUndeclaredPureFunc(src, "ft", {}, input::Span{16, 19}),
+          errInvalidFuncInstantiation(src, input::Span{32, 33}),
+          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{32, 40}));
+
+      CHECK_DIAG(
+          "fun ft{T}(T a = T(), T b) a + b "
+          "fun f() ft{int}()",
+          errNonOptArgFollowingOpt(src, input::Span{21, 23}),
+          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{40, 48}));
+
+      CHECK_DIAG(
+          "fun f(int a = 0, int b) a + b", errNonOptArgFollowingOpt(src, input::Span{17, 21}));
+    }
+  }
+
+  SECTION("Lambda") {
+
+    SECTION("Diagnostics") {
+
+      CHECK_DIAG(
+          "fun f() lambda (int i = 0) i",
+          errUnsupportedArgInitializer(src, "i", input::Span{16, 24}));
+      CHECK_DIAG(
+          "fun f() lambda (int a = 0, int b = 0) a + b",
+          errUnsupportedArgInitializer(src, "a", input::Span{16, 24}),
+          errUnsupportedArgInitializer(src, "b", input::Span{27, 35}));
+    }
+  }
+}
+
+} // namespace frontend

--- a/tests/frontend/overload_test.cpp
+++ b/tests/frontend/overload_test.cpp
@@ -9,7 +9,7 @@ TEST_CASE("[frontend] Analyzing overloads", "frontend") {
     const auto& output = ANALYZE("fun f1(float a, float b) a + b "
                                  "fun f2() f1(42, 1337)");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DEF(output, "f2").getExpr().getType() == GET_TYPE_ID(output, "float"));
+    CHECK(GET_FUNC_DEF(output, "f2").getBody().getType() == GET_TYPE_ID(output, "float"));
   }
 
   SECTION("Prefer overload with no conversion") {
@@ -17,7 +17,7 @@ TEST_CASE("[frontend] Analyzing overloads", "frontend") {
                                  "fun f1(int i) i "
                                  "fun f2() f1(1337)");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DEF(output, "f2").getExpr().getType() == GET_TYPE_ID(output, "int"));
+    CHECK(GET_FUNC_DEF(output, "f2").getBody().getType() == GET_TYPE_ID(output, "int"));
   }
 
   SECTION("Prefer overload with less conversions") {
@@ -25,7 +25,7 @@ TEST_CASE("[frontend] Analyzing overloads", "frontend") {
                                  "fun f1(float a, int b) b "
                                  "fun f2() f1(42, 1337)");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DEF(output, "f2").getExpr().getType() == GET_TYPE_ID(output, "int"));
+    CHECK(GET_FUNC_DEF(output, "f2").getBody().getType() == GET_TYPE_ID(output, "int"));
   }
 
   SECTION("Allow conversion in binary operator") {

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -286,6 +286,13 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         factoryDef.getExpr() ==
         *prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "Test__int"), {}));
   }
+
+  SECTION("Diagnostics") {
+    CHECK_DIAG(
+        "fun ft{T}(T a = T(), T b) a * b "
+        "fun f() ft(1, 2)",
+        errNonOptArgFollowingOpt(src, input::Span{21, 23}));
+  }
 }
 
 } // namespace frontend

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -24,7 +24,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "int")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Chained templated call") {
@@ -44,7 +44,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft1__int", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
         std::move(ft2Args));
 
-    CHECK(ft2Def.getExpr() == *callExpr2);
+    CHECK(ft2Def.getBody() == *callExpr2);
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
     auto fArgs       = std::vector<prog::expr::NodePtr>{};
@@ -54,7 +54,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft2__int", GET_TYPE_ID(output, "int")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Overload templated functions") {
@@ -73,7 +73,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "float"), GET_TYPE_ID(output, "int")),
         std::move(args));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Return type as parameter") {
@@ -94,7 +94,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "int")),
         std::move(args1));
 
-    CHECK(f1Def.getExpr() == *callExpr1);
+    CHECK(f1Def.getBody() == *callExpr1);
 
     auto args2 = std::vector<prog::expr::NodePtr>{};
     args2.push_back(prog::expr::litIntNode(output.getProg(), 1));
@@ -103,7 +103,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft__float", GET_TYPE_ID(output, "int")),
         std::move(args2));
 
-    CHECK(f2Def.getExpr() == *callExpr2);
+    CHECK(f2Def.getBody() == *callExpr2);
 
     auto args3 = std::vector<prog::expr::NodePtr>{};
     args3.push_back(prog::expr::litIntNode(output.getProg(), 1));
@@ -112,7 +112,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft__string", GET_TYPE_ID(output, "int")),
         std::move(args3));
 
-    CHECK(f3Def.getExpr() == *callExpr3);
+    CHECK(f3Def.getBody() == *callExpr3);
   }
 
   SECTION("Substituted constructor") {
@@ -127,7 +127,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     auto callExpr = prog::expr::callExprNode(
         output.getProg(), GET_FUNC_ID(output, "s", GET_TYPE_ID(output, "int")), std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Infer type-parameter in templated call") {
@@ -146,7 +146,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
             output, "ft__int_float", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "float")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Infer type-parameter supports implicit conversion") {
@@ -165,7 +165,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
             output, "ft__float", GET_TYPE_ID(output, "float"), GET_TYPE_ID(output, "float")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Infer type-parameter in templated call") {
@@ -192,7 +192,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
             GET_TYPE_ID(output, "Option__int")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Templated function with non-matching type-parameters is not instantiated") {
@@ -222,7 +222,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "Option__int")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Overloaded func templates prefer less type-parameters") {
@@ -245,7 +245,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
         std::move(f1Args));
 
-    CHECK(f1Def.getExpr() == *callExpr1);
+    CHECK(f1Def.getBody() == *callExpr1);
 
     // Check that f2 instantiates the version with two type-parameters.
     const auto& f2Def = GET_FUNC_DEF(output, "f2");
@@ -258,7 +258,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
             output, "ft__bool_int", GET_TYPE_ID(output, "bool"), GET_TYPE_ID(output, "int")),
         std::move(f2Args));
 
-    CHECK(f2Def.getExpr() == *callExpr2);
+    CHECK(f2Def.getBody() == *callExpr2);
   }
 
   SECTION("Func templates are ignored when arguments don't match") {
@@ -283,7 +283,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
 
     const auto& factoryDef = GET_FUNC_DEF(output, "factory__Test__int");
     CHECK(
-        factoryDef.getExpr() ==
+        factoryDef.getBody() ==
         *prog::expr::callExprNode(output.getProg(), GET_FUNC_ID(output, "Test__int"), {}));
   }
 

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -17,12 +17,10 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "int")),
-        std::move(fArgs));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -34,25 +32,20 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& ft2Def = GET_FUNC_DEF(output, "ft2__int", GET_TYPE_ID(output, "int"));
-    auto ft2Args       = std::vector<prog::expr::NodePtr>{};
-    ft2Args.push_back(
-        prog::expr::constExprNode(ft2Def.getConsts(), *ft2Def.getConsts().lookup("a")));
-    ft2Args.push_back(
-        prog::expr::constExprNode(ft2Def.getConsts(), *ft2Def.getConsts().lookup("a")));
-    auto callExpr2 = prog::expr::callExprNode(
+    auto callExpr2     = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft1__int", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
-        std::move(ft2Args));
+        EXPRS(
+            prog::expr::constExprNode(ft2Def.getConsts(), *ft2Def.getConsts().lookup("a")),
+            prog::expr::constExprNode(ft2Def.getConsts(), *ft2Def.getConsts().lookup("a"))));
 
     CHECK(ft2Def.getBody() == *callExpr2);
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft2__int", GET_TYPE_ID(output, "int")),
-        std::move(fArgs));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -65,13 +58,12 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
 
-    auto args = std::vector<prog::expr::NodePtr>{};
-    args.push_back(prog::expr::litFloatNode(output.getProg(), 1.0));
-    args.push_back(prog::expr::litIntNode(output.getProg(), 2));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "float"), GET_TYPE_ID(output, "int")),
-        std::move(args));
+        EXPRS(
+            prog::expr::litFloatNode(output.getProg(), 1.0),
+            prog::expr::litIntNode(output.getProg(), 2)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -87,30 +79,24 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     const auto& f2Def = GET_FUNC_DEF(output, "f2");
     const auto& f3Def = GET_FUNC_DEF(output, "f3");
 
-    auto args1 = std::vector<prog::expr::NodePtr>{};
-    args1.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr1 = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "int")),
-        std::move(args1));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(f1Def.getBody() == *callExpr1);
 
-    auto args2 = std::vector<prog::expr::NodePtr>{};
-    args2.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr2 = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft__float", GET_TYPE_ID(output, "int")),
-        std::move(args2));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(f2Def.getBody() == *callExpr2);
 
-    auto args3 = std::vector<prog::expr::NodePtr>{};
-    args3.push_back(prog::expr::litIntNode(output.getProg(), 1));
     auto callExpr3 = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft__string", GET_TYPE_ID(output, "int")),
-        std::move(args3));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(f3Def.getBody() == *callExpr3);
   }
@@ -122,10 +108,10 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "factory__s", GET_TYPE_ID(output, "int"));
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::constExprNode(fDef.getConsts(), *fDef.getConsts().lookup("i")));
-    auto callExpr = prog::expr::callExprNode(
-        output.getProg(), GET_FUNC_ID(output, "s", GET_TYPE_ID(output, "int")), std::move(fArgs));
+    auto callExpr    = prog::expr::callExprNode(
+        output.getProg(),
+        GET_FUNC_ID(output, "s", GET_TYPE_ID(output, "int")),
+        EXPRS(prog::expr::constExprNode(fDef.getConsts(), *fDef.getConsts().lookup("i"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -137,14 +123,13 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 2));
-    fArgs.push_back(prog::expr::litFloatNode(output.getProg(), 1.0));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
             output, "ft__int_float", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "float")),
-        std::move(fArgs));
+        EXPRS(
+            prog::expr::litIntNode(output.getProg(), 2),
+            prog::expr::litFloatNode(output.getProg(), 1.0)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -156,14 +141,13 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litFloatNode(output.getProg(), 1.0));
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 2));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
             output, "ft__float", GET_TYPE_ID(output, "float"), GET_TYPE_ID(output, "float")),
-        std::move(fArgs));
+        EXPRS(
+            prog::expr::litFloatNode(output.getProg(), 1.0),
+            prog::expr::litIntNode(output.getProg(), 2)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -178,19 +162,16 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(
-        applyConv(output, "int", "Option__int", prog::expr::litIntNode(output.getProg(), 1)));
-    fArgs.push_back(
-        applyConv(output, "int", "Option__int", prog::expr::litIntNode(output.getProg(), 2)));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
             output,
             "ft__int",
             GET_TYPE_ID(output, "Option__int"),
             GET_TYPE_ID(output, "Option__int")),
-        std::move(fArgs));
+        EXPRS(
+            applyConv(output, "int", "Option__int", prog::expr::litIntNode(output.getProg(), 1)),
+            applyConv(output, "int", "Option__int", prog::expr::litIntNode(output.getProg(), 2))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -214,13 +195,11 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(
-        applyConv(output, "int", "Option__int", prog::expr::litIntNode(output.getProg(), 42)));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "Option__int")),
-        std::move(fArgs));
+        EXPRS(
+            applyConv(output, "int", "Option__int", prog::expr::litIntNode(output.getProg(), 42))));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -237,26 +216,24 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
 
     // Check that f1 instantiates the version with one type-parameter.
     const auto& f1Def = GET_FUNC_DEF(output, "f1");
-    auto f1Args       = std::vector<prog::expr::NodePtr>{};
-    f1Args.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    f1Args.push_back(prog::expr::litIntNode(output.getProg(), 2));
-    auto callExpr1 = prog::expr::callExprNode(
+    auto callExpr1    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "ft__int", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int")),
-        std::move(f1Args));
+        EXPRS(
+            prog::expr::litIntNode(output.getProg(), 1),
+            prog::expr::litIntNode(output.getProg(), 2)));
 
     CHECK(f1Def.getBody() == *callExpr1);
 
     // Check that f2 instantiates the version with two type-parameters.
     const auto& f2Def = GET_FUNC_DEF(output, "f2");
-    auto f2Args       = std::vector<prog::expr::NodePtr>{};
-    f2Args.push_back(prog::expr::litBoolNode(output.getProg(), false));
-    f2Args.push_back(prog::expr::litIntNode(output.getProg(), 2));
-    auto callExpr2 = prog::expr::callExprNode(
+    auto callExpr2    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
             output, "ft__bool_int", GET_TYPE_ID(output, "bool"), GET_TYPE_ID(output, "int")),
-        std::move(f2Args));
+        EXPRS(
+            prog::expr::litBoolNode(output.getProg(), false),
+            prog::expr::litIntNode(output.getProg(), 2)));
 
     CHECK(f2Def.getBody() == *callExpr2);
   }
@@ -292,6 +269,20 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
         "fun ft{T}(T a = T(), T b) a * b "
         "fun f() ft(1, 2)",
         errNonOptArgFollowingOpt(src, input::Span{21, 23}));
+    CHECK_DIAG(
+        "struct S = int i "
+        "fun ft{T}() T() "
+        "fun f() ft{S}()",
+        errUndeclaredTypeOrConversion(src, "S", {}, input::Span{29, 31}),
+        errInvalidFuncInstantiation(src, input::Span{41, 42}),
+        errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{41, 47}));
+    CHECK_DIAG(
+        "struct S{T} = T t "
+        "fun ft{T}() T() "
+        "fun f() ft{S{int}}()",
+        errUndeclaredTypeOrConversion(src, "S{int}", {}, input::Span{30, 32}),
+        errInvalidFuncInstantiation(src, input::Span{42, 43}),
+        errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{42, 53}));
   }
 }
 

--- a/tests/frontend/user_type_templates_test.cpp
+++ b/tests/frontend/user_type_templates_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
             output, "tuple__int_string", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "string")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Construct templated union") {
@@ -42,7 +42,7 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
         GET_FUNC_ID(output, "opt__int", GET_TYPE_ID(output, "int")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Construct templated struct with inferred type params") {
@@ -60,7 +60,7 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
             output, "tuple__int_string", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "string")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Construct templated union with inferred type param") {
@@ -77,7 +77,7 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
         GET_FUNC_ID(output, "opt__int", GET_TYPE_ID(output, "int")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Conversion to templated struct") {
@@ -94,7 +94,7 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
         GET_FUNC_ID(output, "tuple__int_bool", GET_TYPE_ID(output, "int")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 
   SECTION("Templated conversion") {
@@ -114,7 +114,7 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
         GET_FUNC_ID(output, "string", GET_TYPE_ID(output, "tuple__int_float")),
         std::move(fArgs));
 
-    CHECK(fDef.getExpr() == *callExpr);
+    CHECK(fDef.getBody() == *callExpr);
   }
 }
 

--- a/tests/frontend/user_type_templates_test.cpp
+++ b/tests/frontend/user_type_templates_test.cpp
@@ -16,14 +16,13 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    fArgs.push_back(prog::expr::litStringNode(output.getProg(), "hello world"));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
             output, "tuple__int_string", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "string")),
-        std::move(fArgs));
+        EXPRS(
+            prog::expr::litIntNode(output.getProg(), 1),
+            prog::expr::litStringNode(output.getProg(), "hello world")));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -35,12 +34,10 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "opt__int", GET_TYPE_ID(output, "int")),
-        std::move(fArgs));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -51,14 +48,13 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    fArgs.push_back(prog::expr::litStringNode(output.getProg(), "hello world"));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(
             output, "tuple__int_string", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "string")),
-        std::move(fArgs));
+        EXPRS(
+            prog::expr::litIntNode(output.getProg(), 1),
+            prog::expr::litStringNode(output.getProg(), "hello world")));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -70,12 +66,10 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "opt__int", GET_TYPE_ID(output, "int")),
-        std::move(fArgs));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -87,12 +81,10 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
-    auto fArgs       = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::litIntNode(output.getProg(), 1));
-    auto callExpr = prog::expr::callExprNode(
+    auto callExpr    = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "tuple__int_bool", GET_TYPE_ID(output, "int")),
-        std::move(fArgs));
+        EXPRS(prog::expr::litIntNode(output.getProg(), 1)));
 
     CHECK(fDef.getBody() == *callExpr);
   }
@@ -107,12 +99,10 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
     const auto& fDef   = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "tuple__int_float"));
     const auto& consts = fDef.getConsts();
 
-    auto fArgs = std::vector<prog::expr::NodePtr>{};
-    fArgs.push_back(prog::expr::constExprNode(consts, *consts.lookup("t")));
     auto callExpr = prog::expr::callExprNode(
         output.getProg(),
         GET_FUNC_ID(output, "string", GET_TYPE_ID(output, "tuple__int_float")),
-        std::move(fArgs));
+        EXPRS(prog::expr::constExprNode(consts, *consts.lookup("t"))));
 
     CHECK(fDef.getBody() == *callExpr);
   }

--- a/tests/opt/call_inline_test.cpp
+++ b/tests/opt/call_inline_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("[opt] Call inline", "opt") {
         inlADef.getConsts(), *inlADef.getConsts().lookup("__inlined_0_i")));
     auto inlAGroupExpr = prog::expr::groupExprNode(std::move(inlAExprs));
 
-    CHECK(inlADef.getExpr() == *inlAGroupExpr);
+    CHECK(inlADef.getBody() == *inlAGroupExpr);
   }
 
   SECTION("Inline nested call") {
@@ -61,7 +61,7 @@ TEST_CASE("[opt] Call inline", "opt") {
         inlADef.getConsts(), *inlADef.getConsts().lookup("__inlined_0_i")));
     auto inlAGroupExpr = prog::expr::groupExprNode(std::move(inlAExprs));
 
-    CHECK(inlADef.getExpr() == *inlAGroupExpr);
+    CHECK(inlADef.getBody() == *inlAGroupExpr);
   }
 
   SECTION("Inline nested call in arg") {
@@ -89,7 +89,7 @@ TEST_CASE("[opt] Call inline", "opt") {
         inlADef.getConsts(), *inlADef.getConsts().lookup("__inlined_0_i")));
     auto inlAGroupExpr = prog::expr::groupExprNode(std::move(inlAExprs));
 
-    CHECK(inlADef.getExpr() == *inlAGroupExpr);
+    CHECK(inlADef.getBody() == *inlAGroupExpr);
   }
 }
 

--- a/tests/opt/const_elimination_test.cpp
+++ b/tests/opt/const_elimination_test.cpp
@@ -16,7 +16,7 @@ TEST_CASE("[opt] Constants elimination", "opt") {
     // Verify that both constants are removed.
     const auto& funcDef = GET_FUNC_DEF(optProg, "func");
 
-    CHECK(funcDef.getExpr() == *getIntBinaryOpExpr(optProg, prog::Operator::Plus, 42, 1337));
+    CHECK(funcDef.getBody() == *getIntBinaryOpExpr(optProg, prog::Operator::Plus, 42, 1337));
   }
 
   SECTION("Trivial constants are eliminated") {
@@ -29,7 +29,7 @@ TEST_CASE("[opt] Constants elimination", "opt") {
     // Verify that both constants are removed.
     const auto& funcDef = GET_FUNC_DEF(optProg, "func");
 
-    CHECK(funcDef.getExpr() == *getIntBinaryOpExpr(optProg, prog::Operator::Plus, 42, 42));
+    CHECK(funcDef.getBody() == *getIntBinaryOpExpr(optProg, prog::Operator::Plus, 42, 42));
   }
 }
 

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -46,7 +46,7 @@ inline auto buildSource(std::string input) {
     const auto& output = ANALYZE("act test() " INPUT);                                             \
     REQUIRE(output.isSuccess());                                                                   \
     const auto prog = OPT(output.getProg());                                                       \
-    CHECK(GET_FUNC_DEF(prog, "test").getExpr() == *(EXPECTED_EXPR));                               \
+    CHECK(GET_FUNC_DEF(prog, "test").getBody() == *(EXPECTED_EXPR));                               \
   }
 
 inline auto

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -279,7 +279,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
                                    "fun f() int(e.a)");
       REQUIRE(output.isSuccess());
       const auto prog = precomputeLiterals(output.getProg());
-      CHECK(GET_FUNC_DEF(prog, "f").getExpr() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
+      CHECK(GET_FUNC_DEF(prog, "f").getBody() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
     }
 
     {
@@ -287,7 +287,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
                                    "fun f() int(e.a)");
       REQUIRE(output.isSuccess());
       const auto prog = precomputeLiterals(output.getProg());
-      CHECK(GET_FUNC_DEF(prog, "f").getExpr() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
+      CHECK(GET_FUNC_DEF(prog, "f").getBody() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
     }
   }
 
@@ -296,7 +296,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
                                  "fun f() s(42).i");
     REQUIRE(output.isSuccess());
     const auto prog = precomputeLiterals(output.getProg());
-    CHECK(GET_FUNC_DEF(prog, "f").getExpr() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
+    CHECK(GET_FUNC_DEF(prog, "f").getBody() == *litIntNode(prog, 42)); // NOLINT: Magic numbers
   }
 
   SECTION("dynamic call to func literal") {
@@ -305,7 +305,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     REQUIRE(output.isSuccess());
     // Check that it originally is a dynamic call.
     REQUIRE(
-        GET_FUNC_DEF(output.getProg(), "f2").getExpr().getKind() == prog::expr::NodeKind::CallDyn);
+        GET_FUNC_DEF(output.getProg(), "f2").getBody().getKind() == prog::expr::NodeKind::CallDyn);
 
     const auto prog = precomputeLiterals(output.getProg());
 
@@ -315,7 +315,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     auto callExpr =
         callExprNode(prog, GET_FUNC_ID(prog, "f1", GET_TYPE_ID(prog, "int")), std::move(args));
 
-    CHECK(GET_FUNC_DEF(prog, "f2").getExpr() == *callExpr);
+    CHECK(GET_FUNC_DEF(prog, "f2").getBody() == *callExpr);
   }
 
   SECTION("dynamic call to closure") {
@@ -324,14 +324,14 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     // Check that it originally is a dynamic call.
     REQUIRE(
         GET_FUNC_DEF(output.getProg(), "f", GET_TYPE_ID(output.getProg(), "int"))
-            .getExpr()
+            .getBody()
             .getKind() == prog::expr::NodeKind::CallDyn);
 
     const auto prog = precomputeLiterals(output.getProg());
 
     // Verify that it was optimized into a normal call.
     REQUIRE(
-        GET_FUNC_DEF(prog, "f", GET_TYPE_ID(prog, "int")).getExpr().getKind() ==
+        GET_FUNC_DEF(prog, "f", GET_TYPE_ID(prog, "int")).getBody().getKind() ==
         prog::expr::NodeKind::Call);
   }
 
@@ -341,14 +341,14 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     REQUIRE(output.isSuccess());
     // Check that it originally call lazy-get.
     auto& orgCall =
-        *GET_FUNC_DEF(output.getProg(), "f2").getExpr().downcast<prog::expr::CallExprNode>();
+        *GET_FUNC_DEF(output.getProg(), "f2").getBody().downcast<prog::expr::CallExprNode>();
     REQUIRE(
         output.getProg().getFuncDecl(orgCall.getFunc()).getKind() == prog::sym::FuncKind::LazyGet);
 
     const auto prog = precomputeLiterals(output.getProg());
 
     // Verify that it was optimized to call f1 directly.
-    auto& optCall = *GET_FUNC_DEF(prog, "f2").getExpr().downcast<prog::expr::CallExprNode>();
+    auto& optCall = *GET_FUNC_DEF(prog, "f2").getBody().downcast<prog::expr::CallExprNode>();
     CHECK(
         optCall.getFunc() ==
         GET_FUNC_ID(
@@ -366,7 +366,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     auto& orgCall =
         *GET_FUNC_DEF(
              output.getProg(), "f2", GET_TYPE_ID(output.getProg(), "__function_int_int_int"))
-             .getExpr()
+             .getBody()
              .downcast<prog::expr::CallExprNode>();
     REQUIRE(
         output.getProg().getFuncDecl(orgCall.getFunc()).getKind() == prog::sym::FuncKind::LazyGet);
@@ -375,7 +375,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
 
     // Verify that it was optimized to call the delegate directly.
     auto& optCall =
-        GET_FUNC_DEF(prog, "f2", GET_TYPE_ID(output.getProg(), "__function_int_int_int")).getExpr();
+        GET_FUNC_DEF(prog, "f2", GET_TYPE_ID(output.getProg(), "__function_int_int_int")).getBody();
     CHECK(optCall.getKind() == prog::expr::NodeKind::CallDyn);
   }
 }

--- a/tests/opt/synergy_test.cpp
+++ b/tests/opt/synergy_test.cpp
@@ -22,7 +22,7 @@ TEST_CASE("[opt] Optimization synergy", "opt") {
 
     const auto& inlADef = optimizedProg.getFuncDef(*actAId);
 
-    CHECK(inlADef.getExpr() == *prog::expr::litIntNode(optimizedProg, 42));
+    CHECK(inlADef.getBody() == *prog::expr::litIntNode(optimizedProg, 42));
   }
 
   SECTION("One time used lazy calls are optimized out") {
@@ -44,7 +44,7 @@ TEST_CASE("[opt] Optimization synergy", "opt") {
 
     const auto& mainDef = optimizedProg.getFuncDef(*mainId);
 
-    CHECK(mainDef.getExpr() == *prog::expr::litIntNode(optimizedProg, 42 * 2));
+    CHECK(mainDef.getBody() == *prog::expr::litIntNode(optimizedProg, 42 * 2));
   }
 }
 

--- a/tests/opt/treeshake_test.cpp
+++ b/tests/opt/treeshake_test.cpp
@@ -9,8 +9,9 @@ namespace opt {
 TEST_CASE("[opt] Treeshake", "opt") {
 
   SECTION("Unused func") {
-    auto prog   = prog::Program{};
-    auto funcId = prog.declarePureFunc("unused", prog::sym::TypeSet{prog.getInt()}, prog.getBool());
+    auto prog = prog::Program{};
+    auto funcId =
+        prog.declarePureFunc("unused", prog::sym::TypeSet{prog.getInt()}, prog.getBool(), 0u);
     prog.defineFunc(funcId, prog::sym::ConstDeclTable{}, prog::expr::litBoolNode(prog, false));
 
     auto shakedProg = treeshake(prog);
@@ -20,7 +21,7 @@ TEST_CASE("[opt] Treeshake", "opt") {
 
   SECTION("Used func") {
     auto prog   = prog::Program{};
-    auto funcId = prog.declarePureFunc("used", prog::sym::TypeSet{}, prog.getBool());
+    auto funcId = prog.declarePureFunc("used", prog::sym::TypeSet{}, prog.getBool(), 0u);
     prog.defineFunc(funcId, prog::sym::ConstDeclTable{}, prog::expr::litBoolNode(prog, false));
     prog.addExecStmt(prog::sym::ConstDeclTable{}, prog::expr::callExprNode(prog, funcId, {}));
 

--- a/tests/opt/treeshake_test.cpp
+++ b/tests/opt/treeshake_test.cpp
@@ -12,7 +12,7 @@ TEST_CASE("[opt] Treeshake", "opt") {
     auto prog = prog::Program{};
     auto funcId =
         prog.declarePureFunc("unused", prog::sym::TypeSet{prog.getInt()}, prog.getBool(), 0u);
-    prog.defineFunc(funcId, prog::sym::ConstDeclTable{}, prog::expr::litBoolNode(prog, false));
+    prog.defineFunc(funcId, prog::sym::ConstDeclTable{}, prog::expr::litBoolNode(prog, false), {});
 
     auto shakedProg = treeshake(prog);
     CHECK(prog.lookupFunc("unused", prog::sym::TypeSet{prog.getInt()}, prog::OvOptions{}));
@@ -22,7 +22,7 @@ TEST_CASE("[opt] Treeshake", "opt") {
   SECTION("Used func") {
     auto prog   = prog::Program{};
     auto funcId = prog.declarePureFunc("used", prog::sym::TypeSet{}, prog.getBool(), 0u);
-    prog.defineFunc(funcId, prog::sym::ConstDeclTable{}, prog::expr::litBoolNode(prog, false));
+    prog.defineFunc(funcId, prog::sym::ConstDeclTable{}, prog::expr::litBoolNode(prog, false), {});
     prog.addExecStmt(prog::sym::ConstDeclTable{}, prog::expr::callExprNode(prog, funcId, {}));
 
     auto shakedProg = treeshake(prog);

--- a/tests/parse/expr_anon_func_test.cpp
+++ b/tests/parse/expr_anon_func_test.cpp
@@ -10,26 +10,30 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
   CHECK_EXPR(
       "lambda () 1",
       anonFuncExprNode(
-          {}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), std::nullopt, INT(1)));
+          {}, LAMBDA, ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN), std::nullopt, INT(1)));
   CHECK_EXPR(
       "lambda () -> int 1",
       anonFuncExprNode(
           {},
           LAMBDA,
-          ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN),
+          ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
           RetTypeSpec{ARROW, TYPE("int")},
           INT(1)));
   CHECK_EXPR(
       "impure lambda () 1",
       anonFuncExprNode(
-          {IMPURE}, LAMBDA, ArgumentListDecl(OPAREN, {}, COMMAS(0), CPAREN), std::nullopt, INT(1)));
+          {IMPURE},
+          LAMBDA,
+          ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+          std::nullopt,
+          INT(1)));
   CHECK_EXPR(
       "lambda (int x) 1",
       anonFuncExprNode(
           {},
           LAMBDA,
           ArgumentListDecl(
-              OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), CPAREN),
+              OPAREN, ARGS(ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))), COMMAS(0), CPAREN),
           std::nullopt,
           INT(1)));
   CHECK_EXPR(
@@ -39,8 +43,9 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
           LAMBDA,
           ArgumentListDecl(
               OPAREN,
-              {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
-               ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))},
+              ARGS(
+                  ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
+                  ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))),
               COMMAS(1),
               CPAREN),
           std::nullopt,
@@ -52,13 +57,27 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
           LAMBDA,
           ArgumentListDecl(
               OPAREN,
-              {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
-               ArgumentListDecl::ArgSpec(TYPE("int"), ID("y")),
-               ArgumentListDecl::ArgSpec(TYPE("bool"), ID("z"))},
+              ARGS(
+                  ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
+                  ArgumentListDecl::ArgSpec(TYPE("int"), ID("y")),
+                  ArgumentListDecl::ArgSpec(TYPE("bool"), ID("z"))),
               COMMAS(2),
               CPAREN),
           std::nullopt,
           binaryExprNode(ID_EXPR("x"), STAR, ID_EXPR("y"))));
+  CHECK_EXPR(
+      "lambda (int x = 1) 1",
+      anonFuncExprNode(
+          {},
+          LAMBDA,
+          ArgumentListDecl(
+              OPAREN,
+              ARGS(ArgumentListDecl::ArgSpec(
+                  TYPE("int"), ID("x"), ArgumentListDecl::ArgInitializer(EQ, INT(1)))),
+              COMMAS(0),
+              CPAREN),
+          std::nullopt,
+          INT(1)));
 
   SECTION("Errors") {
     CHECK_EXPR(
@@ -66,7 +85,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         anonFuncExprNode(
             {},
             LAMBDA,
-            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -74,7 +93,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(END, {}, COMMAS(0), END),
+            ArgumentListDecl(END, ARGS(), COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -82,7 +101,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(OPAREN, {}, COMMAS(0), END),
+            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -91,7 +110,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
             {},
             LAMBDA,
             ArgumentListDecl(
-                OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))}, COMMAS(0), END),
+                OPAREN, ARGS(ArgumentListDecl::ArgSpec(TYPE("int"), ID("x"))), COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -99,7 +118,8 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(OPAREN, {ArgumentListDecl::ArgSpec(TYPE("int"), END)}, COMMAS(0), END),
+            ArgumentListDecl(
+                OPAREN, ARGS(ArgumentListDecl::ArgSpec(TYPE("int"), END)), COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -109,8 +129,9 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
             LAMBDA,
             ArgumentListDecl(
                 OPAREN,
-                {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
-                 ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))},
+                ARGS(
+                    ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
+                    ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))),
                 COMMAS(0),
                 CPAREN),
             std::nullopt,
@@ -122,8 +143,9 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
             LAMBDA,
             ArgumentListDecl(
                 OPAREN,
-                {ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
-                 ArgumentListDecl::ArgSpec(Type(COMMA), CPAREN)},
+                ARGS(
+                    ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
+                    ArgumentListDecl::ArgSpec(Type(COMMA), CPAREN)),
                 COMMAS(1),
                 END),
             std::nullopt,
@@ -133,7 +155,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {IMPURE},
             ID("function"),
-            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
             std::nullopt,
             INT(1)));
     CHECK_EXPR(
@@ -141,7 +163,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {IMPURE},
             ID("action"),
-            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
             std::nullopt,
             INT(1)));
     CHECK_EXPR(
@@ -149,7 +171,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
             RetTypeSpec{ARROW, parse::Type{END}},
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -157,9 +179,22 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(PARENPAREN, {}, COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
             RetTypeSpec{ARROW, parse::Type{INT_TOK(1)}},
             errInvalidPrimaryExpr(END)));
+    CHECK_EXPR(
+        "lambda (int x =) -> int 1",
+        errInvalidAnonFuncExpr(
+            {},
+            LAMBDA,
+            ArgumentListDecl(
+                OPAREN,
+                ARGS(ArgumentListDecl::ArgSpec(
+                    TYPE("int"), ID("x"), ArgumentListDecl::ArgInitializer(EQ, nullptr))),
+                COMMAS(0),
+                CPAREN),
+            RetTypeSpec{ARROW, TYPE("int")},
+            INT(1)));
   }
 
   SECTION("Spans") {

--- a/tests/parse/expr_anon_func_test.cpp
+++ b/tests/parse/expr_anon_func_test.cpp
@@ -10,13 +10,13 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
   CHECK_EXPR(
       "lambda () 1",
       anonFuncExprNode(
-          {}, LAMBDA, ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN), std::nullopt, INT(1)));
+          {}, LAMBDA, ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN), std::nullopt, INT(1)));
   CHECK_EXPR(
       "lambda () -> int 1",
       anonFuncExprNode(
           {},
           LAMBDA,
-          ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+          ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
           RetTypeSpec{ARROW, TYPE("int")},
           INT(1)));
   CHECK_EXPR(
@@ -24,7 +24,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
       anonFuncExprNode(
           {IMPURE},
           LAMBDA,
-          ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+          ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
           std::nullopt,
           INT(1)));
   CHECK_EXPR(
@@ -85,7 +85,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         anonFuncExprNode(
             {},
             LAMBDA,
-            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -93,7 +93,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(END, ARGS(), COMMAS(0), END),
+            ArgumentListDecl(END, NO_ARGS, COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -101,7 +101,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), END),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -155,7 +155,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {IMPURE},
             ID("function"),
-            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
             std::nullopt,
             INT(1)));
     CHECK_EXPR(
@@ -163,7 +163,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {IMPURE},
             ID("action"),
-            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
             std::nullopt,
             INT(1)));
     CHECK_EXPR(
@@ -171,7 +171,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
             RetTypeSpec{ARROW, parse::Type{END}},
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(
@@ -179,7 +179,7 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
         errInvalidAnonFuncExpr(
             {},
             LAMBDA,
-            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
             RetTypeSpec{ARROW, parse::Type{INT_TOK(1)}},
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(

--- a/tests/parse/expr_call_test.cpp
+++ b/tests/parse/expr_call_test.cpp
@@ -11,16 +11,16 @@ namespace parse {
 
 TEST_CASE("[parse] Parsing call expressions", "parse") {
 
-  CHECK_EXPR("a()", callExprNode({}, ID_EXPR("a"), OPAREN, NODES(), COMMAS(0), CPAREN));
-  CHECK_EXPR("1()", callExprNode({}, INT(1), OPAREN, NODES(), COMMAS(0), CPAREN));
-  CHECK_EXPR("self()", callExprNode({}, SELF_ID_EXPR, OPAREN, NODES(), COMMAS(0), CPAREN));
+  CHECK_EXPR("a()", callExprNode({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), CPAREN));
+  CHECK_EXPR("1()", callExprNode({}, INT(1), OPAREN, NO_NODES, COMMAS(0), CPAREN));
+  CHECK_EXPR("self()", callExprNode({}, SELF_ID_EXPR, OPAREN, NO_NODES, COMMAS(0), CPAREN));
   CHECK_EXPR(
       "1()()",
       callExprNode(
           {},
-          callExprNode({}, INT(1), OPAREN, NODES(), COMMAS(0), CPAREN),
+          callExprNode({}, INT(1), OPAREN, NO_NODES, COMMAS(0), CPAREN),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN));
   CHECK_EXPR(
@@ -29,11 +29,11 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
           {},
           parenExprNode(OPAREN, unaryExprNode(MINUS, INT(1)), CPAREN),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN));
   CHECK_EXPR(
-      "-1()", unaryExprNode(MINUS, callExprNode({}, INT(1), OPAREN, NODES(), COMMAS(0), CPAREN)));
+      "-1()", unaryExprNode(MINUS, callExprNode({}, INT(1), OPAREN, NO_NODES, COMMAS(0), CPAREN)));
   CHECK_EXPR(
       "a(1,2)", callExprNode({}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(2)), COMMAS(1), CPAREN));
   CHECK_EXPR(
@@ -62,7 +62,7 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
           {},
           ID_EXPR("a"),
           OPAREN,
-          NODES(callExprNode({}, ID_EXPR("b"), OPAREN, NODES(), COMMAS(0), CPAREN)),
+          NODES(callExprNode({}, ID_EXPR("b"), OPAREN, NO_NODES, COMMAS(0), CPAREN)),
           COMMAS(0),
           CPAREN));
   CHECK_EXPR(
@@ -71,7 +71,7 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
           {},
           ID_EXPR_PARAM("a", TypeParamList(OCURLY, {TYPE("T")}, COMMAS(0), CCURLY)),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN));
   CHECK_EXPR(
@@ -89,7 +89,7 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
           {},
           ID_EXPR_PARAM("a", TypeParamList(OCURLY, {TYPE("T"), TYPE("Y")}, COMMAS(1), CCURLY)),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN));
   CHECK_EXPR(
@@ -99,7 +99,7 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
           ID_EXPR_PARAM(
               "a", TypeParamList(OCURLY, {TYPE("T"), TYPE("U"), TYPE("W")}, COMMAS(2), CCURLY)),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN));
   CHECK_EXPR(
@@ -108,22 +108,22 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
           {},
           intrinsicExprNode(INTRINSIC, OCURLY, ID("a"), CCURLY, std::nullopt),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN));
 
-  CHECK_EXPR("fork a()", callExprNode({FORK}, ID_EXPR("a"), OPAREN, NODES(), COMMAS(0), CPAREN));
+  CHECK_EXPR("fork a()", callExprNode({FORK}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), CPAREN));
 
   CHECK_EXPR(
       "fork (a)()",
       callExprNode(
-          {FORK}, parenExprNode(OPAREN, ID_EXPR("a"), CPAREN), OPAREN, NODES(), COMMAS(0), CPAREN));
+          {FORK}, parenExprNode(OPAREN, ID_EXPR("a"), CPAREN), OPAREN, NO_NODES, COMMAS(0), CPAREN));
 
   SECTION("Errors") {
     CHECK_EXPR(
         "a(1 1)",
         errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(0), CPAREN));
-    CHECK_EXPR("a(", errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NODES(), COMMAS(0), END));
+    CHECK_EXPR("a(", errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), END));
     CHECK_EXPR("a{", errInvalidIdExpr(ID("a"), TypeParamList(OCURLY, {}, COMMAS(0), END)));
     CHECK_EXPR(
         "a{}()",
@@ -131,7 +131,7 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
             {},
             errInvalidIdExpr(ID("a"), TypeParamList(OCURLY, {}, COMMAS(0), CCURLY)),
             PARENPAREN,
-            NODES(),
+            NO_NODES,
             COMMAS(0),
             PARENPAREN));
     CHECK_EXPR(
@@ -141,7 +141,7 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
             errInvalidIdExpr(
                 ID("a"), TypeParamList(OCURLY, {TYPE("T"), TYPE("U")}, COMMAS(0), CCURLY)),
             PARENPAREN,
-            NODES(),
+            NO_NODES,
             COMMAS(0),
             PARENPAREN));
     CHECK_EXPR(

--- a/tests/parse/expr_index_test.cpp
+++ b/tests/parse/expr_index_test.cpp
@@ -41,11 +41,11 @@ TEST_CASE("[parse] Parsing index expressions", "parse") {
   SECTION("Errors") {
     // Note: The error on '[]' is an unfortunate side-effect of how we lex '[]' vs '[ ]'.
     CHECK_EXPR("a[]", ID_EXPR("a"), errInvalidUnaryOp(SQUARESQUARE, errInvalidPrimaryExpr(END)));
-    CHECK_EXPR("a[ ]", errInvalidIndexExpr(ID_EXPR("a"), OSQUARE, NODES(), COMMAS(0), CSQUARE));
+    CHECK_EXPR("a[ ]", errInvalidIndexExpr(ID_EXPR("a"), OSQUARE, NO_NODES, COMMAS(0), CSQUARE));
     CHECK_EXPR(
         "a[1 1]",
         errInvalidIndexExpr(ID_EXPR("a"), OSQUARE, NODES(INT(1), INT(1)), COMMAS(0), CSQUARE));
-    CHECK_EXPR("a[", errInvalidIndexExpr(ID_EXPR("a"), OSQUARE, NODES(), COMMAS(0), END));
+    CHECK_EXPR("a[", errInvalidIndexExpr(ID_EXPR("a"), OSQUARE, NO_NODES, COMMAS(0), END));
     CHECK_EXPR(
         "a[,",
         errInvalidIndexExpr(

--- a/tests/parse/expr_intrinsic_test.cpp
+++ b/tests/parse/expr_intrinsic_test.cpp
@@ -34,7 +34,7 @@ TEST_CASE("[parse] Parsing intrinsic expressions", "parse") {
           {},
           intrinsicExprNode(INTRINSIC, OCURLY, ID("test"), CCURLY, std::nullopt),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN));
   CHECK_EXPR(

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -148,7 +148,11 @@ inline auto arrayMoveToVec(Array c) {
 
 #define NODES(...) arrayMoveToVec<std::array<NodePtr, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
 
+#define NO_NODES std::vector<NodePtr>{}
+
 #define ARGS(...)                                                                                  \
   arrayMoveToVec<std::array<ArgumentListDecl::ArgSpec, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
+
+#define NO_ARGS std::vector<ArgumentListDecl::ArgSpec>{}
 
 } // namespace parse

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -148,4 +148,7 @@ inline auto arrayMoveToVec(Array c) {
 
 #define NODES(...) arrayMoveToVec<std::array<NodePtr, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
 
+#define ARGS(...)                                                                                  \
+  arrayMoveToVec<std::array<ArgumentListDecl::ArgSpec, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
+
 } // namespace parse

--- a/tests/parse/stmt_exec_test.cpp
+++ b/tests/parse/stmt_exec_test.cpp
@@ -12,14 +12,14 @@ TEST_CASE("[parse] Parsing execute statements", "parse") {
 
   CHECK_STMT(
       "exec()",
-      execStmtNode(callExprNode({}, ID_EXPR("exec"), OPAREN, NODES(), COMMAS(0), CPAREN)));
+      execStmtNode(callExprNode({}, ID_EXPR("exec"), OPAREN, NO_NODES, COMMAS(0), CPAREN)));
   CHECK_STMT(
       "intrinsic{exec}()",
       execStmtNode(callExprNode(
           {},
           intrinsicExprNode(INTRINSIC, OCURLY, ID("exec"), CCURLY, std::nullopt),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN)));
   CHECK_STMT(
@@ -52,7 +52,7 @@ TEST_CASE("[parse] Parsing execute statements", "parse") {
           {},
           ID_EXPR("exec"),
           OPAREN,
-          NODES(callExprNode({}, ID_EXPR("a"), OPAREN, NODES(), COMMAS(0), CPAREN)),
+          NODES(callExprNode({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), CPAREN)),
           COMMAS(0),
           CPAREN)));
   CHECK_STMT(
@@ -61,14 +61,14 @@ TEST_CASE("[parse] Parsing execute statements", "parse") {
           {},
           ID_EXPR_PARAM("exec", TypeParamList(OCURLY, {TYPE("int")}, COMMAS(0), CCURLY)),
           OPAREN,
-          NODES(),
+          NO_NODES,
           COMMAS(0),
           CPAREN)));
   CHECK_STMT(
       "(exec)()",
       execStmtNode(callExprNode(
-          {}, parenExprNode(OPAREN, ID_EXPR("exec"), CPAREN), OPAREN, NODES(), COMMAS(0), CPAREN)));
-  CHECK_STMT("1()", execStmtNode(callExprNode({}, INT(1), OPAREN, NODES(), COMMAS(0), CPAREN)));
+          {}, parenExprNode(OPAREN, ID_EXPR("exec"), CPAREN), OPAREN, NO_NODES, COMMAS(0), CPAREN)));
+  CHECK_STMT("1()", execStmtNode(callExprNode({}, INT(1), OPAREN, NO_NODES, COMMAS(0), CPAREN)));
 
   SECTION("Errors") {
     CHECK_STMT(
@@ -76,7 +76,7 @@ TEST_CASE("[parse] Parsing execute statements", "parse") {
         execStmtNode(errInvalidCallExpr(
             {}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(0), CPAREN)));
     CHECK_STMT(
-        "a(", execStmtNode(errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NODES(), COMMAS(0), END)));
+        "a(", execStmtNode(errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), END)));
     CHECK_STMT(
         "a(,",
         execStmtNode(errInvalidCallExpr(

--- a/tests/parse/stmt_func_decl_test.cpp
+++ b/tests/parse/stmt_func_decl_test.cpp
@@ -18,7 +18,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             std::nullopt,
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             std::nullopt,
             INT(1)));
     CHECK_STMT(
@@ -27,7 +27,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             std::nullopt,
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(
@@ -93,7 +93,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T")}, COMMAS(0), CCURLY},
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             std::nullopt,
             INT(1)));
     CHECK_STMT(
@@ -102,7 +102,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(1), CCURLY},
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             std::nullopt,
             INT(1)));
     CHECK_STMT(
@@ -121,7 +121,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             std::nullopt,
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             RetTypeSpec{ARROW, TYPE("List", TYPE("T", TYPE("Y")))},
             INT(1)));
     CHECK_STMT(
@@ -165,7 +165,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
                             ID_EXPR_PARAM(
                                 "T", TypeParamList(OCURLY, {TYPE("U")}, COMMAS(1), CCURLY)),
                             OPAREN,
-                            NODES(),
+                            NO_NODES,
                             COMMAS(0),
                             CPAREN)))),
                 COMMAS(0),
@@ -181,7 +181,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             ACT,
             ID("a"),
             std::nullopt,
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             std::nullopt,
             INT(1)));
     CHECK_STMT(
@@ -230,7 +230,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             std::nullopt,
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), CPAREN),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             RetTypeSpec{ARROW, TYPE("int")},
             errInvalidPrimaryExpr(END)));
     CHECK_STMT(
@@ -239,7 +239,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             END,
             std::nullopt,
-            ArgumentListDecl(END, ARGS(), COMMAS(0), END),
+            ArgumentListDecl(END, NO_ARGS, COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_STMT(
@@ -248,7 +248,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             TypeSubstitutionList{OCURLY, {}, COMMAS(0), END},
-            ArgumentListDecl(END, ARGS(), COMMAS(0), END),
+            ArgumentListDecl(END, NO_ARGS, COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_STMT(
@@ -277,7 +277,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             DISCARD,
             std::nullopt,
-            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
             std::nullopt,
             INT(1)));
     CHECK_STMT(
@@ -286,7 +286,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             std::nullopt,
-            ArgumentListDecl(OPAREN, ARGS(), COMMAS(0), END),
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), END),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_STMT(
@@ -370,7 +370,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             FUN,
             ID("a"),
             std::nullopt,
-            ArgumentListDecl(PARENPAREN, ARGS(), COMMAS(0), PARENPAREN),
+            ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
             RetTypeSpec{ARROW, Type(ID("T"), TypeParamList(OCURLY, {}, {}, CCURLY))},
             INT(1)));
     CHECK_STMT(

--- a/tests/prog/copy_test.cpp
+++ b/tests/prog/copy_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("[prog] Copy", "prog") {
 
   SECTION("Copy function") {
     auto progA    = Program{};
-    const auto id = progA.declarePureFunc("test", sym::TypeSet{}, progA.getInt());
+    const auto id = progA.declarePureFunc("test", sym::TypeSet{}, progA.getInt(), 0u);
     progA.defineFunc(id, sym::ConstDeclTable{}, expr::litIntNode(progA, 2));
 
     // Copy to another program.

--- a/tests/prog/copy_test.cpp
+++ b/tests/prog/copy_test.cpp
@@ -28,7 +28,7 @@ TEST_CASE("[prog] Copy", "prog") {
   SECTION("Copy function") {
     auto progA    = Program{};
     const auto id = progA.declarePureFunc("test", sym::TypeSet{}, progA.getInt(), 0u);
-    progA.defineFunc(id, sym::ConstDeclTable{}, expr::litIntNode(progA, 2));
+    progA.defineFunc(id, sym::ConstDeclTable{}, expr::litIntNode(progA, 2), {});
 
     // Copy to another program.
     auto progB = Program{};
@@ -36,7 +36,7 @@ TEST_CASE("[prog] Copy", "prog") {
 
     // Assert its presence.
     REQUIRE(progB.lookupFunc("test", sym::TypeSet{}, OvOptions{}) == id);
-    REQUIRE(progB.getFuncDef(id).getExpr() == *expr::litIntNode(progB, 2));
+    REQUIRE(progB.getFuncDef(id).getBody() == *expr::litIntNode(progB, 2));
   }
 
   SECTION("Fail to copy build-in type") {


### PR DESCRIPTION
Add support for optional arguments.

```c
fun add(int a, int b = 1)
  a + b

// Almost any expression is valid as an initializer (for example a lambda definition)
fun check{T}(T val, function{T, bool} predicate = lambda (int val) val != 0)
  predicate(val)
```