### PR TITLE
vm: Gracefully fail when a forked call fails

### DIFF
--- a/include/vm/exec_state.hpp
+++ b/include/vm/exec_state.hpp
@@ -6,21 +6,26 @@ namespace vm {
 
 // Current (or last) state of an executor. Also used as the exit code of the virtual machine.
 enum class ExecState : int8_t {
+  /* Internal states for executors, will never be returned from the vm.
+   */
+  Aborted = -3, // The executor has been aborted.
   Paused  = -2, // The executor is paused, will never be returned from the vm.
   Running = -1, // The executor is running, will never be returned from the vm.
-  Success = 0,  // The executor has finished successfully, is the 'normal' result of the vm.
-  Failed  = 1, // The executor has encountered a 'fail' instruction, is not an error case for the vm
-               // but a mechanism for a user-program to indicate failure.
-  Aborted = 2, // The executor has been aborted, happens to executors when the vm is tearing down.
-  InvalidAssembly = 3, // The executor has encountered an invalid instruction in the assembly, this
-                       // cannot be recovered from.
-  StackOverflow = 4,   // The stack memory of the executor has been exhausted, ususally indicates a
-                       // bad user program.
-  AllocFailed = 5,  // The executor has failed to allocate memory, usually indicates the system is
-                    // out of memory. This cannot be recovered from.
-  DivByZero    = 6, // The executor has encountered a 'divide by zero' during execution.
-  AssertFailed = 7, // An assert in the user programs has failed, note this is not an error-case for
-                    // the vm itself.
+
+  /* Normal exit codes for the vm.
+   */
+  Success      = 0, // The executor has finished successfully, is the 'normal' result of the vm.
+  Failed       = 1, // The executor has encountered a 'fail' instruction.
+  AssertFailed = 2, // An assert in the user programs has failed.
+
+  /* Error exit codes for the vm.
+   */
+  VmInitFailed    = 10, // Failed to initialize the vm, host is likely out of resources.
+  InvalidAssembly = 11, // The executor has encountered an invalid instruction in the assembly.
+  StackOverflow   = 12, // The stack memory of the executor has been exhausted.
+  AllocFailed     = 13, // Failed to allocate memory, host is likely out of resources.
+  DivByZero       = 14, // The executor has encountered a 'divide by zero' during execution.
+  ForkFailed      = 15, // Failed to start a new executor, host is likely out of resources.
 };
 
 auto operator<<(std::ostream& out, const ExecState& rhs) noexcept -> std::ostream&;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,6 +284,7 @@ add_library(vm STATIC
   vm/internal/platform_utilities.cpp
   vm/internal/ref_allocator.cpp
   vm/internal/ref.cpp
+  vm/internal/thread.cpp
   vm/platform_interface.cpp
   vm/vm.cpp
   vm/exec_state.cpp)

--- a/src/vm/exec_state.cpp
+++ b/src/vm/exec_state.cpp
@@ -4,20 +4,28 @@ namespace vm {
 
 auto operator<<(std::ostream& out, const ExecState& rhs) noexcept -> std::ostream& {
   switch (rhs) {
+  case ExecState::Aborted:
+    out << "aborted";
+    break;
   case ExecState::Paused:
     out << "paused";
     break;
   case ExecState::Running:
     out << "running";
     break;
+
   case ExecState::Success:
     out << "success";
     break;
   case ExecState::Failed:
     out << "failed";
     break;
-  case ExecState::Aborted:
-    out << "aborted";
+  case ExecState::AssertFailed:
+    out << "assert-failed";
+    break;
+
+  case ExecState::VmInitFailed:
+    out << "vm-init-failed";
     break;
   case ExecState::InvalidAssembly:
     out << "invalid-assembly";
@@ -31,8 +39,8 @@ auto operator<<(std::ostream& out, const ExecState& rhs) noexcept -> std::ostrea
   case ExecState::DivByZero:
     out << "div-by-zero";
     break;
-  case ExecState::AssertFailed:
-    out << "assert-failed";
+  case ExecState::ForkFailed:
+    out << "fork-failed";
     break;
   }
   return out;

--- a/src/vm/internal/executor.hpp
+++ b/src/vm/internal/executor.hpp
@@ -15,7 +15,7 @@ class FutureRef;
 // 'entryArgCount', 'entryArgSource', 'promise' are used for sub-executers (forked calls) that take
 // arguments from a parent executor and place their result in the 'promise' object.
 auto execute(
-    const Settings& settings,
+    const Settings* settings,
     const novasm::Assembly* assembly,
     PlatformInterface* iface,
     ExecutorRegistry* execRegistry,

--- a/src/vm/internal/executor_handle.hpp
+++ b/src/vm/internal/executor_handle.hpp
@@ -1,10 +1,9 @@
 #pragma once
 #include "internal/intrinsics.hpp"
 #include "internal/stack.hpp"
+#include "internal/thread.hpp"
 #include "vm/exec_state.hpp"
 #include <atomic>
-#include <immintrin.h>
-#include <thread>
 
 namespace vm::internal {
 
@@ -70,9 +69,9 @@ public:
       // Current strategy is we do a single longer pause (thread yield) and after returning from
       // that we do short cpu pauses until we are resumed. This works well if the pause request is
       // very short, but if its longer it starts to be wastefull.
-      std::this_thread::yield();
+      threadYield();
       while (req = m_request.load(std::memory_order_acquire), req == RequestType::Pause) {
-        _mm_pause();
+        threadPause();
       }
       if (unlikely(req == RequestType::Abort)) {
         goto Abort;

--- a/src/vm/internal/executor_registry.cpp
+++ b/src/vm/internal/executor_registry.cpp
@@ -1,5 +1,5 @@
 #include "internal/executor_registry.hpp"
-#include <thread>
+#include "internal/thread.hpp"
 
 namespace vm::internal {
 
@@ -29,7 +29,7 @@ auto ExecutorRegistry::unregisterExecutor(ExecutorHandle* handle) noexcept -> vo
 
   // Double check that its still running after aquiring the lock.
   assert(m_state.load(std::memory_order_acquire) == RegistryState::Running);
-  
+
   assert(m_head);
   assert(handle == m_head || handle->m_prev);
 
@@ -86,7 +86,7 @@ auto ExecutorRegistry::pauseExecutors() noexcept -> void {
         break;
       }
     }
-    std::this_thread::yield();
+    threadYield();
   }
 
   m_state.store(RegistryState::Paused, std::memory_order_release);

--- a/src/vm/internal/os_include.hpp
+++ b/src/vm/internal/os_include.hpp
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <csignal>
 #include <climits>
+#include <pthread.h>
 
 #endif // !_WIN32
 

--- a/src/vm/internal/pcall.hpp
+++ b/src/vm/internal/pcall.hpp
@@ -21,14 +21,13 @@
 #include "vm/platform_interface.hpp"
 #include <chrono>
 #include <cstdlib>
-#include <thread>
 
 namespace vm::internal {
 
 // Execute a 'platform' call. Very similar to normal instructions but are interacting with the
 // 'outside' world (for example file io).
 auto inline pcall(
-    const Settings& settings,
+    const Settings* settings,
     const novasm::Assembly* assembly,
     PlatformInterface* iface,
     RefAllocator* refAlloc,
@@ -321,9 +320,9 @@ auto inline pcall(
   } break;
 
   case PCallCode::SleepNano: {
-    auto sleepTime = std::chrono::nanoseconds(getLong(PEEK()));
+    auto sleepTime = getLong(PEEK());
     execHandle->setState(ExecState::Paused);
-    std::this_thread::sleep_for(sleepTime);
+    threadSleepNano(sleepTime);
     execHandle->setState(ExecState::Running);
     if (execHandle->trap()) {
       return;

--- a/src/vm/internal/ref_stream_tcp.hpp
+++ b/src/vm/internal/ref_stream_tcp.hpp
@@ -312,14 +312,14 @@ inline auto configureSocket(SOCKET sock) noexcept -> void {
 }
 
 inline auto tcpOpenConnection(
-    const Settings& settings,
+    const Settings* settings,
     ExecutorHandle* execHandle,
     RefAllocator* alloc,
     StringRef* address,
     IpAddressFamily family,
     int32_t port) noexcept -> TcpStreamRef* {
 
-  if (!settings.socketsEnabled) {
+  if (!settings->socketsEnabled) {
     // Sockets are not enabled on this runtime.
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Connection, INVALID_SOCKET);
   }
@@ -383,13 +383,13 @@ inline auto tcpOpenConnection(
 }
 
 inline auto tcpStartServer(
-    const Settings& settings,
+    const Settings* settings,
     RefAllocator* alloc,
     IpAddressFamily family,
     int32_t port,
     int32_t backlog) noexcept -> TcpStreamRef* {
 
-  if (!settings.socketsEnabled) {
+  if (!settings->socketsEnabled) {
     // Sockets are not enabled on this runtime.
     return alloc->allocPlain<TcpStreamRef>(TcpStreamType::Server, INVALID_SOCKET);
   }
@@ -477,13 +477,13 @@ inline auto tcpShutdown(Value stream) noexcept -> bool {
 }
 
 inline auto ipLookupAddress(
-    const Settings& settings,
+    const Settings* settings,
     ExecutorHandle* execHandle,
     RefAllocator* alloc,
     StringRef* hostName,
     IpAddressFamily family) noexcept -> StringRef* {
 
-  if (!settings.socketsEnabled) {
+  if (!settings->socketsEnabled) {
     // Sockets are not enabled on this runtime.
     return alloc->allocStr(0);
   }

--- a/src/vm/internal/thread.cpp
+++ b/src/vm/internal/thread.cpp
@@ -1,0 +1,73 @@
+#include "internal/thread.hpp"
+#include "internal/os_include.hpp"
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+namespace vm::internal {
+
+auto threadStart(ThreadRoutineRaw routine, void* arg) noexcept -> ThreadStartResult {
+  auto res = ThreadStartResult::Success;
+
+#if defined(_WIN32)
+
+  const auto threadHandle = CreateThread(nullptr, 0, routine, arg, 0, nullptr);
+  if (!threadHandle) {
+    return ThreadStartResult::Failure;
+  }
+  // Close the handle immediately as we want to create a detacted thread.
+  if (!CloseHandle(threadHandle)) {
+    return ThreadStartResult::Failure;
+  }
+
+#else // !_WIN32
+
+  pthread_attr_t attr;
+  pthread_t threadId;
+
+  if (pthread_attr_init(&attr) != 0) {
+    return ThreadStartResult::Failure;
+  }
+  if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) != 0) {
+    return ThreadStartResult::Failure;
+  }
+  if (pthread_create(&threadId, &attr, routine, arg) != 0) {
+    res = ThreadStartResult::Failure;
+  }
+  if (pthread_attr_destroy(&attr) != 0) {
+    return ThreadStartResult::Failure;
+  }
+
+#endif
+  return res;
+}
+
+auto threadYield() noexcept -> void {
+#if defined(_WIN32)
+  SwitchToThread();
+#elif defined(__APPLE__) // !_WIN32
+  sched_yield();
+#else // !_WIN32 && !__APPLE__
+  pthread_yield();
+#endif
+}
+
+auto threadSleepNano(int64_t time) noexcept -> void {
+#if defined(_WIN32)
+
+  // TODO: This only has milliseconds resolution, investigate win32 alternatives with better
+  // resolution.
+  unsigned long timeMilli = static_cast<unsigned long>(time) / 1'000'000;
+  Sleep(timeMilli > 0 ? timeMilli : 1);
+
+#else // !_WIN32
+
+  timespec ts = {time / 1'000'000'000, time % 1'000'000'000};
+  while (nanosleep(&ts, &ts) == -1 && errno == EINTR) // Resume waiting after interupt.
+    ;
+
+#endif
+}
+
+} // namespace vm::internal

--- a/src/vm/internal/thread.hpp
+++ b/src/vm/internal/thread.hpp
@@ -1,0 +1,82 @@
+#pragma once
+#include <cstdint>
+#include <immintrin.h>
+#include <tuple>
+#include <utility>
+
+namespace vm::internal {
+
+namespace details {
+
+// At the moment these return values are not important as they are never retrievable.
+#if defined(_WIN32)
+using RawRoutineRetType = unsigned long; // On windows thread routines return a 'DWORD'.
+#else // !_WIN32
+using RawRoutineRetType = void*; // On unix thread routines return a opaque pointer.
+#endif
+
+template <typename RetT, typename... TArgs>
+using Routine = RetT (*)(TArgs...) noexcept;
+
+template <typename RetT, typename... TArgs>
+using Invokable = std::tuple<Routine<RetT, TArgs...>, TArgs...>;
+
+template <typename RetT, typename... TArgs, std::size_t... TupleIndices>
+auto invoke(Invokable<RetT, TArgs...> invokable, std::index_sequence<TupleIndices...>) -> RetT {
+  Routine<RetT, TArgs...> routine = std::get<0>(invokable);
+  return routine(std::get<TupleIndices + 1>(invokable)...);
+}
+
+template <typename RetT, typename... TArgs>
+auto invoke(Invokable<RetT, TArgs...> invokable) -> RetT {
+  return invoke(invokable, std::index_sequence_for<TArgs...>{});
+}
+
+} // namespace details
+
+template <typename RetT, typename... TArgs>
+using ThreadRoutine = details::Routine<RetT, TArgs...>;
+
+using ThreadRoutineRaw = details::Routine<details::RawRoutineRetType, void*>;
+
+enum class ThreadStartResult {
+  Success = 0,
+  Failure = 1,
+};
+
+// Start a new thread that calls routine with the given args.
+// NOTE: the return type of the routine is not used at this time.
+template <typename RetT, typename... TArgs>
+[[nodiscard]] auto threadStart(ThreadRoutine<RetT, TArgs...> routine, TArgs... args) noexcept
+    -> ThreadStartResult {
+
+  using Invokeable = details::Invokable<RetT, TArgs...>;
+
+  // Create an invokeable on the heap (containing the routine and the args).
+  auto* dataPtr = new Invokeable(routine, std::forward<TArgs>(args)...);
+
+  // Define a type-erased function that takes an invokable, invokes it and then destroys it.
+  constexpr ThreadRoutineRaw routineWrapper = [](void* rawArg) noexcept {
+    auto* invokeablePtr = static_cast<Invokeable*>(rawArg);
+    details::invoke(*invokeablePtr);
+    delete invokeablePtr; // Cleanup the heap allocated invokable.
+    return details::RawRoutineRetType{};
+  };
+
+  return threadStart(routineWrapper, dataPtr);
+}
+
+// Start a new thread that calls routine with the given arg.
+// NOTE: the return type of the routine is not used at this time.
+[[nodiscard]] auto threadStart(ThreadRoutineRaw routine, void* arg) noexcept -> ThreadStartResult;
+
+// Place this thread at the bottom of the run queue.
+auto threadYield() noexcept -> void;
+
+// Sleep the current thread for the given amount of nanaseconds.
+auto threadSleepNano(int64_t time) noexcept -> void;
+
+// Emit a cpu pause instruction.
+inline auto threadPause() noexcept -> void { _mm_pause(); }
+
+} // namespace vm::internal

--- a/tests/vm/io_process_test.cpp
+++ b/tests/vm/io_process_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->addRet();
         },
         "input",
-        "017");
+        "012");
   }
 
   SECTION("StdOut can be read from a child-process") {


### PR DESCRIPTION
Given a program like this:
![vm-prog](https://user-images.githubusercontent.com/14230060/107098298-8cc21c00-6817-11eb-89a1-135dbfcb62be.jpeg)

We now fail like this:
![vm-new](https://user-images.githubusercontent.com/14230060/107098307-8fbd0c80-6817-11eb-8812-f29cb5490e88.jpeg)

Instead of this:
![vm-old](https://user-images.githubusercontent.com/14230060/107098302-8e8bdf80-6817-11eb-96ca-96381c1dc128.jpeg)

Also gracefully handles the case where we fail to start the garbage-collector thread.