### PR TITLE
improve windows terminal processing

### DIFF
--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -26,8 +26,7 @@ static auto setupWinsock(internal::Settings* settings) noexcept {
   }
 }
 
-static auto enableVTConsoleMode(PlatformInterface* iface) noexcept {
-  // Input buffer options.
+static auto enableInputVTConsoleMode(PlatformInterface* iface) noexcept {
   DWORD inConsoleMode;
   if (!::GetConsoleMode(iface->getStdIn(), &inConsoleMode)) {
     return false;
@@ -40,8 +39,10 @@ static auto enableVTConsoleMode(PlatformInterface* iface) noexcept {
   if (!::SetConsoleCP(CP_UTF8)) {
     return false;
   }
+  return true;
+}
 
-  // Output buffer options.
+static auto enableOutputVTConsoleMode(PlatformInterface* iface) noexcept {
   DWORD outConsoleMode;
   if (!::GetConsoleMode(iface->getStdOut(), &outConsoleMode)) {
     return false;
@@ -58,7 +59,8 @@ static auto enableVTConsoleMode(PlatformInterface* iface) noexcept {
 
 static auto setup(internal::Settings* settings, PlatformInterface* iface) noexcept {
   setupWinsock(settings);
-  enableVTConsoleMode(iface);
+  enableInputVTConsoleMode(iface);
+  enableOutputVTConsoleMode(iface);
 
   if (settings->interceptInterupt) {
     settings->interceptInterupt = internal::interruptSetupHandler();
@@ -75,7 +77,7 @@ static auto teardown(const internal::Settings* settings) noexcept {
 
 #else // !_WIN32
 
-static auto setup(internal::Settings* settings) noexcept {
+static auto setup(internal::Settings* settings, PlatformInterface* /*unused*/) noexcept {
 
   // Ignore sig-pipe (we want to handle it on a per call basis instead of globally).
   signal(SIGPIPE, SIG_IGN);

--- a/std/tty.ns
+++ b/std/tty.ns
@@ -117,7 +117,7 @@ fun ttyLitCursorShowWriter(bool show) -> Writer{None}
 fun ttyAltScreenWriter() -> Writer{bool}
   (
     litWriter(ttyEsc() + "[?1049") & charWriter()
-  ).map(lambda (bool show) show ? 'h' : 'l')
+  ).map(lambda (bool altScreen) altScreen ? 'h' : 'l')
 
 fun ttyLitAltScreenWriter(bool altScreen) -> Writer{None}
   litWriter(ttyEsc() + "[?1049" + (altScreen ? 'h' : 'l'))


### PR DESCRIPTION
Now explicitly request a utf8 code-table, so our tty escape
sequences now also work without setting entire windows to
utf8 mode.

Also enable 'ENABLE_VIRTUAL_TERMINAL_INPUT' input processing,
we're not making use of it yet but makes the behavior more consistent
with unix terminals.