### PR TITLE
vm,novstd: Implement process kill signal

### DIFF
--- a/examples/run-tests.nov
+++ b/examples/run-tests.nov
@@ -27,7 +27,7 @@ act startTests()
     if getPlatform() == Platform.Windows  -> runPowerShell( "scripts/test.ps1", "-Dir"  :: "build")
     else                                  -> runBash(       "scripts/test.sh",  "--dir" :: "build")
   );
-  atInterupt(sendKill[process]);
+  atInterupt(shutdown[process]);
   TestRun(timeNow(), process)
 
 act printOutput(TestRun run)

--- a/examples/run-tests.nov
+++ b/examples/run-tests.nov
@@ -27,7 +27,7 @@ act startTests()
     if getPlatform() == Platform.Windows  -> runPowerShell( "scripts/test.ps1", "-Dir"  :: "build")
     else                                  -> runBash(       "scripts/test.sh",  "--dir" :: "build")
   );
-  atInterupt(sendInterupt[process]);
+  atInterupt(sendKill[process]);
   TestRun(timeNow(), process)
 
 act printOutput(TestRun run)

--- a/novstd/process.nov
+++ b/novstd/process.nov
@@ -1,4 +1,5 @@
 import "std/console.nov"
+import "std/future.nov"
 import "std/list.nov"
 
 // -- Types
@@ -73,9 +74,6 @@ act run(string cmdLine) -> Either{Process, Error}
 act sendInterupt(Process p) -> Option{Error}
   p.sendSignal(Signal.Interupt)
 
-act sendKill(Process p) -> Option{Error}
-  p.sendSignal(Signal.Kill)
-
 act sendSignal(Process p, Signal s) -> Option{Error}
   intrinsic{process_sendsignal}(p.handle, int(s))
     ? None()
@@ -97,6 +95,15 @@ act wait(Process p) -> Either{ProcessResult, Error}
 
 act waitAsync(Process p) -> future{Either{ProcessResult, Error}}
   fork p.wait()
+
+act shutdown(Process p) -> Either{ProcessResult, Error}
+  result = p.waitAsync();
+  if p.sendSignal(Signal.Interupt) as Error interuptErr -> interuptErr
+  else ->
+  if result.get(seconds(1)) as Either{ProcessResult, Error} processRes -> processRes
+  else ->
+  if p.sendSignal(Signal.Kill) as Error killErr -> killErr
+  else -> result.get()
 
 // -- Tests
 

--- a/novstd/process.nov
+++ b/novstd/process.nov
@@ -7,7 +7,8 @@ struct ProcessId  = long id
 struct ExitCode   = int code
 
 enum Signal =
-  Interupt : 0
+  Interupt  : 0,
+  Kill      : 1
 
 struct Process =
   string      cmdLine,
@@ -29,6 +30,7 @@ fun string(ProcessId p)
 
 fun string(Signal s)
   if s == Signal.Interupt -> "Interupt"
+  if s == Signal.Kill     -> "Kill"
   else                    -> "Unknown signal"
 
 fun string(ExitCode p)
@@ -70,6 +72,9 @@ act run(string cmdLine) -> Either{Process, Error}
 
 act sendInterupt(Process p) -> Option{Error}
   p.sendSignal(Signal.Interupt)
+
+act sendKill(Process p) -> Option{Error}
+  p.sendSignal(Signal.Kill)
 
 act sendSignal(Process p, Signal s) -> Option{Error}
   intrinsic{process_sendsignal}(p.handle, int(s))

--- a/src/vm/internal/ref_process.hpp
+++ b/src/vm/internal/ref_process.hpp
@@ -24,6 +24,7 @@ enum class ProcessState : uint8_t {
 
 enum class ProcessSignalKind : uint8_t {
   Interupt = 0, // Request a process to interupt.
+  Kill     = 1, // Request a process to die.
 };
 
 #if defined(_WIN32)
@@ -155,8 +156,7 @@ public:
     return -1;
   }
 
-  [[nodiscard]] auto sendSignal(PlatformError* pErr, ProcessSignalKind kind) const noexcept
-      -> bool {
+  [[nodiscard]] auto sendSignal(PlatformError* pErr, ProcessSignalKind kind) noexcept -> bool {
     switch (kind) {
     case ProcessSignalKind::Interupt:
 #if defined(_WIN32)
@@ -172,6 +172,12 @@ public:
         return false;
       }
 #endif
+      return true;
+    case ProcessSignalKind::Kill:
+      if (!killImpl()) {
+        *pErr = PlatformError::ProcessUnknownError;
+        return false;
+      }
       return true;
     }
     *pErr = PlatformError::ProcessInvalidSignal;
@@ -197,11 +203,11 @@ private:
       m_stdOut{stdOut},
       m_stdErr{stdErr} {}
 
-  auto killImpl() -> void {
+  auto killImpl() noexcept -> bool {
 #if defined(_WIN32)
-    TerminateProcess(m_process.hProcess, static_cast<UINT>(ProcessExitErr::InvalidProcess));
+    return TerminateProcess(m_process.hProcess, static_cast<UINT>(ProcessExitErr::InvalidProcess));
 #else // !_WIN32
-    ::killpg(m_process, SIGKILL);
+    return ::killpg(m_process, SIGKILL) == 0;
 #endif
   }
 

--- a/src/vm/internal/ref_process.hpp
+++ b/src/vm/internal/ref_process.hpp
@@ -46,7 +46,7 @@ template <typename... Handles>
 auto CloseHandle(Handles... handles) {
   (::CloseHandle(handles), ...);
 }
-#else  // !_WIN32
+#else // !_WIN32
 template <typename... Descriptors>
 auto close(Descriptors... descriptors) {
   (::close(descriptors), ...);
@@ -205,7 +205,7 @@ private:
 
   auto killImpl() noexcept -> bool {
 #if defined(_WIN32)
-    return TerminateProcess(m_process.hProcess, static_cast<UINT>(ProcessExitErr::InvalidProcess));
+    return TerminateProcess(m_process.hProcess, 9999); // TODO: Decide what exitcode to use here.
 #else // !_WIN32
     return ::killpg(m_process, SIGKILL) == 0;
 #endif


### PR DESCRIPTION
Add a 'Kill' signal to the process api, for those pesky processes that do not respond to 'Interrupt'.

Also adds a 'shutdown' api to `std/process.nov` that gives a process 1 second to respond to an interrupt signal before killing it.

For unix we should probably use SIGTERM but there is no great win32 equivalent AFAIK.