### PR TITLE
frontend: Fix insting a func templ in type infer

### DIFF
--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -91,10 +91,16 @@ auto FuncTemplate::getRetType(const prog::sym::TypeSet& typeParams)
   return retType->isConcrete() ? std::optional{*retType} : std::nullopt;
 }
 
+auto FuncTemplate::getArgumentTypes(const prog::sym::TypeSet& typeParams)
+    -> std::optional<prog::sym::TypeSet> {
+  const auto subTable = createSubTable(typeParams);
+  return getFuncInput(m_ctx, &subTable, *m_parseNode);
+}
+
 auto FuncTemplate::inferTypeParams(const prog::sym::TypeSet& argTypes)
     -> std::optional<InferResult> {
 
-  auto inputTypes = getInputTypes(argTypes);
+  auto inputTypes = inferOptArgs(argTypes);
   if (!inputTypes) {
     return std::nullopt;
   }
@@ -255,7 +261,7 @@ auto FuncTemplate::createSubTable(const prog::sym::TypeSet& typeParams) const
   return subTable;
 }
 
-auto FuncTemplate::getInputTypes(const prog::sym::TypeSet& argTypes)
+auto FuncTemplate::inferOptArgs(const prog::sym::TypeSet& argTypes)
     -> std::optional<prog::sym::TypeSet> {
 
   const auto maxInputs    = m_parseNode->getArgList().getCount();

--- a/src/frontend/internal/func_template.hpp
+++ b/src/frontend/internal/func_template.hpp
@@ -36,6 +36,9 @@ public:
   [[nodiscard]] auto getRetType(const prog::sym::TypeSet& typeParams)
       -> std::optional<prog::sym::TypeId>;
 
+  [[nodiscard]] auto getArgumentTypes(const prog::sym::TypeSet& typeParams)
+      -> std::optional<prog::sym::TypeSet>;
+
   [[nodiscard]] auto inferTypeParams(const prog::sym::TypeSet& argTypes)
       -> std::optional<InferResult>;
 
@@ -67,7 +70,9 @@ private:
   [[nodiscard]] auto createSubTable(const prog::sym::TypeSet& typeParams) const
       -> TypeSubstitutionTable;
 
-  [[nodiscard]] auto getInputTypes(const prog::sym::TypeSet& argTypes)
+  // Given a set of argument types, try to infer the types of the remaining (optional) arguments.
+  // Returns the full set of arguments (including the given ones) or nullopt.
+  [[nodiscard]] auto inferOptArgs(const prog::sym::TypeSet& argTypes)
       -> std::optional<prog::sym::TypeSet>;
 };
 

--- a/src/frontend/internal/func_template_table.hpp
+++ b/src/frontend/internal/func_template_table.hpp
@@ -8,6 +8,7 @@ namespace frontend::internal {
 class FuncTemplateTable final {
 public:
   struct CallInfo {
+    prog::sym::TypeSet argumentTypes;
     prog::sym::TypeId resultType;
     bool isAction;
   };

--- a/src/frontend/internal/typeinfer_expr.cpp
+++ b/src/frontend/internal/typeinfer_expr.cpp
@@ -27,11 +27,11 @@ TypeInferExpr::TypeInferExpr(
 
 auto TypeInferExpr::getInferredType() const noexcept -> prog::sym::TypeId { return m_type; }
 
-auto TypeInferExpr::visit(const parse::CommentNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::CommentNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ErrorNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ErrorNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
@@ -217,9 +217,10 @@ auto TypeInferExpr::visit(const parse::IdExprNode& n) -> void {
     if (!typeSet) {
       return;
     }
-    const auto instances = m_ctx->getFuncTemplates()->instantiate(name, *typeSet, getOvOptions());
-    if (!instances.empty() && !m_ctx->hasErrors()) {
-      m_type = getDelegate(m_ctx, *instances[0]->getFunc());
+    const auto callInfo = m_ctx->getFuncTemplates()->getCallInfo(name, *typeSet, getOvOptions());
+    if (callInfo) {
+      m_type = m_ctx->getDelegates()->getDelegate(
+          m_ctx, callInfo->isAction, callInfo->argumentTypes, callInfo->resultType);
     }
     return;
   }
@@ -286,7 +287,7 @@ auto TypeInferExpr::visit(const parse::IndexExprNode& n) -> void {
   }
 }
 
-auto TypeInferExpr::visit(const parse::IntrinsicExprNode & /*ununsed*/) -> void {}
+auto TypeInferExpr::visit(const parse::IntrinsicExprNode& /*unused*/) -> void {}
 
 auto TypeInferExpr::visit(const parse::IsExprNode& n) -> void {
   if (n.hasId()) {
@@ -328,11 +329,11 @@ auto TypeInferExpr::visit(const parse::LitExprNode& n) -> void {
 
 auto TypeInferExpr::visit(const parse::ParenExprNode& n) -> void { m_type = inferSubExpr(n[0]); }
 
-auto TypeInferExpr::visit(const parse::SwitchExprElseNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::SwitchExprElseNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::SwitchExprIfNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::SwitchExprIfNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
@@ -377,27 +378,27 @@ auto TypeInferExpr::visit(const parse::UnaryExprNode& n) -> void {
   }
 }
 
-auto TypeInferExpr::visit(const parse::EnumDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::EnumDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ExecStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ExecStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::FuncDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::FuncDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::ImportStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::ImportStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::StructDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::StructDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 
-auto TypeInferExpr::visit(const parse::UnionDeclStmtNode & /*unused*/) -> void {
+auto TypeInferExpr::visit(const parse::UnionDeclStmtNode& /*unused*/) -> void {
   throw std::logic_error{"TypeInferExpr is not implemented for this node type"};
 }
 


### PR DESCRIPTION
Instantiating function templates during the type infer stage is bad
because if the instantiation fails the diagnostics are not reported
in a very user friendly way.