### PR TITLE
vm: cleanup of the stream api

### DIFF
--- a/include/novasm/pcall_code.hpp
+++ b/include/novasm/pcall_code.hpp
@@ -15,10 +15,9 @@ enum class PCallCode : uint8_t {
 
   StreamCheckValid   = 10, // (stream)         -> (int)     Check if given stream is valid.
   StreamReadString   = 11, // (int, stream)    -> (string)  Read up to x bytes from a stream.
-  StreamReadChar     = 12, // (stream)         -> (int)     Read a single character from a stream.
-  StreamWriteString  = 13, // (string, stream) -> (int)     Write string, returns success.
-  StreamSetOptions   = 14, // (int, stream)    -> (int)     Set options, returns success.
-  StreamUnsetOptions = 15, // (int, stream)    -> (int)     Unset options, returns success.
+  StreamWriteString  = 12, // (string, stream) -> (int)     Write string, returns success.
+  StreamSetOptions   = 13, // (int, stream)    -> (int)     Set options, returns success.
+  StreamUnsetOptions = 14, // (int, stream)    -> (int)     Unset options, returns success.
 
   ProcessStart = 20, // (string)  -> (process) Start a new sys process from the given cmdline str.
   ProcessBlock = 21, // (process) -> (int)     Block until the process has exited, returns exitcode.
@@ -66,7 +65,6 @@ enum class PCallCode : uint8_t {
 /* Platform errors
  * The following calls will set the error code that is returned from 'PlatformErrorCode':
  * - StreamReadString, error is set when an empty string is returned.
- * - StreamReadChar, error is set when a null character is returned.
  * - StreamWriteString, error is set when false is returned.
  * - StreamSetOptions, error is set when false is returned.
  * - StreamUnsetOptions, error is set when false is returned.

--- a/include/novasm/pcall_code.hpp
+++ b/include/novasm/pcall_code.hpp
@@ -17,10 +17,8 @@ enum class PCallCode : uint8_t {
   StreamReadString   = 11, // (int, stream)    -> (string)  Read up to x bytes from a stream.
   StreamReadChar     = 12, // (stream)         -> (int)     Read a single character from a stream.
   StreamWriteString  = 13, // (string, stream) -> (int)     Write string, returns success.
-  StreamWriteChar    = 14, // (int, stream)    -> (int)     Write character, returns success.
-  StreamFlush        = 15, // (stream)         -> (int)     Flush any unwritten data, ret success.
-  StreamSetOptions   = 16, // (int, stream)    -> (int)     Set options, returns success.
-  StreamUnsetOptions = 17, // (int, stream)    -> (int)     Unset options, returns success.
+  StreamSetOptions   = 14, // (int, stream)    -> (int)     Set options, returns success.
+  StreamUnsetOptions = 15, // (int, stream)    -> (int)     Unset options, returns success.
 
   ProcessStart = 20, // (string)  -> (process) Start a new sys process from the given cmdline str.
   ProcessBlock = 21, // (process) -> (int)     Block until the process has exited, returns exitcode.
@@ -70,8 +68,6 @@ enum class PCallCode : uint8_t {
  * - StreamReadString, error is set when an empty string is returned.
  * - StreamReadChar, error is set when a null character is returned.
  * - StreamWriteString, error is set when false is returned.
- * - StreamWriteChar, error is set when false is returned.
- * - StreamFlush, error is set when false is returned.
  * - StreamSetOptions, error is set when false is returned.
  * - StreamUnsetOptions, error is set when false is returned.
  * - ProcessStart, error is set when an process with id -1 is returned.

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -7,7 +7,7 @@ namespace novasm {
 // Version number for the binary representation of the novus assembly format.
 // Increase this when performing breaking changes to the format.
 // TODO(bastian): Add system for defining migrations.
-const uint16_t assemblyFormatVersion = 4U;
+const uint16_t assemblyFormatVersion = 5U;
 
 // Write a binary representation of the assembly file to the output iterator.
 template <typename OutputItr>

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -132,8 +132,6 @@ enum class FuncKind {
   ActionStreamReadString,   // Read a string up to size x from a stream.
   ActionStreamReadChar,     // Read a single character from a stream.
   ActionStreamWriteString,  // Write a string to a stream.
-  ActionStreamWriteChar,    // Write a single character to a stream.
-  ActionStreamFlush,        // Flush a stream to the underlying device.
   ActionStreamSetOptions,   // Set options for a stream.
   ActionStreamUnsetOptions, // Unset options for a stream.
 

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -130,7 +130,6 @@ enum class FuncKind {
 
   ActionStreamCheckValid,   // Check if a stream is valid.
   ActionStreamReadString,   // Read a string up to size x from a stream.
-  ActionStreamReadChar,     // Read a single character from a stream.
   ActionStreamWriteString,  // Write a string to a stream.
   ActionStreamSetOptions,   // Set options for a stream.
   ActionStreamUnsetOptions, // Unset options for a stream.

--- a/novstd/console.nov
+++ b/novstd/console.nov
@@ -55,9 +55,6 @@ act readLine() -> Either{string, Error}
 act writeOut(Console c, string str) -> Option{Error}
   c.stdOut.write(str)
 
-act writeOut(Console c, char ch) -> Option{Error}
-  c.stdOut.write(ch)
-
 act writeOut{T}(Console c, Writer{T} writer, T val) -> Option{Error}
   c.writeOut(writer.run(val))
 
@@ -66,9 +63,6 @@ act writeOut(Console c, Writer{None} writer) -> Option{Error}
 
 act writeErr(Console c, string str) -> Option{Error}
   c.stdErr.write(str)
-
-act writeErr(Console c, char ch) -> Option{Error}
-  c.stdErr.write(ch)
 
 act writeErr{T}(Console c, Writer{T} writer, T val) -> Option{Error}
   c.writeErr(writer.run(val))

--- a/novstd/console.nov
+++ b/novstd/console.nov
@@ -32,8 +32,8 @@ act consoleOpen() -> Either{Console, Error}
 
 // -- Read
 
-act read(Console c) -> Either{char, Error}
-  c.stdIn.read()
+act read(Console c, int maxChars) -> Either{string, Error}
+  c.stdIn.read(maxChars)
 
 act readLine(Console c) -> Either{string, Error}
   c.stdIn.readLine()
@@ -44,8 +44,8 @@ act readToEnd(Console c) -> Either{string, Error}
 act readToEnd{T}(Console c, Parser{T} parser) -> Either{T, Error}
   c.readToEnd().map(impure lambda (string s) parser.run(s))
 
-act read() -> Either{char, Error}
-  consoleOpen().map(impure lambda (Console c) c.read())
+act read(int maxChars) -> Either{string, Error}
+  consoleOpen().map(impure lambda (Console c) c.read(maxChars))
 
 act readLine() -> Either{string, Error}
   consoleOpen().map(impure lambda (Console c) c.readLine())

--- a/novstd/stream.nov
+++ b/novstd/stream.nov
@@ -46,12 +46,6 @@ act read(sys_stream s, int maxChars) -> Either{string, Error}
     ? getPlatformError("Failed to read from stream")
     : res
 
-act read(sys_stream s) -> Either{char, Error}
-  res = intrinsic{stream_read_char}(s);
-  res == '\0' && getPlatformErrorCode() != PlatformError.StreamNoDataAvailable
-    ? getPlatformError("Failed to read from stream")
-    : res
-
 act readToEnd(sys_stream s) -> Either{string, Error}
   invoke(
     impure lambda (string result)
@@ -64,12 +58,12 @@ act readToEnd(sys_stream s) -> Either{string, Error}
 act readLine(sys_stream s) -> Either{string, Error}
   invoke(
     impure lambda (string result)
-      readRes = s.read();
-      if readRes as Error e -> e
-      if readRes as char  c ->
-        if c == '\r'              -> self(result)
-        if c == '\n' || c == '\0' -> result
-        else                      -> self(result + c)
+      readRes = s.read(1);
+      if readRes as Error   e -> e
+      if readRes as string  s ->
+        if s == "\r"              -> self(result)
+        if s == "\n" || s == "\0" -> result
+        else                      -> self(result + s)
   , "")
 
 act readLine(StreamReadState state) -> Either{Pair{string, StreamReadState}, Error}

--- a/novstd/stream.nov
+++ b/novstd/stream.nov
@@ -103,11 +103,6 @@ act write(sys_stream s, string str) -> Option{Error}
     ? None()
     : getPlatformError("Failed to write to stream")
 
-act write(sys_stream s, char c) -> Option{Error}
-  intrinsic{stream_write_char}(s, c)
-    ? None()
-    : getPlatformError("Failed to write to stream")
-
 act copy(sys_stream from, sys_stream to) -> Either{int, Error}
   invoke(
     impure lambda(int bytesCopied) -> Either{int, Error}

--- a/novstd/tcp.nov
+++ b/novstd/tcp.nov
@@ -39,9 +39,6 @@ fun TcpServerSettings(
 act write(TcpConnection c, string str) -> Option{Error}
   c.socket.write(str)
 
-act write(TcpConnection c, char ch) -> Option{Error}
-  c.socket.write(ch)
-
 act write{T}(TcpConnection c, Writer{T} writer, T val) -> Option{Error}
   c.write(writer.run(val))
 

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -514,9 +514,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::ActionStreamReadString:
     m_asmb->addPCall(novasm::PCallCode::StreamReadString);
     break;
-  case prog::sym::FuncKind::ActionStreamReadChar:
-    m_asmb->addPCall(novasm::PCallCode::StreamReadChar);
-    break;
   case prog::sym::FuncKind::ActionStreamWriteString:
     m_asmb->addPCall(novasm::PCallCode::StreamWriteString);
     break;

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -520,12 +520,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::ActionStreamWriteString:
     m_asmb->addPCall(novasm::PCallCode::StreamWriteString);
     break;
-  case prog::sym::FuncKind::ActionStreamWriteChar:
-    m_asmb->addPCall(novasm::PCallCode::StreamWriteChar);
-    break;
-  case prog::sym::FuncKind::ActionStreamFlush:
-    m_asmb->addPCall(novasm::PCallCode::StreamFlush);
-    break;
   case prog::sym::FuncKind::ActionStreamSetOptions:
     m_asmb->addPCall(novasm::PCallCode::StreamSetOptions);
     break;

--- a/src/novasm/pcall_code.cpp
+++ b/src/novasm/pcall_code.cpp
@@ -17,9 +17,6 @@ auto operator<<(std::ostream& out, const PCallCode& rhs) noexcept -> std::ostrea
   case PCallCode::StreamReadString:
     out << "stream-read-string";
     break;
-  case PCallCode::StreamReadChar:
-    out << "stream-read-char";
-    break;
   case PCallCode::StreamWriteString:
     out << "stream-write-string";
     break;

--- a/src/novasm/pcall_code.cpp
+++ b/src/novasm/pcall_code.cpp
@@ -23,12 +23,6 @@ auto operator<<(std::ostream& out, const PCallCode& rhs) noexcept -> std::ostrea
   case PCallCode::StreamWriteString:
     out << "stream-write-string";
     break;
-  case PCallCode::StreamWriteChar:
-    out << "stream-write-char";
-    break;
-  case PCallCode::StreamFlush:
-    out << "stream-flush";
-    break;
   case PCallCode::StreamSetOptions:
     out << "stream-set-options";
     break;

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -275,8 +275,6 @@ Program::Program() :
       sym::TypeSet{m_stream, m_int},
       m_string);
   m_funcDecls.registerIntrinsicAction(
-      *this, Fk::ActionStreamReadChar, "stream_read_char", sym::TypeSet{m_stream}, m_char);
-  m_funcDecls.registerIntrinsicAction(
       *this,
       Fk::ActionStreamWriteString,
       "stream_write_string",

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -284,14 +284,6 @@ Program::Program() :
       m_bool);
   m_funcDecls.registerIntrinsicAction(
       *this,
-      Fk::ActionStreamWriteChar,
-      "stream_write_char",
-      sym::TypeSet{m_stream, m_char},
-      m_bool);
-  m_funcDecls.registerIntrinsicAction(
-      *this, Fk::ActionStreamFlush, "stream_flush", sym::TypeSet{m_stream}, m_bool);
-  m_funcDecls.registerIntrinsicAction(
-      *this,
       Fk::ActionStreamSetOptions,
       "stream_setoptions",
       sym::TypeSet{m_stream, m_int},

--- a/src/vm/internal/pcall.hpp
+++ b/src/vm/internal/pcall.hpp
@@ -123,19 +123,6 @@ auto inline pcall(
     POP(); // Pop the stream off the stack.
     PUSH_BOOL(result);
   } break;
-  case PCallCode::StreamWriteChar: {
-    uint8_t val = static_cast<uint8_t>(POP_INT());
-
-    // Note: Keep the stream on the stack, reason is gc could run while we are blocked.
-    auto stream = PEEK();
-    auto result = streamWriteChar(execHandle, pErr, stream, val);
-
-    POP(); // Pop the stream off the stack.
-    PUSH_BOOL(result);
-  } break;
-  case PCallCode::StreamFlush: {
-    PUSH_BOOL(streamFlush(pErr, POP()));
-  } break;
   case PCallCode::StreamSetOptions: {
     auto options = POP_INT();
     auto stream  = POP();

--- a/src/vm/internal/pcall.hpp
+++ b/src/vm/internal/pcall.hpp
@@ -101,15 +101,6 @@ auto inline pcall(
 
     POP_AT(1); // Pop the stream off the stack, 1 because its behind the result string.
   } break;
-  case PCallCode::StreamReadChar: {
-    // Note: Keep the stream on the stack, reason is gc could run while we are blocked.
-    auto stream = PEEK();
-
-    auto readChar = streamReadChar(execHandle, pErr, stream);
-
-    POP(); // Pop the stream off the stack.
-    PUSH_INT(readChar);
-  } break;
   case PCallCode::StreamWriteString: {
     // Note: Keep the string on the stack, reason is gc could run while we are blocked.
     auto* strRef = getStringRef(refAlloc, PEEK());

--- a/src/vm/internal/ref_stream_console.hpp
+++ b/src/vm/internal/ref_stream_console.hpp
@@ -161,35 +161,6 @@ public:
     return true;
   }
 
-  auto writeChar(ExecutorHandle* execHandle, PlatformError* pErr, uint8_t val) noexcept -> bool {
-    if (unlikely(m_kind == ConsoleStreamKind::StdIn)) {
-      *pErr = PlatformError::StreamWriteNotSupported;
-      return false;
-    }
-
-    execHandle->setState(ExecState::Paused);
-
-    auto* valChar          = static_cast<char*>(static_cast<void*>(&val));
-    const int bytesWritten = fileWrite(m_consoleHandle, valChar, 1);
-
-    execHandle->setState(ExecState::Running);
-    if (execHandle->trap()) {
-      return false; // Aborted.
-    }
-
-    if (bytesWritten != 1) {
-      *pErr = getConsolePlatformError();
-      return false;
-    }
-    return true;
-  }
-
-  auto flush(PlatformError* /*unused*/) noexcept -> bool {
-    // At the moment this is a no-op, in the future we can consider adding additional buffering to
-    // console streams (so flush would write to the handle).
-    return true;
-  }
-
   auto setOpts(PlatformError* pErr, StreamOpts opts) noexcept -> bool {
 #if defined(_WIN32)
     if (static_cast<int32_t>(opts) & static_cast<int32_t>(StreamOpts::NoBlock)) {

--- a/src/vm/internal/ref_stream_file.hpp
+++ b/src/vm/internal/ref_stream_file.hpp
@@ -82,29 +82,6 @@ public:
     return bytesRead > 0;
   }
 
-  auto readChar(ExecutorHandle* execHandle, PlatformError* pErr) noexcept -> char {
-
-    execHandle->setState(ExecState::Paused);
-
-    char res;
-    const int bytesRead = fileRead(m_fileHandle, &res, 1);
-
-    execHandle->setState(ExecState::Running);
-    if (execHandle->trap()) {
-      return '\0'; // Aborted.
-    }
-
-    if (bytesRead != 1) {
-      *pErr = getFilePlatformError();
-      return '\0';
-    }
-    if (bytesRead == 0) {
-      *pErr = PlatformError::StreamNoDataAvailable;
-      return '\0';
-    }
-    return res;
-  }
-
   auto writeString(ExecutorHandle* execHandle, PlatformError* pErr, StringRef* str) noexcept
       -> bool {
 

--- a/src/vm/internal/ref_stream_file.hpp
+++ b/src/vm/internal/ref_stream_file.hpp
@@ -39,7 +39,7 @@ public:
     if ((m_flags & AutoRemoveFile) == AutoRemoveFile) {
 #if defined(_WIN32)
       ::DeleteFileA(m_filePath);
-#else //!_WIN32
+#else  //!_WIN32
       ::unlink(m_filePath);
 #endif //!_WIN32
     }
@@ -125,32 +125,6 @@ public:
       *pErr = getFilePlatformError();
       return false;
     }
-    return true;
-  }
-
-  auto writeChar(ExecutorHandle* execHandle, PlatformError* pErr, uint8_t val) noexcept -> bool {
-
-    execHandle->setState(ExecState::Paused);
-
-    auto* valChar          = static_cast<char*>(static_cast<void*>(&val));
-    const int bytesWritten = fileWrite(m_fileHandle, valChar, 1);
-
-    execHandle->setState(ExecState::Running);
-    if (execHandle->trap()) {
-      return false;
-    }
-
-    if (bytesWritten != 1) {
-      *pErr = getFilePlatformError();
-      return false;
-    }
-    return true;
-  }
-
-  auto flush(PlatformError* /*unused*/) noexcept -> bool {
-    // At the moment this is a no-op, in the future we can consider adding additional buffering to
-    // file streams (so flush would write to the file handle). Or alternatively flush could ask the
-    // os to actually write the data to disk, on linux with 'syncfs' or example.
     return true;
   }
 

--- a/src/vm/internal/ref_stream_process.hpp
+++ b/src/vm/internal/ref_stream_process.hpp
@@ -67,34 +67,6 @@ public:
     return bytesRead > 0;
   }
 
-  auto readChar(ExecutorHandle* execHandle, PlatformError* pErr) noexcept -> char {
-    if (unlikely(m_streamKind == ProcessStreamKind::StdIn)) {
-      *pErr = PlatformError::StreamReadNotSupported;
-      return false;
-    }
-
-    // Can block so we mark ourselves as paused so the gc can trigger in the mean time.
-    execHandle->setState(ExecState::Paused);
-
-    char res;
-    const int bytesRead = fileRead(getFile(), &res, 1);
-
-    execHandle->setState(ExecState::Running);
-    if (execHandle->trap()) {
-      return '\0'; // Aborted.
-    }
-
-    if (bytesRead != 1) {
-      *pErr = getProcessStreamPlatformError();
-      return '\0';
-    }
-    if (bytesRead == 0) {
-      *pErr = PlatformError::StreamNoDataAvailable;
-      return '\0';
-    }
-    return res;
-  }
-
   auto writeString(ExecutorHandle* execHandle, PlatformError* pErr, StringRef* str) noexcept
       -> bool {
     if (unlikely(m_streamKind != ProcessStreamKind::StdIn)) {

--- a/src/vm/internal/ref_stream_process.hpp
+++ b/src/vm/internal/ref_stream_process.hpp
@@ -118,36 +118,6 @@ public:
     return true;
   }
 
-  auto writeChar(ExecutorHandle* execHandle, PlatformError* pErr, uint8_t val) noexcept -> bool {
-    if (unlikely(m_streamKind != ProcessStreamKind::StdIn)) {
-      *pErr = PlatformError::StreamWriteNotSupported;
-      return false;
-    }
-
-    // Can block so we mark ourselves as paused so the gc can trigger in the mean time.
-    execHandle->setState(ExecState::Paused);
-
-    auto* valChar          = static_cast<char*>(static_cast<void*>(&val));
-    const int bytesWritten = fileWrite(getFile(), valChar, 1);
-
-    execHandle->setState(ExecState::Running);
-    if (execHandle->trap()) {
-      return false; // Aborted.
-    }
-
-    if (bytesWritten != 1) {
-      *pErr = getProcessStreamPlatformError();
-      return false;
-    }
-    return true;
-  }
-
-  auto flush(PlatformError* /*unused*/) noexcept -> bool {
-    // At the moment this is a no-op, in the future we can consider adding additional buffering to
-    // console streams (so flush would write to the handle).
-    return true;
-  }
-
   auto setOpts(PlatformError* pErr, StreamOpts /*unused*/) noexcept -> bool {
     // On unix we could implement non-blocking by setting the file-descriptor to be non-blocking,
     // but this is not something we can implement on windows.

--- a/src/vm/internal/ref_stream_tcp.hpp
+++ b/src/vm/internal/ref_stream_tcp.hpp
@@ -287,57 +287,6 @@ public:
     return true;
   }
 
-  auto writeChar(ExecutorHandle* execHandle, PlatformError* pErr, uint8_t val) noexcept -> bool {
-    if (unlikely(m_type != TcpStreamType::Connection)) {
-      *pErr = PlatformError::StreamWriteNotSupported;
-      return false;
-    }
-
-    execHandle->setState(ExecState::Paused);
-
-    auto* valChar    = static_cast<char*>(static_cast<void*>(&val));
-    int bytesWritten = -1;
-    while (m_state.load(std::memory_order_acquire) == TcpStreamState::Valid) {
-      bytesWritten = ::send(m_socket, valChar, 1, 0);
-      if (bytesWritten >= 0) {
-        break; // No error while writing.
-      }
-
-      // Retry the send for certain errors.
-#if defined(_WIN32)
-      const bool shouldRetry = WSAGetLastError() == WSAEINTR;
-#else  // !_WIN32
-      const bool shouldRetry = errno == EINTR;
-#endif // !_WIN32
-      if (!shouldRetry) {
-        break;
-      }
-      threadYield(); // Yield between retries.
-    }
-
-    execHandle->setState(ExecState::Running);
-    if (execHandle->trap()) {
-      return false;
-    }
-
-    if (bytesWritten < 0) {
-      *pErr = getTcpPlatformError();
-      m_state.store(TcpStreamState::Failed, std::memory_order_release);
-      return false;
-    }
-    if (bytesWritten == 0) {
-      *pErr = PlatformError::TcpUnknownError;
-      return false;
-    }
-    return true;
-  }
-
-  auto flush(PlatformError* /*unused*/) noexcept -> bool {
-    // Is a no-op at the moment, in the future we can considering asking the os to actually send the
-    // data. Perhaps by temporary disabling the nagle algorithm (TCP_NODELAY)?
-    return true;
-  }
-
   auto setOpts(PlatformError* pErr, StreamOpts /*unused*/) noexcept -> bool {
     // TODO(bastian): Support non-blocking sockets.
     *pErr = PlatformError::StreamOptionsNotSupported;

--- a/src/vm/internal/stream_utilities.hpp
+++ b/src/vm/internal/stream_utilities.hpp
@@ -46,15 +46,6 @@ inline auto streamReadString(
   STREAM_DISPATCH(stream, readString(execHandle, pErr, tgt))
 }
 
-inline auto
-streamReadChar(ExecutorHandle* execHandle, PlatformError* pErr, const Value& stream) noexcept
-    -> char {
-  if (!streamCheckValid(stream)) {
-    return '\0';
-  }
-  STREAM_DISPATCH(stream, readChar(execHandle, pErr))
-}
-
 inline auto streamWriteString(
     ExecutorHandle* execHandle, PlatformError* pErr, const Value& stream, StringRef* str) noexcept
     -> bool {

--- a/src/vm/internal/stream_utilities.hpp
+++ b/src/vm/internal/stream_utilities.hpp
@@ -65,23 +65,6 @@ inline auto streamWriteString(
   STREAM_DISPATCH(stream, writeString(execHandle, pErr, str))
 }
 
-inline auto streamWriteChar(
-    ExecutorHandle* execHandle, PlatformError* pErr, const Value& stream, uint8_t val) noexcept
-    -> bool {
-
-  if (!streamCheckValid(stream)) {
-    return false;
-  }
-  STREAM_DISPATCH(stream, writeChar(execHandle, pErr, val))
-}
-
-inline auto streamFlush(PlatformError* pErr, const Value& stream) noexcept -> bool {
-  if (!streamCheckValid(stream)) {
-    return false;
-  }
-  STREAM_DISPATCH(stream, flush(pErr))
-}
-
 inline auto streamSetOpts(PlatformError* pErr, const Value& stream, StreamOpts opts) noexcept
     -> bool {
   if (!streamCheckValid(stream)) {

--- a/tests/vm/helpers.hpp
+++ b/tests/vm/helpers.hpp
@@ -116,10 +116,11 @@ inline auto prepareStdIn(std::string input) -> FileHandle {
 
 #define ADD_PRINT_CHAR(ASMB)                                                                       \
   {                                                                                                \
+    (ASMB)->addConvCharString();                                                                   \
     (ASMB)->addLoadLitInt(1); /* StdOut. */                                                        \
     (ASMB)->addPCall(novasm::PCallCode::ConsoleOpenStream);                                        \
     (ASMB)->addSwap(); /* Swap because the stream needs to be on the stack before the char. */     \
-    (ASMB)->addPCall(novasm::PCallCode::StreamWriteChar);                                          \
+    (ASMB)->addPCall(novasm::PCallCode::StreamWriteString);                                        \
   }
 
 } // namespace vm

--- a/tests/vm/helpers.hpp
+++ b/tests/vm/helpers.hpp
@@ -114,13 +114,4 @@ inline auto prepareStdIn(std::string input) -> FileHandle {
     (ASMB)->addPCall(novasm::PCallCode::StreamWriteString);                                        \
   }
 
-#define ADD_PRINT_CHAR(ASMB)                                                                       \
-  {                                                                                                \
-    (ASMB)->addConvCharString();                                                                   \
-    (ASMB)->addLoadLitInt(1); /* StdOut. */                                                        \
-    (ASMB)->addPCall(novasm::PCallCode::ConsoleOpenStream);                                        \
-    (ASMB)->addSwap(); /* Swap because the stream needs to be on the stack before the char. */     \
-    (ASMB)->addPCall(novasm::PCallCode::StreamWriteString);                                        \
-  }
-
 } // namespace vm

--- a/tests/vm/io_process_test.cpp
+++ b/tests/vm/io_process_test.cpp
@@ -15,13 +15,6 @@ namespace vm {
     (ASMB)->addPCall(novasm::PCallCode::StreamWriteString);                                        \
   }
 
-#define FLUSH_STD_IN(ASMB)                                                                         \
-  {                                                                                                \
-    (ASMB)->addLoadLitInt(0); /* StdIn. */                                                         \
-    (ASMB)->addPCall(novasm::PCallCode::ProcessOpenStream);                                        \
-    (ASMB)->addPCall(novasm::PCallCode::StreamFlush);                                              \
-  }
-
 #define READ_STD_OUT(ASMB)                                                                         \
   {                                                                                                \
     (ASMB)->addLoadLitInt(1); /* StdOut. */                                                        \
@@ -157,8 +150,6 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->addLoadLitString("Hello from your parent\n");
           WRITE_STD_IN(asmb);
           asmb->addPop(); // Ignore the success / failure of the write.
-          FLUSH_STD_IN(asmb);
-          asmb->addPop(); // Ignore the success / failure of the flush.
 
           asmb->addDup(); // Duplicate the process.
           asmb->addPCall(novasm::PCallCode::ProcessBlock);

--- a/tests/vm/io_tcp_test.cpp
+++ b/tests/vm/io_tcp_test.cpp
@@ -66,8 +66,8 @@ TEST_CASE("[vm] Execute tcp platform-calls", "vm") {
           asmb->addLoadLitInt(1);    // Address family: IpV6.
           asmb->addLoadLitInt(5001); // Port.
           asmb->addPCall(novasm::PCallCode::TcpOpenCon);
-          asmb->addLoadLitInt('!');
-          asmb->addPCall(novasm::PCallCode::StreamWriteChar);
+          asmb->addLoadLitString("!");
+          asmb->addPCall(novasm::PCallCode::StreamWriteString);
           asmb->addPop(); // Ignore the write result.
 
           // Accept the connection on the server and read the message.

--- a/tests/vm/io_tcp_test.cpp
+++ b/tests/vm/io_tcp_test.cpp
@@ -73,10 +73,11 @@ TEST_CASE("[vm] Execute tcp platform-calls", "vm") {
           // Accept the connection on the server and read the message.
           asmb->addStackLoad(0);
           asmb->addPCall(novasm::PCallCode::TcpAcceptCon);
-          asmb->addPCall(novasm::PCallCode::StreamReadChar);
+          asmb->addLoadLitInt(1); // Read a single character.
+          asmb->addPCall(novasm::PCallCode::StreamReadString);
 
           // Print the received message.
-          ADD_PRINT_CHAR(asmb);
+          ADD_PRINT(asmb);
           asmb->addRet();
         },
         "input",

--- a/tests/vm/io_test.cpp
+++ b/tests/vm/io_test.cpp
@@ -112,20 +112,12 @@ TEST_CASE("[vm] Execute input and output", "vm") {
           asmb->addPCall(novasm::PCallCode::Assert);
 
           // Write character to file.
-          asmb->addStackLoad(0);    // Load stream.
-          asmb->addLoadLitInt('d'); // Content.
-          asmb->addPCall(novasm::PCallCode::StreamWriteChar);
+          asmb->addStackLoad(0);       // Load stream.
+          asmb->addLoadLitString("d"); // Content.
+          asmb->addPCall(novasm::PCallCode::StreamWriteString);
 
           // Assert that writing succeeded.
           asmb->addLoadLitString("Write failed");
-          asmb->addPCall(novasm::PCallCode::Assert);
-
-          // Flush file.
-          asmb->addStackLoad(0); // Load stream.
-          asmb->addPCall(novasm::PCallCode::StreamFlush);
-
-          // Assert that flushing succeeded.
-          asmb->addLoadLitString("Flush failed");
           asmb->addPCall(novasm::PCallCode::Assert);
 
           // Open the file again for reading.

--- a/tests/vm/io_test.cpp
+++ b/tests/vm/io_test.cpp
@@ -77,13 +77,15 @@ TEST_CASE("[vm] Execute input and output", "vm") {
           asmb->addDup(); // Duplicate the stream on the stack.
 
           // Read and print the first character.
-          asmb->addPCall(novasm::PCallCode::StreamReadChar);
-          ADD_PRINT_CHAR(asmb);
+          asmb->addLoadLitInt(1); // Read a single character.
+          asmb->addPCall(novasm::PCallCode::StreamReadString);
+          ADD_PRINT(asmb);
           asmb->addPop(); // Ignore the result of printing.
 
           // Read and print the second character.
-          asmb->addPCall(novasm::PCallCode::StreamReadChar);
-          ADD_PRINT_CHAR(asmb);
+          asmb->addLoadLitInt(1); // Read a single character.
+          asmb->addPCall(novasm::PCallCode::StreamReadString);
+          ADD_PRINT(asmb);
         },
         "Hello world",
         "He");
@@ -133,9 +135,10 @@ TEST_CASE("[vm] Execute input and output", "vm") {
           asmb->addPCall(novasm::PCallCode::Assert);
 
           // Read and print the first character.
-          asmb->addStackLoad(0); // Load stream.
-          asmb->addPCall(novasm::PCallCode::StreamReadChar);
-          ADD_PRINT_CHAR(asmb);
+          asmb->addStackLoad(0);  // Load stream.
+          asmb->addLoadLitInt(1); // Read a single character.
+          asmb->addPCall(novasm::PCallCode::StreamReadString);
+          ADD_PRINT(asmb);
           asmb->addPop(); // Ignore the result of printing.
 
           // Read and print the remaining characters.


### PR DESCRIPTION
Cleanup of the stream api:
* Remove `StreamReadChar`, its a very inefficient api to read character for character from the kernel.
* Remove `StreamWriteChar`, its a very inefficient api to write character for character to the kernel.
* Remove `StreamFlush`, now that we no longer do buffering on the vm side flushing does nothing. 