### PR TITLE
Shebang in nova format

### DIFF
--- a/apps/novrt/main.cpp
+++ b/apps/novrt/main.cpp
@@ -9,27 +9,16 @@
 
 auto main(int argc, const char** argv) noexcept -> int {
 
-  /* Note: Supports either reading a 'nova' assembly file as argment 1 or looking for a 'prog.nova'
-   * in current working directory. */
-
-  auto implicitPath = true;
-  auto relProgPath  = filesystem::path{"prog.nova"};
-  if (argc >= 2) {
-    auto arg1Path = filesystem::path(std::string(argv[1]));
-    if (arg1Path.extension() == ".nova") {
-      relProgPath  = std::move(arg1Path);
-      implicitPath = false;
-    }
+  if (argc < 2) {
+    std::cerr << "Novus runtime [" PROJECT_VER "] - Please provide path to a 'nova' file\n";
+    return 1;
   }
+  auto relProgPath = filesystem::path(std::string(argv[1]));
 
   // Open a handle to the program assembly file.
   auto fs = std::ifstream{relProgPath.string(), std::ios::binary};
   if (!fs.good()) {
-    if (implicitPath) {
-      std::cerr << "Novus runtime [" PROJECT_VER "] - Please provide path to a 'nova' file\n";
-    } else {
-      std::cerr << "Novus runtime [" PROJECT_VER "] - Failed to open file: " << relProgPath << '\n';
-    }
+    std::cerr << "Novus runtime [" PROJECT_VER "] - Failed to open file: " << relProgPath << '\n';
     return 1;
   }
 
@@ -43,7 +32,7 @@ auto main(int argc, const char** argv) noexcept -> int {
   // Close the handle to the program assembly file.
   fs.close();
 
-  const auto consumedArgs   = implicitPath ? 1 : 2; // 1 for executable path and 1 for nova file.
+  const auto consumedArgs   = 1; // Consume the path to the runtime executable itself.
   const auto vmEnvArgsCount = argc - consumedArgs;
   const char** vmEnvArgs    = argv + consumedArgs;
   auto absProgPath          = filesystem::canonical(relProgPath).string();

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -7,7 +7,7 @@ namespace novasm {
 // Version number for the binary representation of the novus assembly format.
 // Increase this when performing breaking changes to the format.
 // TODO(bastian): Add system for defining migrations.
-const uint16_t assemblyFormatVersion = 7U;
+const uint16_t assemblyFormatVersion = 8U;
 
 // Write a binary representation of the assembly file to the output iterator.
 template <typename OutputItr>


### PR DESCRIPTION
Add a shebang line to instruct operating systems that support
it to execute this file with the 'novrt' runtime executable. This
is just an optional feature and does not hinder systems that do
not support it.

NOTE: To avoid hardcoding the absolute path of novrt we
use '/usr/bin/env'  to lookup  the executable. This is
not fully portable but works across many posix systems.

 More info: https://en.wikipedia.org/wiki/Shebang_(Unix)