### PR TITLE
Noinline

### DIFF
--- a/ide/nano/novus.nanorc
+++ b/ide/nano/novus.nanorc
@@ -4,7 +4,7 @@ syntax "nov" "\.nov$"
 comment "//"
 
 # Keywords.
-color brightblue "\b(intrinsic|import|struct|union|enum|fun|act|lambda|impure|fork|lazy)\b"
+color brightblue "\b(intrinsic|import|struct|union|enum|fun|act|lambda|impure|fork|lazy|noinline)\b"
 color red "(\b(if|else)\b)|(\?|\:)"
 color brightyellow "((\b(is|as)\b)|(\+\+)|(\-\-)|(\&\&)|(\|\|)|(\<\<)|(\>\>)|(\<\=)|(\>\=)|(\=\=)|(\!\=)|\+|\-|\*|(\/)|\^|\~|\%|\&|\!|<|>)"
 

--- a/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
+++ b/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
@@ -240,7 +240,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>\b(fun|act)\s+(.+?)\s*(?=\{|\()</string>
+					<string>\b(fun|act)\s+(noinline)?\s*(.+?)\s*(?=\{|\()</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -249,6 +249,11 @@
 							<string>keyword.other.function.source.novus</string>
 						</dict>
 						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.noinline.source.novus</string>
+						</dict>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>entity.name.function.source.novus</string>
@@ -363,7 +368,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>\s*\b(impure\s+)?(lambda)\s*\(</string>
+					<string>\s*\b(impure)?\s*(lambda)\s*\(</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>

--- a/ide/vscode/novus/syntaxes/novus.tmLanguage.json
+++ b/ide/vscode/novus/syntaxes/novus.tmLanguage.json
@@ -155,12 +155,15 @@
     "function_declaration": {
       "patterns": [
         {
-          "begin": "\\b(fun|act)\\s+(.+?)\\s*(?=\\{|\\()",
+          "begin": "\\b(fun|act)\\s+(noinline)?\\s*(.+?)\\s*(?=\\{|\\()",
           "beginCaptures": {
             "1": {
               "name": "keyword.other.function.source.novus"
             },
             "2": {
+              "name": "keyword.other.noinline.source.novus"
+            },
+            "3": {
               "name": "entity.name.function.source.novus"
             }
           },
@@ -236,7 +239,7 @@
     "lambda_declaration": {
       "patterns": [
         {
-          "begin": "\\s*\\b(impure\\s+)?(lambda)\\s*\\(",
+          "begin": "\\s*\\b(impure)?\\s*(lambda)\\s*\\(",
           "beginCaptures": {
             "1": {
               "name": "keyword.other.impure.source.novus"

--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -21,7 +21,8 @@ enum class Keyword {
   If,
   Else,
   Is,
-  As
+  As,
+  Noinline
 };
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream&;

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -17,6 +17,7 @@ namespace parse {
 
 [[nodiscard]] auto errInvalidStmtFuncDecl(
     lex::Token kw,
+    std::vector<lex::Token> modifiers,
     lex::Token id,
     std::optional<TypeSubstitutionList> typeSubs,
     ArgumentListDecl argList,

--- a/include/parse/node_expr_anon_func.hpp
+++ b/include/parse/node_expr_anon_func.hpp
@@ -28,6 +28,7 @@ public:
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
   [[nodiscard]] auto isImpure() const -> bool;
+  [[nodiscard]] auto isNoinline() const -> bool;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
   [[nodiscard]] auto getRetType() const -> const std::optional<RetTypeSpec>&;
   [[nodiscard]] auto getBody() const -> const Node&;

--- a/include/parse/node_stmt_func_decl.hpp
+++ b/include/parse/node_stmt_func_decl.hpp
@@ -12,6 +12,7 @@ class FuncDeclStmtNode final : public Node {
 public:
   friend auto funcDeclStmtNode(
       lex::Token kw,
+      std::vector<lex::Token> modifiers,
       lex::Token id,
       std::optional<TypeSubstitutionList> typeSubs,
       ArgumentListDecl argList,
@@ -28,6 +29,7 @@ public:
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
   [[nodiscard]] auto isAction() const -> bool;
+  [[nodiscard]] auto isNoinline() const -> bool;
   [[nodiscard]] auto getId() const -> const lex::Token&;
   [[nodiscard]] auto getTypeSubs() const -> const std::optional<TypeSubstitutionList>&;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
@@ -38,6 +40,7 @@ public:
 
 private:
   const lex::Token m_kw;
+  const std::vector<lex::Token> m_modifiers;
   const lex::Token m_id;
   const std::optional<TypeSubstitutionList> m_typeSubs;
   const ArgumentListDecl m_argList;
@@ -46,6 +49,7 @@ private:
 
   FuncDeclStmtNode(
       lex::Token kw,
+      std::vector<lex::Token> modifiers,
       lex::Token id,
       std::optional<TypeSubstitutionList> typeSubs,
       ArgumentListDecl argList,
@@ -58,6 +62,7 @@ private:
 // Factories.
 auto funcDeclStmtNode(
     lex::Token kw,
+    std::vector<lex::Token> modifiers,
     lex::Token id,
     std::optional<TypeSubstitutionList> typeSubs,
     ArgumentListDecl argList,

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -177,7 +177,8 @@ public:
       sym::FuncId id,
       sym::ConstDeclTable consts,
       expr::NodePtr body,
-      std::vector<expr::NodePtr> optArgInitializers) -> void;
+      std::vector<expr::NodePtr> optArgInitializers,
+      sym::FuncDef::Flags flags = sym::FuncDef::Flags::None) -> void;
 
   auto addExecStmt(sym::ConstDeclTable consts, expr::NodePtr expr) -> void;
 

--- a/include/prog/sym/func_def.hpp
+++ b/include/prog/sym/func_def.hpp
@@ -11,6 +11,11 @@ class FuncDef final {
   friend class FuncDefTable;
 
 public:
+  enum class Flags : unsigned int {
+    None     = 0U,
+    NoInline = 1U << 0U, // Hint to the optmizer that it should not inline this function.
+  };
+
   FuncDef()                   = delete;
   FuncDef(const FuncDef& rhs) = delete;
   FuncDef(FuncDef&& rhs)      = default;
@@ -20,6 +25,8 @@ public:
   auto operator=(FuncDef&& rhs) noexcept -> FuncDef& = delete;
 
   [[nodiscard]] auto getId() const noexcept -> const FuncId&;
+  [[nodiscard]] auto getFlags() const noexcept -> Flags;
+  [[nodiscard]] auto hasFlags(Flags flags) const noexcept -> bool;
   [[nodiscard]] auto getConsts() const noexcept -> const sym::ConstDeclTable&;
   [[nodiscard]] auto getBody() const noexcept -> const expr::Node&;
   [[nodiscard]] auto getOptArgInitializer(unsigned int i) const -> expr::NodePtr;
@@ -29,12 +36,14 @@ private:
   sym::ConstDeclTable m_consts;
   expr::NodePtr m_body;
   std::vector<expr::NodePtr> m_optArgInitializers;
+  Flags m_flags;
 
   FuncDef(
       sym::FuncId id,
       sym::ConstDeclTable consts,
       expr::NodePtr body,
-      std::vector<expr::NodePtr> optArgInitializers);
+      std::vector<expr::NodePtr> optArgInitializers,
+      Flags flags);
 };
 
 } // namespace prog::sym

--- a/include/prog/sym/func_def_table.hpp
+++ b/include/prog/sym/func_def_table.hpp
@@ -32,7 +32,8 @@ public:
       sym::FuncId id,
       sym::ConstDeclTable consts,
       expr::NodePtr body,
-      std::vector<expr::NodePtr> optArgInitializers) -> void;
+      std::vector<expr::NodePtr> optArgInitializers,
+      FuncDef::Flags flags) -> void;
 
 private:
   std::unordered_map<FuncId, FuncDef, FuncIdHasher> m_funcDefs;

--- a/novstd/console.nov
+++ b/novstd/console.nov
@@ -72,36 +72,36 @@ act writeErr(Console c, Writer{None} writer) -> Option{Error}
 
 // -- Print
 
-act print{T}(T x) -> Option{Error}
+act noinline print{T}(T x) -> Option{Error}
   consoleOpen().map(impure lambda (Console c) c.writeOut(x.string() + '\n'))
 
-act print{T}(T x, TtyStyle style) -> Option{Error}
+act noinline print{T}(T x, TtyStyle style) -> Option{Error}
   styledWriter = ttyStyledTextWriter(style);
   consoleOpen().map(impure lambda (Console c)
     c.writeOut(styledWriter, x.string() + '\n')
   )
 
-act printErr{T}(T x) -> Option{Error}
+act noinline printErr{T}(T x) -> Option{Error}
   consoleOpen().map(impure lambda (Console c)
     c.writeErr(x.string() + '\n')
   )
 
-act printErr{T}(T x, TtyStyle style) -> Option{Error}
+act noinline printErr{T}(T x, TtyStyle style) -> Option{Error}
   styledWriter = ttyStyledTextWriter(style);
   consoleOpen().map(impure lambda (Console c)
     c.writeErr(styledWriter, x.string() + '\n')
   )
 
-act printBits{T}(T mask, bool includeLeadingZeroes = false) -> Option{Error}
+act noinline printBits{T}(T mask, bool includeLeadingZeroes = false) -> Option{Error}
   print(toBitString(mask, includeLeadingZeroes))
 
-act printBits(float f, bool includeLeadingZeroes = false) -> Option{Error}
+act noinline printBits(float f, bool includeLeadingZeroes = false) -> Option{Error}
   print(toBitString(asInt(f), includeLeadingZeroes))
 
-act printHex{T}(T mask, bool includeLeadingZeroes = false) -> Option{Error}
+act noinline printHex{T}(T mask, bool includeLeadingZeroes = false) -> Option{Error}
   print(toHexString(mask, includeLeadingZeroes))
 
-act printHex(float f, bool includeLeadingZeroes = false) -> Option{Error}
+act noinline printHex(float f, bool includeLeadingZeroes = false) -> Option{Error}
   print(toHexString(asInt(f), includeLeadingZeroes))
 
 // -- Meta

--- a/novstd/env.nov
+++ b/novstd/env.nov
@@ -17,7 +17,7 @@ fun string(EnvOpt eo)
 
 // -- Functions
 
-fun findEnvOpt(List{string} args, string name) -> Option{EnvOpt}
+fun noinline findEnvOpt(List{string} args, string name) -> Option{EnvOpt}
   shortOpt  = name.length() == 1;
   longOpt   = name.length() > 1;
   if args.front() as string s ->
@@ -35,7 +35,7 @@ fun isLongOpt(string s)
 fun takeNonOpts(List{string} l) -> List{string}
   l.take(lambda (string str) str[0] != '-' || str[1].isDigit())
 
-fun findEnvOpt{T}(List{string} args, string n, Parser{T} p) -> Either{T, Error}
+fun noinline findEnvOpt{T}(List{string} args, string n, Parser{T} p) -> Either{T, Error}
   if findEnvOpt(args, n) as EnvOpt o  ->
     if o.args.front() as string str   -> p(str) ?? Error("Failed to parse argument")
     else                              -> Error("Option '" + n + "' has no arguments")

--- a/novstd/rt.nov
+++ b/novstd/rt.nov
@@ -69,7 +69,7 @@ fun string(Platform p)
   if p == Platform.Windows  -> "Windows"
   else                      -> "Unknown"
 
-fun string(PlatformError err)
+fun noinline string(PlatformError err)
   if err == PlatformError.Unknown                       -> "Unknown"
   if err == PlatformError.FeatureNetworkNotEnabled      -> "Network feature not enabled"
   if err == PlatformError.StreamOptionsNotSupported     -> "Stream does not support the given options"
@@ -176,11 +176,11 @@ act fail(string msg) -> Option{Error}
 act fail(Error err) -> Option{Error}
   fail{Option{Error}}(err)
 
-act fail{TResult}(string msg) -> TResult
+act noinline fail{TResult}(string msg) -> TResult
   printErr(msg);
   intrinsic{fail}{TResult}()
 
-act fail{TResult}(Error err) -> TResult
+act noinline fail{TResult}(Error err) -> TResult
   writer = litWriter("Failed:\n") & errorWriter(litWriter("- "), newlineWriter());
   fail{TResult}(writer.run(err))
 

--- a/novstd/time.nov
+++ b/novstd/time.nov
@@ -106,7 +106,7 @@ enum Month =
   November,
   December
 
-fun string(Month m, bool short = false)
+fun noinline string(Month m, bool short = false)
   if m == Month.January   -> short ? "Jan" : "January"
   if m == Month.February  -> short ? "Feb" : "February"
   if m == Month.March     -> short ? "Mar" : "March"
@@ -139,7 +139,7 @@ fun WeekDay(Date e)
 fun WeekDay(DateTime dt)
   WeekDay((dt.daysSinceEpoch() + WeekDay.Thursday) % 7)
 
-fun string(WeekDay d, bool short = false)
+fun noinline string(WeekDay d, bool short = false)
   if d ==  WeekDay.Sunday     -> short ? "Sun"  : "Sunday"
   if d ==  WeekDay.Monday     -> short ? "Mon"  : "Monday"
   if d ==  WeekDay.Tuesday    -> short ? "Tue"  : "Tuesday"
@@ -216,7 +216,7 @@ fun days(Duration d)          d.ns / day().ns
 fun weeks(Duration d)         d.ns / week().ns
 
 // Create a human readable representation.
-fun string(Duration d)
+fun noinline string(Duration d)
   if d.ns < 0L  -> "-" + absDuration(d).string()
   else          ->
     if d < microsecond()  ->  d.nanoseconds().string()    + "ns"

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -123,9 +123,12 @@ auto defineFunc(
     return false;
   }
 
+  const auto funcDefFlags =
+      n.isNoinline() ? prog::sym::FuncDef::Flags::NoInline : prog::sym::FuncDef::Flags::None;
+
   if (bodyExpr->getType() == funcRetType) {
     ctx->getProg()->defineFunc(
-        id, std::move(consts), std::move(bodyExpr), std::move(optInputInitializers));
+        id, std::move(consts), std::move(bodyExpr), std::move(optInputInitializers), funcDefFlags);
     return true;
   }
 
@@ -137,7 +140,8 @@ auto defineFunc(
         id,
         std::move(consts),
         prog::expr::callExprNode(*ctx->getProg(), *conv, std::move(convArgs)),
-        std::move(optInputInitializers));
+        std::move(optInputInitializers),
+        funcDefFlags);
     return true;
   }
 

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -136,8 +136,11 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
       : m_ctx->getProg()->declarePureFunc(
             nameoss.str(), prog::sym::TypeSet{inputTypes}, *retType, 0u);
 
+  const auto funcDefFlags =
+      n.isNoinline() ? prog::sym::FuncDef::Flags::NoInline : prog::sym::FuncDef::Flags::None;
+
   // Define the function in the program.
-  m_ctx->getProg()->defineFunc(funcId, std::move(consts), std::move(expr), {});
+  m_ctx->getProg()->defineFunc(funcId, std::move(consts), std::move(expr), {}, funcDefFlags);
 
   // Either create a function literal or a closure, depending on if the anonymous func binds any
   // consts from the parent.

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -17,11 +17,11 @@ public:
     // Checked constants access means that any constants that this expression declares are only
     // visible when this expression evaluates to 'true'. For example the 'as' expression (with a
     // constant) is only valid in a 'CheckedConstsAccess' expression.
-    CheckedConstsAccess = 1U << 1U,
+    CheckedConstsAccess = 1U << 0U,
 
-    AllowPureFuncCalls = 1U << 2U,
-    AllowActionCalls   = 1U << 3U,
-    NoOptArgs          = 1U << 4U, // Disallow optional arguments (requires passing all args).
+    AllowPureFuncCalls = 1U << 1U,
+    AllowActionCalls   = 1U << 2U,
+    NoOptArgs          = 1U << 3U, // Disallow optional arguments (requires passing all args).
   };
 
   GetExpr() = delete;

--- a/src/frontend/internal/typeinfer_expr.hpp
+++ b/src/frontend/internal/typeinfer_expr.hpp
@@ -11,10 +11,10 @@ public:
 
     // Without the aggressive flag inference will only reach an conclusion when it has all the
     // information required, with aggressive it can act on incomplete data.
-    Aggressive = 1U << 1U,
+    Aggressive = 1U << 0U,
 
-    AllowActionCalls = 1U << 2U,
-    NoOptArgs        = 1U << 3U, // Disallow optional arguments (requires passing all args).
+    AllowActionCalls = 1U << 1U,
+    NoOptArgs        = 1U << 2U, // Disallow optional arguments (requires passing all args).
   };
 
   TypeInferExpr() = delete;

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -53,6 +53,9 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::As:
     out << "as";
     break;
+  case Keyword::Noinline:
+    out << "noinline";
+    break;
   }
   return out;
 }
@@ -75,6 +78,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
       {"else", Keyword::Else},
       {"is", Keyword::Is},
       {"as", Keyword::As},
+      {"noinline", Keyword::Noinline},
   };
 
   const auto keywordSearch = keywordTable.find(str);

--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -73,6 +73,10 @@ auto CallInlineRewriter::isInlinable(const prog::expr::CallExprNode* callExpr) -
     return false;
   }
 
+  if (internal::hasFuncDefFlags(m_prog, funcId, prog::sym::FuncDef::Flags::NoInline)) {
+    return false;
+  }
+
   // Recursive functions are not inlined.
   if (internal::isRecursive(m_prog, funcId)) {
     return false;

--- a/src/opt/internal/expr_matchers.cpp
+++ b/src/opt/internal/expr_matchers.cpp
@@ -35,6 +35,15 @@ auto isRecursive(const prog::Program& prog, prog::sym::FuncId funcId) -> bool {
   return calledFuncs.find(funcId) != calledFuncs.end();
 }
 
+auto hasFuncDefFlags(
+    const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::FuncDef::Flags flags) -> bool {
+  const auto& funcDecl = prog.getFuncDecl(funcId);
+  if (funcDecl.getKind() != prog::sym::FuncKind::User) {
+    return false;
+  }
+  return prog.getFuncDef(funcId).hasFlags(flags);
+}
+
 auto hasSideEffect(const prog::Program& prog, const prog::expr::Node& expr) -> bool {
   auto matcher = ExprMatcher{[&prog](const prog::expr::Node& n) {
     switch (n.getKind()) {

--- a/src/opt/internal/expr_matchers.hpp
+++ b/src/opt/internal/expr_matchers.hpp
@@ -47,6 +47,9 @@ auto isUserFunc(const prog::Program& prog, prog::sym::FuncId funcId) -> bool;
 
 auto isRecursive(const prog::Program& prog, prog::sym::FuncId funcId) -> bool;
 
+auto hasFuncDefFlags(
+    const prog::Program& prog, prog::sym::FuncId funcId, prog::sym::FuncDef::Flags flags) -> bool;
+
 auto hasSideEffect(const prog::Program& prog, const prog::expr::Node& expr) -> bool;
 
 auto isLiteral(const prog::expr::Node& expr) -> bool;

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -119,6 +119,7 @@ auto errInvalidStmtImport(lex::Token kw, lex::Token path) -> NodePtr {
 
 auto errInvalidStmtFuncDecl(
     lex::Token kw,
+    std::vector<lex::Token> modifiers,
     lex::Token id,
     std::optional<TypeSubstitutionList> typeSubs,
     ArgumentListDecl argList,
@@ -140,6 +141,9 @@ auto errInvalidStmtFuncDecl(
 
   auto tokens = std::vector<lex::Token>{};
   tokens.push_back(std::move(kw));
+  for (auto& mod : modifiers) {
+    tokens.push_back(std::move(mod));
+  }
   tokens.push_back(std::move(id));
   if (typeSubs) {
     addTokens(*typeSubs, &tokens);

--- a/src/parse/node_expr_anon_func.cpp
+++ b/src/parse/node_expr_anon_func.cpp
@@ -53,6 +53,8 @@ auto AnonFuncExprNode::isImpure() const -> bool {
   });
 }
 
+auto AnonFuncExprNode::isNoinline() const -> bool { return false; }
+
 auto AnonFuncExprNode::getArgList() const -> const ArgumentListDecl& { return m_argList; }
 
 auto AnonFuncExprNode::getRetType() const -> const std::optional<RetTypeSpec>& { return m_retType; }

--- a/src/prog/copy.cpp
+++ b/src/prog/copy.cpp
@@ -73,7 +73,12 @@ auto copyFunc(
     modified = rewriter && rewriter->hasModified();
 
     toDefTable.registerFunc(
-        toDeclTable, id, std::move(consts), std::move(newBody), std::move(optInputInitializers));
+        toDeclTable,
+        id,
+        std::move(consts),
+        std::move(newBody),
+        std::move(optInputInitializers),
+        fromDef.getFlags());
   }
   return true;
 }

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -708,9 +708,10 @@ auto Program::defineFunc(
     sym::FuncId id,
     sym::ConstDeclTable consts,
     expr::NodePtr body,
-    std::vector<expr::NodePtr> optArgInitializers) -> void {
+    std::vector<expr::NodePtr> optArgInitializers,
+    sym::FuncDef::Flags flags) -> void {
   m_funcDefs.registerFunc(
-      m_funcDecls, id, std::move(consts), std::move(body), std::move(optArgInitializers));
+      m_funcDecls, id, std::move(consts), std::move(body), std::move(optArgInitializers), flags);
 }
 
 auto Program::addExecStmt(sym::ConstDeclTable consts, expr::NodePtr expr) -> void {

--- a/src/prog/sym/func_def.cpp
+++ b/src/prog/sym/func_def.cpp
@@ -7,13 +7,22 @@ FuncDef::FuncDef(
     sym::FuncId id,
     sym::ConstDeclTable consts,
     expr::NodePtr body,
-    std::vector<expr::NodePtr> optArgInitializers) :
+    std::vector<expr::NodePtr> optArgInitializers,
+    Flags flags) :
     m_id{id},
     m_consts{std::move(consts)},
     m_body{std::move(body)},
-    m_optArgInitializers{std::move(optArgInitializers)} {}
+    m_optArgInitializers{std::move(optArgInitializers)},
+    m_flags{flags} {}
 
 auto FuncDef::getId() const noexcept -> const FuncId& { return m_id; }
+
+auto FuncDef::getFlags() const noexcept -> Flags { return m_flags; };
+
+auto FuncDef::hasFlags(Flags flags) const noexcept -> bool {
+  const auto raw = static_cast<unsigned int>(flags);
+  return (static_cast<unsigned int>(m_flags) & raw) == raw;
+}
 
 auto FuncDef::getConsts() const noexcept -> const sym::ConstDeclTable& { return m_consts; }
 

--- a/src/prog/sym/func_def_table.cpp
+++ b/src/prog/sym/func_def_table.cpp
@@ -21,7 +21,8 @@ auto FuncDefTable::registerFunc(
     sym::FuncId id,
     sym::ConstDeclTable consts,
     expr::NodePtr body,
-    std::vector<expr::NodePtr> optArgInitializers) -> void {
+    std::vector<expr::NodePtr> optArgInitializers,
+    FuncDef::Flags flags) -> void {
 
   if (body == nullptr) {
     throw std::invalid_argument{"Function body expresion cannot be null"};
@@ -50,7 +51,7 @@ auto FuncDefTable::registerFunc(
     throw std::logic_error{"Function already has a definition registered"};
   }
   m_funcDefs.insert(
-      {id, FuncDef{id, std::move(consts), std::move(body), std::move(optArgInitializers)}});
+      {id, FuncDef{id, std::move(consts), std::move(body), std::move(optArgInitializers), flags}});
   m_funcs.insert(id);
 }
 

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -43,6 +43,14 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
     CHECK(funcDef.getBody() == *prog::expr::constExprNode(consts, *a));
   }
 
+  SECTION("Define noinline function") {
+    const auto& output = ANALYZE("fun noinline f() -> int 42");
+    REQUIRE(output.isSuccess());
+    const auto& funcDef = GET_FUNC_DEF(output, "f");
+    CHECK(funcDef.getBody() == *prog::expr::litIntNode(output.getProg(), 42));
+    CHECK(funcDef.hasFlags(prog::sym::FuncDef::Flags::NoInline));
+  }
+
   SECTION("Diagnostics") {
     CHECK_DIAG(
         "fun f() -> int true",

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -19,6 +19,7 @@ TEST_CASE("[lex] Lexing keywords", "lex") {
   CHECK_TOKENS("else", keywordToken(Keyword::Else));
   CHECK_TOKENS("is", keywordToken(Keyword::Is));
   CHECK_TOKENS("as", keywordToken(Keyword::As));
+  CHECK_TOKENS("noinline", keywordToken(Keyword::Noinline));
 }
 
 } // namespace lex

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -56,6 +56,7 @@ namespace parse {
 #define ACT lex::keywordToken(lex::Keyword::Act)
 #define LAMBDA lex::keywordToken(lex::Keyword::Lambda)
 #define IMPURE lex::keywordToken(lex::Keyword::Impure)
+#define NOINLINE lex::keywordToken(lex::Keyword::Noinline)
 #define FORK lex::keywordToken(lex::Keyword::Fork)
 #define STRUCT lex::keywordToken(lex::Keyword::Struct)
 #define UNION lex::keywordToken(lex::Keyword::Union)

--- a/tests/parse/stmt_func_decl_test.cpp
+++ b/tests/parse/stmt_func_decl_test.cpp
@@ -16,6 +16,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a() 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
@@ -25,6 +26,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a() -> int 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
@@ -34,6 +36,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x) -> int 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -44,6 +47,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x = 0) -> int 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -58,6 +62,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x = true, int y = 42) -> int 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -75,6 +80,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x, int y, bool z) -> int x * y",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -91,6 +97,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T}() 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T")}, COMMAS(0), CCURLY},
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
@@ -100,6 +107,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T, U}() 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(1), CCURLY},
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
@@ -109,6 +117,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T, U, W}(T x) -> T x",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U"), ID("W")}, COMMAS(2), CCURLY},
             ArgumentListDecl(
@@ -119,6 +128,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a() -> List{T{Y}} 1",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
@@ -128,6 +138,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T, U, W}(T x) -> T x",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U"), ID("W")}, COMMAS(2), CCURLY},
             ArgumentListDecl(
@@ -138,6 +149,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T, U}(T{U} x) x",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(1), CCURLY},
             ArgumentListDecl(
@@ -151,6 +163,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T, U}(T{U} x = T{U}()) x",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(1), CCURLY},
             ArgumentListDecl(
@@ -172,6 +185,16 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
                 CPAREN),
             std::nullopt,
             ID_EXPR("x")));
+    CHECK_STMT(
+        "fun noinline a() 1",
+        funcDeclStmtNode(
+            FUN,
+            {NOINLINE},
+            ID("a"),
+            std::nullopt,
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
+            std::nullopt,
+            INT(1)));
   }
 
   SECTION("Actions") {
@@ -179,6 +202,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "act a() 1",
         funcDeclStmtNode(
             ACT,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
@@ -188,6 +212,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "act a(int x) -> int 1",
         funcDeclStmtNode(
             ACT,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -198,6 +223,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "act a(int x = 0) -> int 1",
         funcDeclStmtNode(
             ACT,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -212,6 +238,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "act a{T, U}(T{U} x) x",
         funcDeclStmtNode(
             ACT,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(1), CCURLY},
             ArgumentListDecl(
@@ -221,6 +248,16 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
                 CPAREN),
             std::nullopt,
             ID_EXPR("x")));
+    CHECK_STMT(
+        "act noinline a() 1",
+        funcDeclStmtNode(
+            ACT,
+            {NOINLINE},
+            ID("a"),
+            std::nullopt,
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
+            std::nullopt,
+            INT(1)));
   }
 
   SECTION("Errors") {
@@ -228,6 +265,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a() -> int",
         funcDeclStmtNode(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
@@ -237,6 +275,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             END,
             std::nullopt,
             ArgumentListDecl(END, NO_ARGS, COMMAS(0), END),
@@ -246,6 +285,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {}, COMMAS(0), END},
             ArgumentListDecl(END, NO_ARGS, COMMAS(0), END),
@@ -255,6 +295,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{}(int x) -> int 1",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {}, COMMAS(0), CCURLY},
             ArgumentListDecl(
@@ -265,6 +306,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T U}(int x) -> int 1",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(0), CCURLY},
             ArgumentListDecl(
@@ -275,6 +317,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun _() 1",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             DISCARD,
             std::nullopt,
             ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
@@ -284,6 +327,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), END),
@@ -293,6 +337,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -303,6 +348,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -313,6 +359,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x int y) -> x",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -328,6 +375,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x int y) -> int 1",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -343,6 +391,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x,) -> int 1",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -353,6 +402,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x,,) -> int",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(
@@ -368,6 +418,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a() -> T{} 1",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(PARENPAREN, NO_ARGS, COMMAS(0), PARENPAREN),
@@ -377,6 +428,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a{T, U}(T{} x) x",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             TypeSubstitutionList{OCURLY, {ID("T"), ID("U")}, COMMAS(1), CCURLY},
             ArgumentListDecl(
@@ -391,6 +443,7 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
         "fun a(int x =) -> int 1",
         errInvalidStmtFuncDecl(
             FUN,
+            {},
             ID("a"),
             std::nullopt,
             ArgumentListDecl(


### PR DESCRIPTION
Adds an optional `noinline` modifier that can be added to functions and actions. It is a hint to the optimizer that its not worth inlining this function. This can be beneficial when you know a function has many different call sites but its rare that it actually gets called. As the optimizer has no way of knowing if its rare or common that this function will be called.
```c
fun noinline string(PlatformError err)
  if err == PlatformError.Unknown                       -> "Unknown"
  if err == PlatformError.FeatureNetworkNotEnabled      -> "Network feature not enabled"
  if err == PlatformError.StreamOptionsNotSupported     -> "Stream does not support the given options"
  if err == PlatformError.StreamNoDataAvailable         -> "No data available"
```