### PR TITLE
frontend: SourceTable

### DIFF
--- a/apps/novc/compiler.cpp
+++ b/apps/novc/compiler.cpp
@@ -62,7 +62,8 @@ auto compile(Options options) -> bool {
   if (!frontendOut.isSuccess()) {
     msgHeader(std::cerr) << rang::style::bold << rang::bg::red << "Compilation failed, errors:\n";
     for (auto diagItr = frontendOut.beginDiags(); diagItr != frontendOut.endDiags(); ++diagItr) {
-      std::cerr << *diagItr << '\n';
+      diagItr->print(std::cerr, frontendOut.getSourceTable());
+      std::cerr << '\n';
     }
     std::cerr << rang::style::reset;
     return false;

--- a/apps/novdiag-asm/main.cpp
+++ b/apps/novdiag-asm/main.cpp
@@ -117,8 +117,9 @@ auto runFromSource(
     // Print diagnostics.
     for (auto diagItr = frontendOutput.beginDiags(); diagItr != frontendOutput.endDiags();
          ++diagItr) {
-      std::cerr << rang::style::bold << rang::bg::red << *diagItr << rang::bg::reset << '\n'
-                << rang::style::reset;
+      std::cerr << rang::style::bold << rang::bg::red;
+      diagItr->print(std::cerr, frontendOutput.getSourceTable());
+      std::cerr << rang::bg::reset << '\n' << rang::style::reset;
     }
     return 1;
   }

--- a/apps/novdiag-prog/main.cpp
+++ b/apps/novdiag-prog/main.cpp
@@ -274,12 +274,14 @@ auto run(
     const auto& diag = *diagItr;
     switch (diag.getSeverity()) {
     case frontend::DiagSeverity::Warning:
-      std::cerr << rang::style::bold << rang::bg::yellow << diag << rang::bg::reset << '\n'
-                << rang::style::reset;
+      std::cerr << rang::style::bold << rang::bg::yellow;
+      diag.print(std::cerr, output.getSourceTable());
+      std::cerr << rang::bg::reset << '\n' << rang::style::reset;
       break;
     case frontend::DiagSeverity::Error:
-      std::cerr << rang::style::bold << rang::bg::red << diag << rang::bg::reset << '\n'
-                << rang::style::reset;
+      std::cerr << rang::style::bold << rang::bg::red;
+      diag.print(std::cerr, output.getSourceTable());
+      std::cerr << rang::bg::reset << '\n' << rang::style::reset;
       break;
     }
   }

--- a/apps/novdiag-prog/main.cpp
+++ b/apps/novdiag-prog/main.cpp
@@ -19,6 +19,7 @@ using Duration = std::chrono::duration<double>;
 auto operator<<(std::ostream& out, const Duration& rhs) -> std::ostream&;
 
 auto printExpr(
+    const frontend::SourceTable& srcTable,
     const prog::expr::Node& n,
     std::string prefix = "",
     bool isRoot        = true,
@@ -48,12 +49,18 @@ auto printExpr(
   n.accept(&exprCol);
 
   std::cout << rang::style::bold << exprCol.getFgColor()
-            << input::escapeNonPrintingAsHex(n.toString()) << ' ' << rang::fg::reset
-            << rang::style::dim << n.getType() << rang::style::reset << '\n';
+            << input::escapeNonPrintingAsHex(n.toString()) << rang::fg::reset << " -> "
+            << n.getType();
+
+  if (n.getSourceId().isSet()) {
+    const auto& srcInfo = srcTable[n.getSourceId()];
+    std::cout << rang::style::dim << " (" << srcInfo.getId() << ": " << srcInfo.getStart() << ")";
+  }
+  std::cout << rang::style::reset << '\n';
 
   const auto childCount = n.getChildCount();
   for (auto i = 0U; i < childCount; ++i) {
-    printExpr(n[i], prefix, false, i == (childCount - 1));
+    printExpr(srcTable, n[i], prefix, false, i == (childCount - 1));
   }
 }
 
@@ -186,7 +193,7 @@ auto printConsts(const prog::sym::ConstDeclTable& consts) -> void {
   }
 }
 
-auto printFuncDefs(const prog::Program& prog) -> void {
+auto printFuncDefs(const frontend::SourceTable& srcTable, const prog::Program& prog) -> void {
   std::cout << rang::style::bold << "Function definitions:\n" << rang::style::reset;
   for (auto funcItr = prog.beginFuncDefs(); funcItr != prog.endFuncDefs(); ++funcItr) {
     if (funcItr != prog.beginFuncDefs()) {
@@ -208,11 +215,11 @@ auto printFuncDefs(const prog::Program& prog) -> void {
     }
 
     std::cout << rang::style::italic << "  Body:\n" << rang::style::reset;
-    printExpr(funcDef.getBody(), "   ");
+    printExpr(srcTable, funcDef.getBody(), "   ");
   }
 }
 
-auto printExecStmts(const prog::Program& prog) -> void {
+auto printExecStmts(const frontend::SourceTable& srcTable, const prog::Program& prog) -> void {
   std::cout << rang::style::bold << "Execute statements:\n" << rang::style::reset;
   for (auto execItr = prog.beginExecStmts(); execItr != prog.endExecStmts(); ++execItr) {
     const auto& consts = execItr->getConsts();
@@ -222,12 +229,14 @@ auto printExecStmts(const prog::Program& prog) -> void {
     }
 
     std::cout << rang::style::italic << "  Body:\n" << rang::style::reset;
-    printExpr(execItr->getExpr(), "   ");
+    printExpr(srcTable, execItr->getExpr(), "   ");
     std::cout << '\n';
   }
 }
 
-auto printProgram(const prog::Program& prog, bool includeIntrinsics) -> void {
+auto printProgram(
+    const frontend::SourceTable& srcTable, const prog::Program& prog, bool includeIntrinsics)
+    -> void {
   printTypeDecls(prog);
   std::cout << '\n';
   printFuncDecls(prog, includeIntrinsics);
@@ -237,11 +246,11 @@ auto printProgram(const prog::Program& prog, bool includeIntrinsics) -> void {
   }
   if (prog.beginFuncDefs() != prog.endFuncDefs()) {
     std::cout << '\n';
-    printFuncDefs(prog);
+    printFuncDefs(srcTable, prog);
   }
   if (prog.beginExecStmts() != prog.endExecStmts()) {
     std::cout << '\n';
-    printExecStmts(prog);
+    printExecStmts(srcTable, prog);
   }
 }
 
@@ -288,11 +297,11 @@ auto run(
 
   if (output.isSuccess() && outputProgram) {
     if (optimize) {
-      printProgram(opt::optimize(output.getProg()), includeIntrinsics);
+      printProgram(output.getSourceTable(), opt::optimize(output.getProg()), includeIntrinsics);
     } else if (treeshake) {
-      printProgram(opt::treeshake(output.getProg()), includeIntrinsics);
+      printProgram(output.getSourceTable(), opt::treeshake(output.getProg()), includeIntrinsics);
     } else {
-      printProgram(output.getProg(), includeIntrinsics);
+      printProgram(output.getSourceTable(), output.getProg(), includeIntrinsics);
     }
     std::cout << rang::style::dim << std::string(width, '-') << '\n';
   }

--- a/apps/nove/main.cpp
+++ b/apps/nove/main.cpp
@@ -55,7 +55,8 @@ auto run(
     std::cerr << rang::style::bold << rang::bg::red;
     for (auto diagItr = frontendOutput.beginDiags(); diagItr != frontendOutput.endDiags();
          ++diagItr) {
-      std::cerr << *diagItr << '\n';
+      diagItr->print(std::cerr, frontendOutput.getSourceTable());
+      std::cerr << '\n';
     }
     std::cerr << rang::style::reset;
   }

--- a/include/frontend/diag.hpp
+++ b/include/frontend/diag.hpp
@@ -1,16 +1,15 @@
 #pragma once
 #include "frontend/diag_severity.hpp"
-#include "frontend/source.hpp"
-#include "input/span.hpp"
-#include "input/textpos.hpp"
+#include "prog/sym/source_id.hpp"
 #include <string>
 
 namespace frontend {
 
+class SourceTable;
+
 class Diag final {
-  friend auto warning(const Source& src, std::string msg, input::Span span) -> Diag;
-  friend auto error(const Source& src, std::string msg, input::Span span) -> Diag;
-  friend auto operator<<(std::ostream& out, const Diag& rhs) -> std::ostream&;
+  friend auto warning(std::string msg, prog::sym::SourceId src) -> Diag;
+  friend auto error(std::string msg, prog::sym::SourceId src) -> Diag;
 
 public:
   Diag() = delete;
@@ -20,28 +19,19 @@ public:
 
   [[nodiscard]] auto getSeverity() const noexcept -> DiagSeverity;
   [[nodiscard]] auto getMsg() const noexcept -> std::string;
-  [[nodiscard]] auto getSourcePath() const noexcept -> std::optional<filesystem::path>;
-  [[nodiscard]] auto getSourceStart() const noexcept -> input::TextPos;
-  [[nodiscard]] auto getSourceEnd() const noexcept -> input::TextPos;
+  [[nodiscard]] auto getSrc() const noexcept -> prog::sym::SourceId;
+
+  auto print(std::ostream& stream, const SourceTable& sourceTable) const -> void;
 
 private:
   DiagSeverity m_severity;
   std::string m_msg;
-  std::optional<filesystem::path> m_sourcePath;
-  input::TextPos m_sourceStart;
-  input::TextPos m_sourceEnd;
+  prog::sym::SourceId m_src;
 
-  Diag(
-      DiagSeverity severity,
-      std::string msg,
-      std::optional<filesystem::path> sourcePath,
-      input::TextPos sourceStart,
-      input::TextPos sourceEnd);
+  Diag(DiagSeverity severity, std::string msg, prog::sym::SourceId src);
 };
 
-auto operator<<(std::ostream& out, const Diag& rhs) -> std::ostream&;
-
-auto warning(const Source& src, std::string msg, input::Span span) -> Diag;
-auto error(const Source& src, std::string msg, input::Span span) -> Diag;
+auto warning(std::string msg, prog::sym::SourceId src) -> Diag;
+auto error(std::string msg, prog::sym::SourceId src) -> Diag;
 
 } // namespace frontend

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -1,266 +1,226 @@
 #pragma once
 #include "frontend/diag.hpp"
-#include "frontend/source.hpp"
 #include "parse/node_error.hpp"
+#include "prog/sym/source_id.hpp"
 
 namespace frontend {
 
-[[nodiscard]] auto errUnresolvedImport(const Source& src, const std::string& path, input::Span span)
+[[nodiscard]] auto errUnresolvedImport(prog::sym::SourceId src, const std::string& path) -> Diag;
+
+[[nodiscard]] auto errParseError(prog::sym::SourceId src, const parse::ErrorNode& n) -> Diag;
+
+[[nodiscard]] auto errUnsupportedLiteral(prog::sym::SourceId src, const std::string& name) -> Diag;
+
+[[nodiscard]] auto errTypeAlreadyDeclared(prog::sym::SourceId src, const std::string& name) -> Diag;
+
+[[nodiscard]] auto errTypeTemplateAlreadyDeclared(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 
-[[nodiscard]] auto errParseError(const Source& src, const parse::ErrorNode& n) -> Diag;
+[[nodiscard]] auto errTypeNameIsReserved(prog::sym::SourceId src, const std::string& name) -> Diag;
 
-[[nodiscard]] auto
-errUnsupportedLiteral(const Source& src, const std::string& name, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errTypeAlreadyDeclared(const Source& src, const std::string& name, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errTypeTemplateAlreadyDeclared(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto errTypeNameConflictsWithFunc(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 
 [[nodiscard]] auto
-errTypeNameIsReserved(const Source& src, const std::string& name, input::Span span) -> Diag;
+errDuplicateFieldNameInStruct(prog::sym::SourceId src, const std::string& fieldName) -> Diag;
 
 [[nodiscard]] auto
-errTypeNameConflictsWithFunc(const Source& src, const std::string& name, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errDuplicateFieldNameInStruct(const Source& src, const std::string& fieldName, input::Span span)
+errFieldNameConflictsWithTypeSubstitution(prog::sym::SourceId src, const std::string& fieldName)
     -> Diag;
-
-[[nodiscard]] auto errFieldNameConflictsWithTypeSubstitution(
-    const Source& src, const std::string& fieldName, input::Span span) -> Diag;
 
 [[nodiscard]] auto errCyclicStruct(
-    const Source& src,
-    const std::string& fieldName,
-    const std::string& structName,
-    input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& fieldName, const std::string& structName) -> Diag;
 
-[[nodiscard]] auto
-errFieldNameConflictsWithType(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto errFieldNameConflictsWithType(prog::sym::SourceId src, const std::string& name)
+    -> Diag;
 
 [[nodiscard]] auto errFieldNotFoundOnType(
-    const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
-    -> Diag;
+    prog::sym::SourceId src, const std::string& fieldName, const std::string& typeName) -> Diag;
 
 [[nodiscard]] auto errStaticFieldNotFoundOnType(
-    const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
-    -> Diag;
+    prog::sym::SourceId src, const std::string& fieldName, const std::string& typeName) -> Diag;
 
 [[nodiscard]] auto errDuplicateTypeInUnion(
-    const Source& src,
-    const std::string& typeName,
-    const std::string& substitutedTypeName,
-    input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& typeName, const std::string& substitutedTypeName)
+    -> Diag;
 
-[[nodiscard]] auto errNonUnionIsExpression(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errNonUnionIsExpression(prog::sym::SourceId src) -> Diag;
 
 [[nodiscard]] auto errTypeNotPartOfUnion(
-    const Source& src, const std::string& typeName, const std::string& unionName, input::Span span)
-    -> Diag;
+    prog::sym::SourceId src, const std::string& typeName, const std::string& unionName) -> Diag;
 
-[[nodiscard]] auto errUncheckedAsExpressionWithConst(const Source& src, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errDuplicateEntryNameInEnum(const Source& src, const std::string& entryName, input::Span span)
-    -> Diag;
+[[nodiscard]] auto errUncheckedAsExpressionWithConst(prog::sym::SourceId src) -> Diag;
 
 [[nodiscard]] auto
-errDuplicateEntryValueInEnum(const Source& src, int32_t entryValue, input::Span span) -> Diag;
+errDuplicateEntryNameInEnum(prog::sym::SourceId src, const std::string& entryName) -> Diag;
+
+[[nodiscard]] auto errDuplicateEntryValueInEnum(prog::sym::SourceId src, int32_t entryValue)
+    -> Diag;
 
 [[nodiscard]] auto errValueNotFoundInEnum(
-    const Source& src, const std::string& entryName, const std::string& enumName, input::Span span)
-    -> Diag;
+    prog::sym::SourceId src, const std::string& entryName, const std::string& enumName) -> Diag;
 
 [[nodiscard]] auto errIncorrectReturnTypeInConvFunc(
-    const Source& src, const std::string& name, const std::string& returnedType, input::Span span)
+    prog::sym::SourceId src, const std::string& name, const std::string& returnedType) -> Diag;
+
+[[nodiscard]] auto errNonOverloadableOperator(prog::sym::SourceId src, const std::string& name)
+    -> Diag;
+
+[[nodiscard]] auto errNonPureOperatorOverload(prog::sym::SourceId src) -> Diag;
+
+[[nodiscard]] auto errOperatorOverloadWithoutArgs(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 
 [[nodiscard]] auto
-errNonOverloadableOperator(const Source& src, const std::string& name, input::Span span) -> Diag;
+errTypeParamNameConflictsWithType(prog::sym::SourceId src, const std::string& name) -> Diag;
 
-[[nodiscard]] auto errNonPureOperatorOverload(const Source& src, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errOperatorOverloadWithoutArgs(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto errDuplicateFuncDeclaration(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 
-[[nodiscard]] auto
-errTypeParamNameConflictsWithType(const Source& src, const std::string& name, input::Span span)
-    -> Diag;
-
-[[nodiscard]] auto
-errDuplicateFuncDeclaration(const Source& src, const std::string& name, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errUnableToInferFuncReturnType(const Source& src, const std::string& name, input::Span span)
+[[nodiscard]] auto errUnableToInferFuncReturnType(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 
 [[nodiscard]] auto errUnableToInferReturnTypeOfConversionToTemplatedType(
-    const Source& src, const std::string& name, input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& name) -> Diag;
 
 [[nodiscard]] auto errNonMatchingFuncReturnType(
-    const Source& src,
+    prog::sym::SourceId src,
     const std::string& name,
     const std::string& declaredType,
-    const std::string& returnedType,
-    input::Span span) -> Diag;
+    const std::string& returnedType) -> Diag;
 
 [[nodiscard]] auto errNonMatchingInitializerType(
-    const Source& src,
-    const std::string& declaredType,
-    const std::string& intializerType,
-    input::Span span) -> Diag;
-
-[[nodiscard]] auto errUnableToInferLambdaReturnType(const Source& src, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errConstNameConflictsWithType(const Source& src, const std::string& name, input::Span span) -> Diag;
-
-[[nodiscard]] auto errConstNameConflictsWithTypeSubstitution(
-    const Source& src, const std::string& name, input::Span span) -> Diag;
-
-[[nodiscard]] auto
-errConstNameConflictsWithConst(const Source& src, const std::string& name, input::Span span)
+    prog::sym::SourceId src, const std::string& declaredType, const std::string& intializerType)
     -> Diag;
 
-[[nodiscard]] auto errConstDeclareNotSupported(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errUnableToInferLambdaReturnType(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errUndeclaredType(
-    const Source& src, const std::string& name, unsigned int typeParams, input::Span span) -> Diag;
+[[nodiscard]] auto errConstNameConflictsWithType(prog::sym::SourceId src, const std::string& name)
+    -> Diag;
+
+[[nodiscard]] auto
+errConstNameConflictsWithTypeSubstitution(prog::sym::SourceId src, const std::string& name) -> Diag;
+
+[[nodiscard]] auto errConstNameConflictsWithConst(prog::sym::SourceId src, const std::string& name)
+    -> Diag;
+
+[[nodiscard]] auto errConstDeclareNotSupported(prog::sym::SourceId src) -> Diag;
+
+[[nodiscard]] auto
+errUndeclaredType(prog::sym::SourceId src, const std::string& name, unsigned int typeParams)
+    -> Diag;
 
 [[nodiscard]] auto errUndeclaredTypeOrConversion(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag;
 
 [[nodiscard]] auto errNoTypeOrConversionFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag;
+
+[[nodiscard]] auto errTypeParamOnSubstitutionType(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 
-[[nodiscard]] auto
-errTypeParamOnSubstitutionType(const Source& src, const std::string& name, input::Span span)
-    -> Diag;
+[[nodiscard]] auto errInvalidTypeInstantiation(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errInvalidTypeInstantiation(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errUndeclaredConst(prog::sym::SourceId src, const std::string& name) -> Diag;
 
-[[nodiscard]] auto errUndeclaredConst(const Source& src, const std::string& name, input::Span span)
-    -> Diag;
-
-[[nodiscard]] auto
-errUninitializedConst(const Source& src, const std::string& name, input::Span span) -> Diag;
+[[nodiscard]] auto errUninitializedConst(prog::sym::SourceId src, const std::string& name) -> Diag;
 
 [[nodiscard]] auto errUndeclaredPureFunc(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag;
 
 [[nodiscard]] auto errUndeclaredAction(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag;
 
 [[nodiscard]] auto errUndeclaredFuncOrAction(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag;
 
 [[nodiscard]] auto errUnknownIntrinsic(
-    const Source& src,
+    prog::sym::SourceId src,
     const std::string& name,
     bool pureOnly,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag;
+    const std::vector<std::string>& argTypes) -> Diag;
 
-[[nodiscard]] auto errPureFuncInfRecursion(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errPureFuncInfRecursion(prog::sym::SourceId src) -> Diag;
 
 [[nodiscard]] auto errNoPureFuncFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag;
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag;
 
 [[nodiscard]] auto errNoActionFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag;
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag;
 
 [[nodiscard]] auto errNoFuncOrActionFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag;
-
-[[nodiscard]] auto errNoTypeParamsProvidedToTemplateFunction(
-    const Source& src, const std::string& name, input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag;
 
 [[nodiscard]] auto
-errAmbiguousFunction(const Source& src, const std::string& name, input::Span span) -> Diag;
+errNoTypeParamsProvidedToTemplateFunction(prog::sym::SourceId src, const std::string& name) -> Diag;
+
+[[nodiscard]] auto errAmbiguousFunction(prog::sym::SourceId src, const std::string& name) -> Diag;
 
 [[nodiscard]] auto errAmbiguousTemplateFunction(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag;
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag;
 
-[[nodiscard]] auto errIllegalDelegateCall(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errIllegalDelegateCall(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errIncorrectArgsToDelegate(const Source& src, input::Span span) -> Diag;
-
-[[nodiscard]] auto errUndeclaredCallOperator(
-    const Source& src, const std::vector<std::string>& argTypes, input::Span span) -> Diag;
-
-[[nodiscard]] auto errUndeclaredIndexOperator(
-    const Source& src, const std::vector<std::string>& argTypes, input::Span span) -> Diag;
-
-[[nodiscard]] auto errInvalidFuncInstantiation(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errIncorrectArgsToDelegate(prog::sym::SourceId src) -> Diag;
 
 [[nodiscard]] auto
-errUnsupportedOperator(const Source& src, const std::string& name, input::Span span) -> Diag;
+errUndeclaredCallOperator(prog::sym::SourceId src, const std::vector<std::string>& argTypes)
+    -> Diag;
+
+[[nodiscard]] auto
+errUndeclaredIndexOperator(prog::sym::SourceId src, const std::vector<std::string>& argTypes)
+    -> Diag;
+
+[[nodiscard]] auto errInvalidFuncInstantiation(prog::sym::SourceId src) -> Diag;
+
+[[nodiscard]] auto errUnsupportedOperator(prog::sym::SourceId src, const std::string& name) -> Diag;
 
 [[nodiscard]] auto errUndeclaredUnaryOperator(
-    const Source& src, const std::string& name, const std::string& type, input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& name, const std::string& type) -> Diag;
 
 [[nodiscard]] auto errUndeclaredBinOperator(
-    const Source& src,
+    prog::sym::SourceId src,
     const std::string& name,
     const std::string& lhsType,
-    const std::string& rhsType,
-    input::Span span) -> Diag;
+    const std::string& rhsType) -> Diag;
 
-[[nodiscard]] auto errBranchesHaveNoCommonType(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errBranchesHaveNoCommonType(prog::sym::SourceId src) -> Diag;
 
 [[nodiscard]] auto errNoImplicitConversionFound(
-    const Source& src, const std::string& from, const std::string& to, input::Span span) -> Diag;
+    prog::sym::SourceId src, const std::string& from, const std::string& to) -> Diag;
 
-[[nodiscard]] auto errNonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errNonExhaustiveSwitchWithoutElse(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errNonPureConversion(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errNonPureConversion(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errForkedNonUserFunc(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errForkedNonUserFunc(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errLazyNonUserFunc(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errLazyNonUserFunc(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errForkedSelfCall(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errForkedSelfCall(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errLazySelfCall(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errLazySelfCall(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errSelfCallInNonFunc(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errSelfCallInNonFunc(prog::sym::SourceId src) -> Diag;
 
-[[nodiscard]] auto errSelfCallWithoutInferredRetType(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errSelfCallWithoutInferredRetType(prog::sym::SourceId src) -> Diag;
 
 [[nodiscard]] auto errIncorrectNumArgsInSelfCall(
-    const Source& src, unsigned int expectedNumArgs, unsigned int actualNumArgs, input::Span span)
-    -> Diag;
-
-[[nodiscard]] auto errInvalidFailIntrinsicCall(
-    const Source& src, unsigned int typeParams, unsigned int argCount, input::Span span) -> Diag;
-
-[[nodiscard]] auto errIntrinsicFuncLiteral(const Source& src, input::Span span) -> Diag;
+    prog::sym::SourceId src, unsigned int expectedNumArgs, unsigned int actualNumArgs) -> Diag;
 
 [[nodiscard]] auto
-errUnsupportedArgInitializer(const Source& src, const std::string& name, input::Span span) -> Diag;
+errInvalidFailIntrinsicCall(prog::sym::SourceId src, unsigned int typeParams, unsigned int argCount)
+    -> Diag;
 
-[[nodiscard]] auto errNonOptArgFollowingOpt(const Source& src, input::Span span) -> Diag;
+[[nodiscard]] auto errIntrinsicFuncLiteral(prog::sym::SourceId src) -> Diag;
+
+[[nodiscard]] auto errUnsupportedArgInitializer(prog::sym::SourceId src, const std::string& name)
+    -> Diag;
+
+[[nodiscard]] auto errNonOptArgFollowingOpt(prog::sym::SourceId src) -> Diag;
 
 } // namespace frontend

--- a/include/frontend/output.hpp
+++ b/include/frontend/output.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "frontend/diag.hpp"
 #include "prog/program.hpp"
+#include "source_table.hpp"
 #include <forward_list>
 #include <utility>
 #include <vector>
@@ -11,6 +12,7 @@ class Output final {
   friend auto buildOutput(
       std::unique_ptr<prog::Program> prog,
       std::forward_list<Source> importedSources,
+      SourceTable sourceTable,
       std::vector<Diag> diags) -> Output;
 
 public:
@@ -21,6 +23,7 @@ public:
   [[nodiscard]] auto isSuccess() const noexcept -> bool;
   [[nodiscard]] auto getProg() const noexcept -> const prog::Program&;
   [[nodiscard]] auto getImportedSources() const noexcept -> const std::forward_list<Source>&;
+  [[nodiscard]] auto getSourceTable() const noexcept -> const SourceTable&;
 
   [[nodiscard]] auto beginDiags() const noexcept -> DiagIterator;
   [[nodiscard]] auto endDiags() const noexcept -> DiagIterator;
@@ -28,17 +31,14 @@ public:
 private:
   std::unique_ptr<prog::Program> m_prog;
   std::forward_list<Source> m_importedSources;
+  SourceTable m_sourceTable;
   std::vector<Diag> m_diags;
 
   Output(
       std::unique_ptr<prog::Program> prog,
       std::forward_list<Source> importedSources,
+      SourceTable sourceTable,
       std::vector<Diag> diags);
 };
-
-auto buildOutput(
-    std::unique_ptr<prog::Program> prog,
-    std::forward_list<Source> importedSources,
-    std::vector<Diag> diags) -> Output;
 
 } // namespace frontend

--- a/include/frontend/source_table.hpp
+++ b/include/frontend/source_table.hpp
@@ -15,7 +15,9 @@ struct SourceInfo {
   const Source* source;
   input::Span span;
 
-  [[nodiscard]] auto getPath() const noexcept -> std::optional<filesystem::path> {
+  [[nodiscard]] auto getId() const noexcept -> const std::string& { return source->getId(); }
+
+  [[nodiscard]] auto getPath() const noexcept -> const std::optional<filesystem::path>& {
     return source->getPath();
   }
 

--- a/include/frontend/source_table.hpp
+++ b/include/frontend/source_table.hpp
@@ -2,11 +2,11 @@
 #include "input/span.hpp"
 #include "prog/sym/source_id.hpp"
 #include "prog/sym/source_id_hasher.hpp"
+#include "source.hpp"
 #include <unordered_map>
 
 namespace frontend {
 
-class Source;
 namespace internal {
 class SourceTableBuilder;
 }
@@ -14,6 +14,18 @@ class SourceTableBuilder;
 struct SourceInfo {
   const Source* source;
   input::Span span;
+
+  [[nodiscard]] auto getPath() const noexcept -> std::optional<filesystem::path> {
+    return source->getPath();
+  }
+
+  [[nodiscard]] auto getStart() const noexcept -> input::TextPos {
+    return source->getTextPos(span.getStart());
+  }
+
+  [[nodiscard]] auto getEnd() const noexcept -> input::TextPos {
+    return source->getTextPos(span.getStart());
+  }
 };
 
 class SourceTable final {

--- a/include/frontend/source_table.hpp
+++ b/include/frontend/source_table.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include "input/span.hpp"
+#include "prog/sym/source_id.hpp"
+#include "prog/sym/source_id_hasher.hpp"
+#include <unordered_map>
+
+namespace frontend {
+
+class Source;
+namespace internal {
+class SourceTableBuilder;
+}
+
+struct SourceInfo {
+  const Source* source;
+  input::Span span;
+};
+
+class SourceTable final {
+  friend class internal::SourceTableBuilder;
+
+public:
+  SourceTable()                           = delete;
+  SourceTable(const SourceTable& rhs)     = delete;
+  SourceTable(SourceTable&& rhs) noexcept = default;
+  ~SourceTable()                          = default;
+
+  auto operator=(const SourceTable& rhs) -> SourceTable& = delete;
+  auto operator=(SourceTable&& rhs) noexcept -> SourceTable& = default;
+
+  [[nodiscard]] auto operator[](prog::sym::SourceId source) const -> SourceInfo;
+
+private:
+  using SrcId       = prog::sym::SourceId;
+  using SrcIdHasher = prog::sym::SourceIdHasher;
+  using Map         = std::unordered_map<SrcId, SourceInfo, SrcIdHasher>;
+
+  Map m_map;
+
+  SourceTable(Map map);
+};
+
+} // namespace frontend

--- a/include/prog/expr/node.hpp
+++ b/include/prog/expr/node.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "prog/expr/node_kind.hpp"
 #include "prog/expr/node_visitor.hpp"
+#include "prog/sym/source_id.hpp"
 #include "prog/sym/type_id.hpp"
 #include <iostream>
 #include <memory>
@@ -26,11 +27,14 @@ public:
   virtual auto operator!=(const Node& rhs) const noexcept -> bool = 0;
 
   [[nodiscard]] auto getKind() const -> NodeKind;
+  [[nodiscard]] auto getSourceId() const -> sym::SourceId;
 
   [[nodiscard]] virtual auto operator[](unsigned int) const -> const Node& = 0;
   [[nodiscard]] virtual auto getChildCount() const -> unsigned int         = 0;
   [[nodiscard]] virtual auto getType() const noexcept -> sym::TypeId       = 0;
   [[nodiscard]] virtual auto toString() const -> std::string               = 0;
+
+  auto setSourceId(sym::SourceId source) -> void;
 
   [[nodiscard]] virtual auto clone(Rewriter* rewriter) const -> std::unique_ptr<Node> = 0;
 
@@ -50,6 +54,7 @@ protected:
 
 private:
   NodeKind m_kind;
+  sym::SourceId m_sourceId;
 };
 
 using NodePtr = std::unique_ptr<Node>;

--- a/include/prog/sym/source_id.hpp
+++ b/include/prog/sym/source_id.hpp
@@ -22,6 +22,7 @@ public:
   auto operator==(const SourceId& rhs) const noexcept -> bool;
   auto operator!=(const SourceId& rhs) const noexcept -> bool;
 
+  [[nodiscard]] auto isSet() const noexcept -> bool;
   [[nodiscard]] auto getNum() const noexcept -> unsigned int;
 
 private:

--- a/include/prog/sym/source_id.hpp
+++ b/include/prog/sym/source_id.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <iostream>
+
+namespace prog::sym {
+
+// Opaque identifier for a region of source-code.
+//
+// Usefull to attach knowledge about the source location to program expressions. They are opaque
+// identifiers so as much information can be attached to program as desired by keeping seperate
+// tables that map SourceId's.
+//
+// Note: 0 is a special value to indicate that no source-id is present.
+class SourceId final {
+  friend class SourceIdHasher;
+  friend auto operator<<(std::ostream& out, const SourceId& rhs) -> std::ostream&;
+
+public:
+  [[nodiscard]] static auto none() noexcept -> SourceId;
+
+  explicit SourceId(unsigned int id);
+
+  auto operator==(const SourceId& rhs) const noexcept -> bool;
+  auto operator!=(const SourceId& rhs) const noexcept -> bool;
+
+  [[nodiscard]] auto getNum() const noexcept -> unsigned int;
+
+private:
+  unsigned int m_id;
+};
+
+auto operator<<(std::ostream& out, const SourceId& rhs) -> std::ostream&;
+
+} // namespace prog::sym

--- a/include/prog/sym/source_id_hasher.hpp
+++ b/include/prog/sym/source_id_hasher.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "prog/sym/source_id.hpp"
+
+namespace prog::sym {
+
+// Generate a hash for a SourceId.
+class SourceIdHasher final {
+public:
+  auto operator()(const SourceId& id) const -> std::size_t;
+};
+
+} // namespace prog::sym

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -178,6 +178,7 @@ add_library(frontend STATIC
   frontend/internal/lazy_table.cpp
   frontend/internal/get_expr.cpp
   frontend/internal/import_sources.cpp
+  frontend/internal/source_table_builder.cpp
   frontend/internal/struct_template.cpp
   frontend/internal/type_template_base.cpp
   frontend/internal/type_template_table.cpp
@@ -198,6 +199,7 @@ add_library(frontend STATIC
   frontend/diag_severity.cpp
   frontend/diag.cpp
   frontend/output.cpp
+  frontend/source_table.cpp
   frontend/source.cpp)
 target_compile_features(frontend PRIVATE cxx_std_17)
 if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,8 @@ add_library(prog STATIC
   prog/sym/func_id.cpp
   prog/sym/future_def.cpp
   prog/sym/lazy_def.cpp
+  prog/sym/source_id_hasher.cpp
+  prog/sym/source_id.cpp
   prog/sym/struct_def.cpp
   prog/sym/type_decl_table.cpp
   prog/sym/type_decl.cpp

--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -64,7 +64,8 @@ auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchP
 
   // Resolve all imports.
   auto importedSources = std::forward_list<Source>{};
-  auto import          = internal::ImportSources{mainSrc, searchPaths, &importedSources, &diags};
+  auto import =
+      internal::ImportSources{mainSrc, sourceTableBuilder, searchPaths, &importedSources, &diags};
   mainSrc.accept(&import);
   auto allContexts = std::vector<internal::Context>{makeCtx(mainSrc)};
   for (const auto& importSrc : importedSources) {

--- a/src/frontend/diag.cpp
+++ b/src/frontend/diag.cpp
@@ -1,61 +1,42 @@
 #include "frontend/diag.hpp"
+#include "frontend/source_table.hpp"
 #include <utility>
 
 namespace frontend {
 
-Diag::Diag(
-    DiagSeverity severity,
-    std::string msg,
-    std::optional<filesystem::path> sourcePath,
-    input::TextPos sourceStart,
-    input::TextPos sourceEnd) :
-    m_severity{severity},
-    m_msg{std::move(msg)},
-    m_sourcePath{std::move(sourcePath)},
-    m_sourceStart{sourceStart},
-    m_sourceEnd{sourceEnd} {};
-
+Diag::Diag(DiagSeverity severity, std::string msg, prog::sym::SourceId src) :
+    m_severity{severity}, m_msg{std::move(msg)}, m_src{src} {};
 auto Diag::operator==(const Diag& rhs) const noexcept -> bool {
-  return m_severity == rhs.m_severity && m_msg == rhs.m_msg && m_sourcePath == rhs.m_sourcePath &&
-      m_sourceStart == rhs.m_sourceStart && m_sourceEnd == rhs.m_sourceEnd;
+  return m_severity == rhs.m_severity && m_msg == rhs.m_msg;
 }
 
 auto Diag::operator!=(const Diag& rhs) const noexcept -> bool { return !Diag::operator==(rhs); }
-
 auto Diag::getSeverity() const noexcept -> DiagSeverity { return m_severity; }
 
 auto Diag::getMsg() const noexcept -> std::string { return m_msg; }
 
-auto Diag::getSourcePath() const noexcept -> std::optional<filesystem::path> {
-  return m_sourcePath;
-}
+auto Diag::getSrc() const noexcept -> prog::sym::SourceId { return m_src; }
 
-auto Diag::getSourceStart() const noexcept -> input::TextPos { return m_sourceStart; }
+auto Diag::print(std::ostream& stream, const SourceTable& sourceTable) const -> void {
+  const auto& sourceInfo = sourceTable[m_src];
 
-auto Diag::getSourceEnd() const noexcept -> input::TextPos { return m_sourceEnd; }
+  const auto id        = sourceInfo.getPath() ? sourceInfo.getPath()->string() : "inline";
+  const auto startLine = sourceInfo.getStart().getLine();
+  const auto startCol  = sourceInfo.getStart().getCol();
+  const auto endLine   = sourceInfo.getEnd().getLine();
+  const auto endCol    = sourceInfo.getEnd().getCol() + 1; // + 1 to include the last char.
 
-auto operator<<(std::ostream& out, const Diag& rhs) -> std::ostream& {
-  const auto id        = rhs.m_sourcePath ? rhs.m_sourcePath->string() : "inline";
-  const auto startLine = rhs.m_sourceStart.getLine();
-  const auto startCol  = rhs.m_sourceStart.getCol();
-  const auto endLine   = rhs.m_sourceEnd.getLine();
-  const auto endCol = rhs.m_sourceEnd.getCol() + 1; // + 1 because we want to include the last char.
-
-  return out << id << ':' << startLine << ':' << startCol << '-' << endLine << ':' << endCol << ": "
-             << rhs.getSeverity() << ": " << rhs.m_msg;
+  stream << id << ':' << startLine << ':' << startCol << '-' << endLine << ':' << endCol << ": "
+         << m_severity << ": " << m_msg;
 }
 
 // Factories.
-auto warning(const Source& src, std::string msg, input::Span span) -> Diag {
-  const auto srcStart = src.getTextPos(span.getStart());
-  const auto srcEnd   = src.getTextPos(span.getEnd());
-  return Diag{DiagSeverity::Warning, std::move(msg), src.getId(), srcStart, srcEnd};
+auto warning(std::string msg, prog::sym::SourceId src) -> Diag {
+  return Diag{DiagSeverity::Warning, std::move(msg), src};
 }
 
-auto error(const Source& src, std::string msg, input::Span span) -> Diag {
-  const auto srcStart = src.getTextPos(span.getStart());
-  const auto srcEnd   = src.getTextPos(span.getEnd());
-  return Diag{DiagSeverity::Error, std::move(msg), src.getPath(), srcStart, srcEnd};
+auto error(std::string msg, prog::sym::SourceId src) -> Diag {
+  return Diag{DiagSeverity::Error, std::move(msg), src};
 }
 
 } // namespace frontend

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -3,272 +3,247 @@
 
 namespace frontend {
 
-auto errUnresolvedImport(const Source& src, const std::string& path, input::Span span) -> Diag {
+auto errUnresolvedImport(prog::sym::SourceId src, const std::string& path) -> Diag {
   std::ostringstream oss;
   oss << "Unable to resolve import '" << path << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errParseError(const Source& src, const parse::ErrorNode& n) -> Diag {
+auto errParseError(prog::sym::SourceId src, const parse::ErrorNode& n) -> Diag {
   std::ostringstream oss;
   oss << n.getMessage();
-  return error(src, oss.str(), n.getSpan());
+  return error(oss.str(), src);
 }
 
-auto errUnsupportedLiteral(const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errUnsupportedLiteral(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Unsupported literal: " << name;
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errTypeAlreadyDeclared(const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errTypeAlreadyDeclared(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Type name '" << name << "' conflicts with an previously declared type";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errTypeTemplateAlreadyDeclared(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errTypeTemplateAlreadyDeclared(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Type name '" << name << "' conflicts with an previously declared type template";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errTypeNameIsReserved(const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errTypeNameIsReserved(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Type name '" << name << "' is a reserved type-name that cannot be used for user types";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errTypeNameConflictsWithFunc(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errTypeNameConflictsWithFunc(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Type name '" << name << "' conflicts with a build-in function with the same name";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errDuplicateFieldNameInStruct(
-    const Source& src, const std::string& fieldName, input::Span span) -> Diag {
+auto errDuplicateFieldNameInStruct(prog::sym::SourceId src, const std::string& fieldName) -> Diag {
   std::ostringstream oss;
   oss << "Field name '" << fieldName << "' conflicts with another field with the same name";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errFieldNameConflictsWithTypeSubstitution(
-    const Source& src, const std::string& fieldName, input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& fieldName) -> Diag {
   std::ostringstream oss;
   oss << "Field name '" << fieldName << "' conflicts with a type-substitution with the same name";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errCyclicStruct(
-    const Source& src,
-    const std::string& fieldName,
-    const std::string& structName,
-    input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& fieldName, const std::string& structName) -> Diag {
   std::ostringstream oss;
   oss << "Field '" << fieldName << "' causes struct '" << structName << "' to become cyclic";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errFieldNameConflictsWithType(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errFieldNameConflictsWithType(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Field name '" << name << "' conflicts with a type with the same name";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errFieldNotFoundOnType(
-    const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& fieldName, const std::string& typeName) -> Diag {
   std::ostringstream oss;
   oss << "Type '" << typeName << "' has no field named '" << fieldName << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errStaticFieldNotFoundOnType(
-    const Source& src, const std::string& fieldName, const std::string& typeName, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& fieldName, const std::string& typeName) -> Diag {
   std::ostringstream oss;
   oss << "Type '" << typeName << "' has no static field named '" << fieldName << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errDuplicateTypeInUnion(
-    const Source& src,
-    const std::string& typeName,
-    const std::string& substitutedTypeName,
-    input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& typeName, const std::string& substitutedTypeName)
+    -> Diag {
   std::ostringstream oss;
   oss << "Type '" << typeName << '\'';
   if (typeName != substitutedTypeName) {
     oss << " ('" << substitutedTypeName << "')";
   }
   oss << " is already part of this union";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errNonUnionIsExpression(const Source& src, input::Span span) -> Diag {
+auto errNonUnionIsExpression(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Left-hand-side of 'is' expression has to be a union type";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errTypeNotPartOfUnion(
-    const Source& src, const std::string& typeName, const std::string& unionName, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& typeName, const std::string& unionName) -> Diag {
   std::ostringstream oss;
   oss << "Type '" << typeName << "' is not part of the union '" << unionName << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUncheckedAsExpressionWithConst(const Source& src, input::Span span) -> Diag {
+auto errUncheckedAsExpressionWithConst(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Unchecked 'as' expression with constant declaration, either use in a checked context or "
          "discard '_' the const";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errDuplicateEntryNameInEnum(const Source& src, const std::string& entryName, input::Span span)
-    -> Diag {
+auto errDuplicateEntryNameInEnum(prog::sym::SourceId src, const std::string& entryName) -> Diag {
   std::ostringstream oss;
   oss << "Name '" << entryName << "' conflicts with a previous entry in the same enum";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errDuplicateEntryValueInEnum(const Source& src, int32_t entryValue, input::Span span) -> Diag {
+auto errDuplicateEntryValueInEnum(prog::sym::SourceId src, int32_t entryValue) -> Diag {
   std::ostringstream oss;
   oss << "Value '" << entryValue << "' conflicts with a previous entry in the same enum";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errValueNotFoundInEnum(
-    const Source& src, const std::string& entryName, const std::string& enumName, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& entryName, const std::string& enumName) -> Diag {
   std::ostringstream oss;
   oss << "Enum '" << enumName << "' does not contain '" << entryName << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errIncorrectReturnTypeInConvFunc(
-    const Source& src, const std::string& name, const std::string& returnedType, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& name, const std::string& returnedType) -> Diag {
   std::ostringstream oss;
   oss << "Conversion function '" << name << "' returns incorrect type '" << returnedType << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errNonOverloadableOperator(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errNonOverloadableOperator(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Operator '" << name << "' does not support overloading";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errNonPureOperatorOverload(const Source& src, input::Span span) -> Diag {
+auto errNonPureOperatorOverload(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Operator overloads have to be pure ('fun' instead of 'act')";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errOperatorOverloadWithoutArgs(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errOperatorOverloadWithoutArgs(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Operator '" << name << "' cannot be defined without arguments";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errTypeParamNameConflictsWithType(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errTypeParamNameConflictsWithType(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Type parameter name '" << name << "' conflicts with a type with the same name";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errDuplicateFuncDeclaration(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errDuplicateFuncDeclaration(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Declaration of function '" << name
       << "' conflicts with an existing function with the same name and inputs";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUnableToInferFuncReturnType(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errUnableToInferFuncReturnType(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Unable to infer return-type of function '" << name
       << "', please specify return-type using the '-> [TYPE]' syntax";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUnableToInferReturnTypeOfConversionToTemplatedType(
-    const Source& src, const std::string& name, input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Unable to infer return-type of conversion '" << name
       << "' to templated type, please specify return-type using the '-> [TYPE]' syntax";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errNonMatchingFuncReturnType(
-    const Source& src,
+    prog::sym::SourceId src,
     const std::string& name,
     const std::string& declaredType,
-    const std::string& returnedType,
-    input::Span span) -> Diag {
+    const std::string& returnedType) -> Diag {
   std::ostringstream oss;
   oss << "Function '" << name << "' returns value of type '" << returnedType
       << "' but its declared to return a value of type '" << declaredType << "'";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errNonMatchingInitializerType(
-    const Source& src,
-    const std::string& declaredType,
-    const std::string& initializerType,
-    input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& declaredType, const std::string& initializerType)
+    -> Diag {
   std::ostringstream oss;
   oss << "Initializer returns value of type '" << initializerType
       << "' which is incompatible with the declared type '" << declaredType << "'";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errConstNameConflictsWithTypeSubstitution(
-    const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errConstNameConflictsWithTypeSubstitution(prog::sym::SourceId src, const std::string& name)
+    -> Diag {
   std::ostringstream oss;
   oss << "Constant name '" << name << "' conflicts with a type-substitution with the same name";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUnableToInferLambdaReturnType(const Source& src, input::Span span) -> Diag {
+auto errUnableToInferLambdaReturnType(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Unable to infer return-type of lambda, please specify return-type using the '-> [TYPE]' "
          "syntax";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errConstNameConflictsWithType(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errConstNameConflictsWithType(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Constant name '" << name << "' conflicts with a type with the same name";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errConstNameConflictsWithConst(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errConstNameConflictsWithConst(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Constant name '" << name
       << "' conflicts with an already declared constant in the same scope";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errConstDeclareNotSupported(const Source& src, input::Span span) -> Diag {
+auto errConstDeclareNotSupported(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Declaring constants is not supported in this context";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUndeclaredType(
-    const Source& src, const std::string& name, unsigned int typeParams, input::Span span) -> Diag {
+auto errUndeclaredType(prog::sym::SourceId src, const std::string& name, unsigned int typeParams)
+    -> Diag {
   std::ostringstream oss;
   oss << "Unknown type: '" << name << '\'';
   if (typeParams == 0) {
@@ -276,14 +251,12 @@ auto errUndeclaredType(
   } else {
     oss << " with '" << typeParams << "' type parameters";
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUndeclaredTypeOrConversion(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag {
   std::ostringstream oss;
   if (argTypes.empty()) {
     oss << "No type or conversion '" << name << "' has been declared without any arguments";
@@ -296,48 +269,44 @@ auto errUndeclaredTypeOrConversion(
       oss << '\'' << argTypes[i] << '\'';
     }
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errNoTypeOrConversionFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag {
   std::ostringstream oss;
   oss << "No templated type or conversion '" << name << "' has been declared with '"
       << templateParamCount << "' type parameters";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errTypeParamOnSubstitutionType(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errTypeParamOnSubstitutionType(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Type parameters cannot be applied to substitution type: '" << name << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errInvalidTypeInstantiation(const Source& src, input::Span span) -> Diag {
+auto errInvalidTypeInstantiation(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "One or more errors occurred in type template instantiation";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUndeclaredConst(const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errUndeclaredConst(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "No constant named '" << name << "' has been declared in the current scope";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUninitializedConst(const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errUninitializedConst(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Constant '" << name << "' is not initialized at point of access";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUndeclaredPureFunc(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag {
   std::ostringstream oss;
   if (argTypes.empty()) {
     oss << "No overload for a pure function called: '" << name
@@ -352,14 +321,12 @@ auto errUndeclaredPureFunc(
       oss << '\'' << argTypes[i] << '\'';
     }
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUndeclaredAction(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag {
   std::ostringstream oss;
   if (argTypes.empty()) {
     oss << "No overload for an action named '" << name
@@ -374,14 +341,12 @@ auto errUndeclaredAction(
       oss << '\'' << argTypes[i] << '\'';
     }
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUndeclaredFuncOrAction(
-    const Source& src,
-    const std::string& name,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& name, const std::vector<std::string>& argTypes)
+    -> Diag {
   std::ostringstream oss;
   if (argTypes.empty()) {
     oss << "No overload for a function or action called: '" << name
@@ -396,15 +361,14 @@ auto errUndeclaredFuncOrAction(
       oss << '\'' << argTypes[i] << '\'';
     }
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUnknownIntrinsic(
-    const Source& src,
+    prog::sym::SourceId src,
     const std::string& name,
     bool pureOnly,
-    const std::vector<std::string>& argTypes,
-    input::Span span) -> Diag {
+    const std::vector<std::string>& argTypes) -> Diag {
   std::ostringstream oss;
   oss << "No " << (pureOnly ? "pure " : "") << "compiler intrinsic called: '" << name << "' ";
   if (argTypes.empty()) {
@@ -418,78 +382,74 @@ auto errUnknownIntrinsic(
       oss << '\'' << argTypes[i] << '\'';
     }
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errPureFuncInfRecursion(const Source& src, input::Span span) -> Diag {
+auto errPureFuncInfRecursion(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Pure function recurses infinitely";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errNoPureFuncFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag {
   std::ostringstream oss;
   oss << "No templated pure function '" << name << "' has been declared with '"
       << templateParamCount << "' type parameters";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errNoActionFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag {
   std::ostringstream oss;
   oss << "No templated action '" << name << "' has been declared with '" << templateParamCount
       << "' type parameters";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errNoFuncOrActionFoundToInstantiate(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag {
   std::ostringstream oss;
   oss << "No templated function or action '" << name << "' has been declared with '"
       << templateParamCount << "' type parameters";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errNoTypeParamsProvidedToTemplateFunction(
-    const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errNoTypeParamsProvidedToTemplateFunction(prog::sym::SourceId src, const std::string& name)
+    -> Diag {
   std::ostringstream oss;
   oss << "No type parameters provided to function template '" << name << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errAmbiguousFunction(const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errAmbiguousFunction(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Ambiguous function, multiple functions named '" << name << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errAmbiguousTemplateFunction(
-    const Source& src, const std::string& name, unsigned int templateParamCount, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, const std::string& name, unsigned int templateParamCount) -> Diag {
   std::ostringstream oss;
   oss << "Ambiguous function, multiple templated functions named '" << name << "' with '"
       << templateParamCount << "' type parameters";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errIllegalDelegateCall(const Source& src, input::Span span) -> Diag {
+auto errIllegalDelegateCall(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Cannot invoke the delegate, action's cannot be called from pure functions";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errIncorrectArgsToDelegate(const Source& src, input::Span span) -> Diag {
+auto errIncorrectArgsToDelegate(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Incorrect arguments provided to delegate";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUndeclaredCallOperator(
-    const Source& src, const std::vector<std::string>& argTypes, input::Span span) -> Diag {
+auto errUndeclaredCallOperator(prog::sym::SourceId src, const std::vector<std::string>& argTypes)
+    -> Diag {
   std::ostringstream oss;
   oss << "No overload for the call operator '()' has been declared with argument types: ";
   for (auto i = 0U; i < argTypes.size(); ++i) {
@@ -498,11 +458,11 @@ auto errUndeclaredCallOperator(
     }
     oss << '\'' << argTypes[i] << '\'';
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUndeclaredIndexOperator(
-    const Source& src, const std::vector<std::string>& argTypes, input::Span span) -> Diag {
+auto errUndeclaredIndexOperator(prog::sym::SourceId src, const std::vector<std::string>& argTypes)
+    -> Diag {
   std::ostringstream oss;
   oss << "No overload for the index operator '[]' has been declared with argument types: ";
   for (auto i = 0U; i < argTypes.size(); ++i) {
@@ -511,113 +471,111 @@ auto errUndeclaredIndexOperator(
     }
     oss << '\'' << argTypes[i] << '\'';
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errInvalidFuncInstantiation(const Source& src, input::Span span) -> Diag {
+auto errInvalidFuncInstantiation(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "One or more errors occurred in function template instantiation";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUnsupportedOperator(const Source& src, const std::string& name, input::Span span) -> Diag {
+auto errUnsupportedOperator(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Unsupported operator '" << name << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUndeclaredUnaryOperator(
-    const Source& src, const std::string& name, const std::string& type, input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& name, const std::string& type) -> Diag {
   std::ostringstream oss;
   oss << "No overload for unary operator '" << name << "' has been declared for type: '" << type
       << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errUndeclaredBinOperator(
-    const Source& src,
+    prog::sym::SourceId src,
     const std::string& name,
     const std::string& lhsType,
-    const std::string& rhsType,
-    input::Span span) -> Diag {
+    const std::string& rhsType) -> Diag {
   std::ostringstream oss;
   oss << "No overload for binary operator '" << name << "' has been declared for types: '"
       << lhsType << "' and '" << rhsType << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errBranchesHaveNoCommonType(const Source& src, input::Span span) -> Diag {
+auto errBranchesHaveNoCommonType(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Branches have no common type they are convertable to";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errNoImplicitConversionFound(
-    const Source& src, const std::string& from, const std::string& to, input::Span span) -> Diag {
+    prog::sym::SourceId src, const std::string& from, const std::string& to) -> Diag {
   std::ostringstream oss;
   oss << "No implicit conversion found from '" << from << "' to '" << to << '\'';
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errNonExhaustiveSwitchWithoutElse(const Source& src, input::Span span) -> Diag {
+auto errNonExhaustiveSwitchWithoutElse(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Switch expression is missing an 'else' branch and cannot be guaranteed to be exhaustive";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errNonPureConversion(const Source& src, input::Span span) -> Diag {
+auto errNonPureConversion(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Type conversion has to be pure ('fun' instead of 'act')";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errForkedNonUserFunc(const Source& src, input::Span span) -> Diag {
+auto errForkedNonUserFunc(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Only user-defined functions can be forked";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errLazyNonUserFunc(const Source& src, input::Span span) -> Diag {
+auto errLazyNonUserFunc(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Only user-defined functions can be called lazily";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errForkedSelfCall(const Source& src, input::Span span) -> Diag {
+auto errForkedSelfCall(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Self calls cannot be forked";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errLazySelfCall(const Source& src, input::Span span) -> Diag {
+auto errLazySelfCall(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Self calls cannot be lazy";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errSelfCallInNonFunc(const Source& src, input::Span span) -> Diag {
+auto errSelfCallInNonFunc(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Self calls can only be used inside functions or actions";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errSelfCallWithoutInferredRetType(const Source& src, input::Span span) -> Diag {
+auto errSelfCallWithoutInferredRetType(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Failed to bind self call as return type could not be inferred";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errIncorrectNumArgsInSelfCall(
-    const Source& src, unsigned int expectedNumArgs, unsigned int actualNumArgs, input::Span span)
-    -> Diag {
+    prog::sym::SourceId src, unsigned int expectedNumArgs, unsigned int actualNumArgs) -> Diag {
   std::ostringstream oss;
   oss << "Self call requires '" << expectedNumArgs << "' arguments but got '" << actualNumArgs
       << "'";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 auto errInvalidFailIntrinsicCall(
-    const Source& src, unsigned int typeParams, unsigned int argCount, input::Span span) -> Diag {
+    prog::sym::SourceId src, unsigned int typeParams, unsigned int argCount) -> Diag {
   std::ostringstream oss;
   oss << "Invalid fail intrinsic action call";
   if (typeParams != 1) {
@@ -626,26 +584,25 @@ auto errInvalidFailIntrinsicCall(
   if (argCount != 0) {
     oss << ", requires '0' arguments but got '" << argCount << "'";
   }
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errIntrinsicFuncLiteral(const Source& src, input::Span span) -> Diag {
+auto errIntrinsicFuncLiteral(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Compiler intrinsic cannot be used as a function literal";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errUnsupportedArgInitializer(const Source& src, const std::string& name, input::Span span)
-    -> Diag {
+auto errUnsupportedArgInitializer(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Initializer for input argument '" << name << "' is unsupported in the current context";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
-auto errNonOptArgFollowingOpt(const Source& src, input::Span span) -> Diag {
+auto errNonOptArgFollowingOpt(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Required argument cannot follow an optional argument";
-  return error(src, oss.str(), span);
+  return error(oss.str(), src);
 }
 
 } // namespace frontend

--- a/src/frontend/internal/context.cpp
+++ b/src/frontend/internal/context.cpp
@@ -1,4 +1,5 @@
 #include "internal/context.hpp"
+#include "internal/source_table_builder.hpp"
 #include <sstream>
 
 namespace frontend::internal {
@@ -6,6 +7,7 @@ namespace frontend::internal {
 Context::Context(
     const Source& src,
     prog::Program* prog,
+    SourceTableBuilder* sourceTableBuilder,
     TypeTemplateTable* typeTemplates,
     FuncTemplateTable* funcTemplates,
     DelegateTable* delegates,
@@ -16,6 +18,7 @@ Context::Context(
     std::vector<Diag>* diags) :
     m_src{src},
     m_prog{prog},
+    m_sourceTableBuilder{sourceTableBuilder},
     m_typeTemplates{typeTemplates},
     m_funcTemplates{funcTemplates},
     m_delegates{delegates},
@@ -27,6 +30,9 @@ Context::Context(
 
   if (m_prog == nullptr) {
     throw std::invalid_argument{"Program cannot be null"};
+  }
+  if (m_sourceTableBuilder == nullptr) {
+    throw std::invalid_argument{"SourceTableBuilder cannot be null"};
   }
   if (m_typeTemplates == nullptr) {
     throw std::invalid_argument{"TypeTemplatesTable cannot be null"};

--- a/src/frontend/internal/context.cpp
+++ b/src/frontend/internal/context.cpp
@@ -90,4 +90,11 @@ auto Context::declareTypeInfo(prog::sym::TypeId typeId, TypeInfo typeInfo) -> vo
   m_typeInfos->insert({typeId, std::move(typeInfo)});
 }
 
+auto Context::associateSrc(const prog::expr::NodePtr& expr, input::Span span) -> void {
+  if (expr) {
+    const auto srcId = m_sourceTableBuilder->add(&m_src, span);
+    expr->setSourceId(srcId);
+  }
+}
+
 } // namespace frontend::internal

--- a/src/frontend/internal/context.hpp
+++ b/src/frontend/internal/context.hpp
@@ -50,8 +50,9 @@ public:
   auto declareTypeInfo(prog::sym::TypeId typeId, TypeInfo typeInfo) -> void;
 
   template <typename DiagConstructor, class... Args>
-  auto reportDiag(DiagConstructor constructor, Args&&... args) -> void {
-    m_diags->push_back(constructor(m_src, std::forward<Args>(args)...));
+  auto reportDiag(DiagConstructor constructor, input::Span span, Args&&... args) -> void {
+    const auto srcId = m_sourceTableBuilder->add(&m_src, span);
+    m_diags->push_back(constructor(srcId, std::forward<Args>(args)...));
   }
 
 private:

--- a/src/frontend/internal/context.hpp
+++ b/src/frontend/internal/context.hpp
@@ -55,6 +55,8 @@ public:
     m_diags->push_back(constructor(srcId, std::forward<Args>(args)...));
   }
 
+  auto associateSrc(const prog::expr::NodePtr& expr, input::Span span) -> void;
+
 private:
   const Source& m_src;
   prog::Program* m_prog;

--- a/src/frontend/internal/context.hpp
+++ b/src/frontend/internal/context.hpp
@@ -5,6 +5,7 @@
 #include "internal/func_template_table.hpp"
 #include "internal/future_table.hpp"
 #include "internal/lazy_table.hpp"
+#include "internal/source_table_builder.hpp"
 #include "internal/type_info.hpp"
 #include "internal/type_template_table.hpp"
 #include "prog/program.hpp"
@@ -22,6 +23,7 @@ public:
   Context(
       const Source& src,
       prog::Program* prog,
+      SourceTableBuilder* sourceTableBuilder,
       TypeTemplateTable* typeTemplates,
       FuncTemplateTable* funcTemplates,
       DelegateTable* delegates,
@@ -55,6 +57,7 @@ public:
 private:
   const Source& m_src;
   prog::Program* m_prog;
+  SourceTableBuilder* m_sourceTableBuilder;
   TypeTemplateTable* m_typeTemplates;
   FuncTemplateTable* m_funcTemplates;
   DelegateTable* m_delegates;

--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -30,14 +30,14 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
 
     auto op = getOperator(n.getId());
     if (!op) {
-      m_ctx->reportDiag(errNonOverloadableOperator, n.getId().str(), n.getId().getSpan());
+      m_ctx->reportDiag(errNonOverloadableOperator, n.getId().getSpan(), n.getId().str());
       return;
     }
     name        = prog::getFuncName(*op);
     displayName = "operator" + n.getId().str();
 
     if (n.getArgList().getCount() == 0) {
-      m_ctx->reportDiag(errOperatorOverloadWithoutArgs, displayName, n.getId().getSpan());
+      m_ctx->reportDiag(errOperatorOverloadWithoutArgs, n.getId().getSpan(), displayName);
       return;
     }
   }
@@ -66,7 +66,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
 
   // Verify that this is not a duplicate declaration.
   if (m_ctx->getProg()->lookupFunc(name, input.value(), prog::OvOptions{0})) {
-    m_ctx->reportDiag(errDuplicateFuncDeclaration, displayName, n.getSpan());
+    m_ctx->reportDiag(errDuplicateFuncDeclaration, n.getSpan(), displayName);
     return;
   }
 
@@ -94,9 +94,9 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
       } else if (*retType != *nonTemplConvType) {
         m_ctx->reportDiag(
             errIncorrectReturnTypeInConvFunc,
+            n.getId().getSpan(),
             name,
-            getDisplayName(*m_ctx, *retType),
-            n.getId().getSpan());
+            getDisplayName(*m_ctx, *retType));
         return;
       }
     } else {
@@ -105,7 +105,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
             inferRetType(m_ctx, nullptr, n, *input, nullptr, TypeInferExpr::Flags::Aggressive);
         if (!retType->isConcrete()) {
           m_ctx->reportDiag(
-              errUnableToInferReturnTypeOfConversionToTemplatedType, name, n.getId().getSpan());
+              errUnableToInferReturnTypeOfConversionToTemplatedType, n.getId().getSpan(), name);
           return;
         }
       }
@@ -113,9 +113,9 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
       if (!typeInfo || typeInfo->getName() != name) {
         m_ctx->reportDiag(
             errIncorrectReturnTypeInConvFunc,
+            n.getId().getSpan(),
             name,
-            getDisplayName(*m_ctx, *retType),
-            n.getId().getSpan());
+            getDisplayName(*m_ctx, *retType));
         return;
       }
     }
@@ -147,7 +147,7 @@ auto DeclareUserFuncs::validateType(
   if (!isType(m_ctx, nullptr, name) &&
       std::find(typeSubParams.begin(), typeSubParams.end(), name) == typeSubParams.end()) {
 
-    m_ctx->reportDiag(errUndeclaredType, name, type.getParamCount(), type.getSpan());
+    m_ctx->reportDiag(errUndeclaredType, type.getSpan(), name, type.getParamCount());
     isValid = false;
   }
 

--- a/src/frontend/internal/declare_user_types.cpp
+++ b/src/frontend/internal/declare_user_types.cpp
@@ -94,19 +94,19 @@ auto DeclareUserTypes::visit(const parse::EnumDeclStmtNode& n) -> void {
 auto DeclareUserTypes::validateTypeName(const lex::Token& nameToken) -> bool {
   const auto name = getName(nameToken);
   if (m_ctx->getProg()->lookupType(name)) {
-    m_ctx->reportDiag(errTypeAlreadyDeclared, name, nameToken.getSpan());
+    m_ctx->reportDiag(errTypeAlreadyDeclared, nameToken.getSpan(), name);
     return false;
   }
   if (m_ctx->getTypeTemplates()->hasType(name)) {
-    m_ctx->reportDiag(errTypeTemplateAlreadyDeclared, name, nameToken.getSpan());
+    m_ctx->reportDiag(errTypeTemplateAlreadyDeclared, nameToken.getSpan(), name);
     return false;
   }
   if (isReservedTypeName(name)) {
-    m_ctx->reportDiag(errTypeNameIsReserved, name, nameToken.getSpan());
+    m_ctx->reportDiag(errTypeNameIsReserved, nameToken.getSpan(), name);
     return false;
   }
   if (m_ctx->getProg()->hasFunc(name)) {
-    m_ctx->reportDiag(errTypeNameConflictsWithFunc, name, nameToken.getSpan());
+    m_ctx->reportDiag(errTypeNameConflictsWithFunc, nameToken.getSpan(), name);
     return false;
   }
   return true;

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -56,9 +56,9 @@ static auto getOptInputInitializers(
 
     ctx->reportDiag(
         errNonMatchingInitializerType,
+        n[i].getSpan(),
         getDisplayName(*ctx, type),
-        getDisplayName(*ctx, initializerExpr->getType()),
-        n[i].getSpan());
+        getDisplayName(*ctx, initializerExpr->getType()));
   }
 
   return result;
@@ -97,7 +97,7 @@ auto defineFunc(
   // Report this diagnostic after processing the body so other errors have priority over this.
   if (funcRetType.isInfer()) {
     if (!ctx->hasErrors()) {
-      ctx->reportDiag(errUnableToInferFuncReturnType, funcDisplayName, n.getSpan());
+      ctx->reportDiag(errUnableToInferFuncReturnType, n.getSpan(), funcDisplayName);
     }
     return false;
   }
@@ -147,10 +147,10 @@ auto defineFunc(
 
   ctx->reportDiag(
       errNonMatchingFuncReturnType,
+      n.getBody().getSpan(),
       funcDisplayName,
       getDisplayName(*ctx, funcRetType),
-      getDisplayName(*ctx, bodyExpr->getType()),
-      n.getBody().getSpan());
+      getDisplayName(*ctx, bodyExpr->getType()));
   return false;
 }
 

--- a/src/frontend/internal/define_user_types.cpp
+++ b/src/frontend/internal/define_user_types.cpp
@@ -23,9 +23,9 @@ auto defineType(
     if (!fieldType) {
       ctx->reportDiag(
           errUndeclaredType,
+          fieldParseType.getSpan(),
           getName(fieldParseType),
-          fieldParseType.getParamCount(),
-          fieldParseType.getSpan());
+          fieldParseType.getParamCount());
       isValid = false;
       continue;
     }
@@ -33,18 +33,18 @@ auto defineType(
     // Get field identifier.
     const auto fieldName = getName(field.getIdentifier());
     if (fieldTable.lookup(fieldName)) {
-      ctx->reportDiag(errDuplicateFieldNameInStruct, fieldName, field.getIdentifier().getSpan());
+      ctx->reportDiag(errDuplicateFieldNameInStruct, field.getIdentifier().getSpan(), fieldName);
       isValid = false;
       continue;
     }
     if (typeSubTable != nullptr && typeSubTable->lookupType(fieldName)) {
       ctx->reportDiag(
-          errFieldNameConflictsWithTypeSubstitution, fieldName, field.getIdentifier().getSpan());
+          errFieldNameConflictsWithTypeSubstitution, field.getIdentifier().getSpan(), fieldName);
       isValid = false;
       continue;
     }
     if (ctx->getProg()->lookupType(fieldName) || isReservedTypeName(fieldName)) {
-      ctx->reportDiag(errFieldNameConflictsWithType, fieldName, field.getIdentifier().getSpan());
+      ctx->reportDiag(errFieldNameConflictsWithType, field.getIdentifier().getSpan(), fieldName);
       isValid = false;
       continue;
     }
@@ -69,16 +69,16 @@ auto defineType(
     const auto type = getOrInstType(ctx, typeSubTable, parseType);
     if (!type) {
       ctx->reportDiag(
-          errUndeclaredType, getName(parseType), parseType.getParamCount(), parseType.getSpan());
+          errUndeclaredType, parseType.getSpan(), getName(parseType), parseType.getParamCount());
       isValid = false;
       continue;
     }
     if (std::find(types.begin(), types.end(), *type) != types.end()) {
       ctx->reportDiag(
           errDuplicateTypeInUnion,
+          parseType.getSpan(),
           getName(parseType),
-          getDisplayName(*ctx, *type),
-          parseType.getSpan());
+          getDisplayName(*ctx, *type));
       isValid = false;
       continue;
     }
@@ -104,11 +104,11 @@ auto defineType(Context* ctx, prog::sym::TypeId id, const parse::EnumDeclStmtNod
         entry.getValueSpec() ? entry.getValueSpec()->getValue() : lastValue + 1;
 
     if (!entries.insert({name, value}).second) {
-      ctx->reportDiag(errDuplicateEntryNameInEnum, name, entry.getSpan());
+      ctx->reportDiag(errDuplicateEntryNameInEnum, entry.getSpan(), name);
       isValid = false;
     }
     if (!values.insert(value).second) {
-      ctx->reportDiag(errDuplicateEntryValueInEnum, value, entry.getSpan());
+      ctx->reportDiag(errDuplicateEntryValueInEnum, entry.getSpan(), value);
       isValid = false;
     }
   }

--- a/src/frontend/internal/func_template.cpp
+++ b/src/frontend/internal/func_template.cpp
@@ -201,9 +201,9 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
       if (instance->m_retType != *nonTemplConvType) {
         m_ctx->reportDiag(
             errIncorrectReturnTypeInConvFunc,
+            m_parseNode->getSpan(),
             instance->getDisplayName(*m_ctx),
-            getDisplayName(*m_ctx, *instance->m_retType),
-            m_parseNode->getSpan());
+            getDisplayName(*m_ctx, *instance->m_retType));
 
         instance->m_success = false;
         return;
@@ -214,9 +214,9 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
       if (!typeInfo || typeInfo->getName() != m_name) {
         m_ctx->reportDiag(
             errIncorrectReturnTypeInConvFunc,
+            m_parseNode->getSpan(),
             instance->getDisplayName(*m_ctx),
-            getDisplayName(*m_ctx, *instance->m_retType),
-            m_parseNode->getSpan());
+            getDisplayName(*m_ctx, *instance->m_retType));
 
         instance->m_success = false;
         return;
@@ -230,7 +230,7 @@ auto FuncTemplate::setupInstance(FuncTemplateInst* instance) -> void {
   // Check if an identical function has already been registered.
   if (m_ctx->getProg()->lookupFunc(funcName, *funcInput, prog::OvOptions{0})) {
     m_ctx->reportDiag(
-        errDuplicateFuncDeclaration, instance->getDisplayName(*m_ctx), m_parseNode->getSpan());
+        errDuplicateFuncDeclaration, m_parseNode->getSpan(), instance->getDisplayName(*m_ctx));
     instance->m_success = false;
     return;
   }

--- a/src/frontend/internal/get_parse_diags.hpp
+++ b/src/frontend/internal/get_parse_diags.hpp
@@ -16,7 +16,7 @@ public:
 
   auto visit(const parse::ErrorNode& n) -> void override {
     parse::DeepNodeVisitor::visit(n);
-    m_ctx->reportDiag(errParseError, n);
+    m_ctx->reportDiag(errParseError, n.getSpan(), n);
   }
 
 private:

--- a/src/frontend/internal/import_sources.hpp
+++ b/src/frontend/internal/import_sources.hpp
@@ -2,6 +2,7 @@
 #include "filesystem.hpp"
 #include "frontend/diag.hpp"
 #include "frontend/source.hpp"
+#include "internal/source_table_builder.hpp"
 #include "parse/node_visitor_optional.hpp"
 #include <forward_list>
 #include <optional>
@@ -17,12 +18,14 @@ public:
   ImportSources() = delete;
   ImportSources(
       const Source& mainSource,
+      SourceTableBuilder& sourceTableBuilder,
       const std::vector<Path>& searchPaths,
       std::forward_list<Source>* importedSources,
       std::vector<Diag>* diags);
   ImportSources(
       const Source& mainSource,
       const Source& currentSource,
+      SourceTableBuilder& sourceTableBuilder,
       const std::vector<Path>& searchPaths,
       std::forward_list<Source>* importedSources,
       std::vector<Diag>* diags);
@@ -32,6 +35,7 @@ public:
 private:
   const Source& m_mainSource;
   const Source& m_currentSource;
+  SourceTableBuilder& m_sourceTableBuilder;
   const std::vector<Path>& m_searchPaths;
   std::forward_list<Source>* m_importedSources;
   std::vector<Diag>* m_diags;

--- a/src/frontend/internal/intrinsic_call_hooks.cpp
+++ b/src/frontend/internal/intrinsic_call_hooks.cpp
@@ -20,9 +20,9 @@ auto injectFailIntrinsic(
     // Invalid fail intrinsic, expects 1 type parameter and 0 normal arguments.
     ctx->reportDiag(
         errInvalidFailIntrinsicCall,
+        callSpan,
         typeParams ? typeParams->getCount() : 0u,
-        args.first.size(),
-        callSpan);
+        args.first.size());
     return;
   }
 

--- a/src/frontend/internal/source_table_builder.cpp
+++ b/src/frontend/internal/source_table_builder.cpp
@@ -1,0 +1,28 @@
+#include "source_table_builder.hpp"
+#include <cassert>
+#include <stdexcept>
+
+namespace frontend::internal {
+
+SourceTableBuilder::SourceTableBuilder() noexcept : m_build{false}, m_srcIdNum{0} {}
+
+auto SourceTableBuilder::add(const Source* src, input::Span span) -> prog::sym::SourceId {
+  if (m_build) {
+    throw std::logic_error{"SourceTable has already been build"};
+  }
+  auto srcId = prog::sym::SourceId{++m_srcIdNum};
+  if (!m_map.insert({srcId, SourceInfo{src, span}}).second) {
+    assert(false); // Internal error, means we have duplicate source-ids.
+  }
+  return srcId;
+}
+
+auto SourceTableBuilder::build() -> SourceTable {
+  if (m_build) {
+    throw std::logic_error{"SourceTable has already been build"};
+  }
+  m_build = true;
+  return SourceTable{std::move(m_map)};
+}
+
+} // namespace frontend::internal

--- a/src/frontend/internal/source_table_builder.hpp
+++ b/src/frontend/internal/source_table_builder.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "frontend/source_table.hpp"
+#include "input/span.hpp"
+
+namespace frontend::internal {
+
+class SourceTableBuilder final {
+public:
+  SourceTableBuilder() noexcept;
+  SourceTableBuilder(const SourceTableBuilder& rhs)     = delete;
+  SourceTableBuilder(SourceTableBuilder&& rhs) noexcept = default;
+  ~SourceTableBuilder()                                 = default;
+
+  auto operator=(const SourceTableBuilder& rhs) -> SourceTableBuilder& = delete;
+  auto operator=(SourceTableBuilder&& rhs) noexcept -> SourceTableBuilder& = default;
+
+  [[nodiscard]] auto add(const Source* src, input::Span span) -> prog::sym::SourceId;
+  [[nodiscard]] auto build() -> SourceTable;
+
+private:
+  bool m_build;
+  SourceTable::Map m_map;
+  unsigned int m_srcIdNum;
+};
+
+} // namespace frontend::internal

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -263,7 +263,7 @@ auto getOrInstType(
     const auto subType = subTable->lookupType(name);
     if (subType) {
       if (parseType.getParamList()) {
-        ctx->reportDiag(errTypeParamOnSubstitutionType, name, parseType.getSpan());
+        ctx->reportDiag(errTypeParamOnSubstitutionType, parseType.getSpan(), name);
         return std::nullopt;
       }
       return subType;
@@ -330,9 +330,9 @@ auto getRetType(
   if (!retType) {
     ctx->reportDiag(
         errUndeclaredType,
+        retParseType.getSpan(),
         getName(retParseType),
-        retParseType.getParamCount(),
-        retParseType.getSpan());
+        retParseType.getParamCount());
     return std::nullopt;
   }
   return retType;
@@ -433,9 +433,9 @@ auto getFuncInput(
     } else {
       ctx->reportDiag(
           errUndeclaredType,
+          argParseType.getSpan(),
           getName(argParseType),
-          argParseType.getParamCount(),
-          argParseType.getSpan());
+          argParseType.getParamCount());
       isValid = false;
     }
   }
@@ -473,7 +473,7 @@ auto declareFuncInput(
       continue;
     }
     if (arg.hasInitializer() && !allowArgInitializer) {
-      ctx->reportDiag(errUnsupportedArgInitializer, *constName, arg.getSpan());
+      ctx->reportDiag(errUnsupportedArgInitializer, arg.getSpan(), *constName);
       isValid = false;
       continue;
     }
@@ -483,9 +483,9 @@ auto declareFuncInput(
     if (!argType) {
       ctx->reportDiag(
           errUndeclaredType,
+          argParseType.getSpan(),
           getName(argParseType),
-          argParseType.getParamCount(),
-          argParseType.getSpan());
+          argParseType.getParamCount());
       isValid = false;
       continue;
     }
@@ -502,7 +502,7 @@ auto getSubstitutionParams(Context* ctx, const parse::TypeSubstitutionList& subL
   for (const auto& typeSubToken : subList) {
     const auto typeParamName = getName(typeSubToken);
     if (isType(ctx, nullptr, typeParamName)) {
-      ctx->reportDiag(errTypeParamNameConflictsWithType, typeParamName, typeSubToken.getSpan());
+      ctx->reportDiag(errTypeParamNameConflictsWithType, typeSubToken.getSpan(), typeParamName);
       isValid = false;
     } else {
       typeParams.push_back(typeParamName);
@@ -523,7 +523,7 @@ auto getTypeSet(
       types.push_back(*type);
     } else {
       ctx->reportDiag(
-          errUndeclaredType, getName(parseType), parseType.getParamCount(), parseType.getSpan());
+          errUndeclaredType, parseType.getSpan(), getName(parseType), parseType.getParamCount());
       isValid = false;
     }
   }
@@ -546,15 +546,15 @@ auto getConstName(
 
   const auto name = getName(nameToken);
   if (subTable != nullptr && subTable->lookupType(name)) {
-    ctx->reportDiag(errConstNameConflictsWithTypeSubstitution, name, nameToken.getSpan());
+    ctx->reportDiag(errConstNameConflictsWithTypeSubstitution, nameToken.getSpan(), name);
     return std::nullopt;
   }
   if (isType(ctx, nullptr, name)) {
-    ctx->reportDiag(errConstNameConflictsWithType, name, nameToken.getSpan());
+    ctx->reportDiag(errConstNameConflictsWithType, nameToken.getSpan(), name);
     return std::nullopt;
   }
   if (consts.lookup(name)) {
-    ctx->reportDiag(errConstNameConflictsWithConst, name, nameToken.getSpan());
+    ctx->reportDiag(errConstNameConflictsWithConst, nameToken.getSpan(), name);
     return std::nullopt;
   }
   return name;

--- a/src/frontend/internal/validate_types.cpp
+++ b/src/frontend/internal/validate_types.cpp
@@ -50,7 +50,7 @@ auto validateType(prog::sym::TypeId id, const TypeInfo& info) -> void {
     const auto cyclicField = getCyclicField(ctx, fields, visitedTypes);
     if (cyclicField) {
       const auto fieldName = fields[*cyclicField].getName();
-      ctx->reportDiag(errCyclicStruct, fieldName, typeDecl.getName(), info.getSourceSpan());
+      ctx->reportDiag(errCyclicStruct, info.getSourceSpan(), fieldName, typeDecl.getName());
       return;
     }
   }

--- a/src/frontend/output.cpp
+++ b/src/frontend/output.cpp
@@ -22,6 +22,8 @@ auto Output::getImportedSources() const noexcept -> const std::forward_list<Sour
   return m_importedSources;
 }
 
+auto Output::getSourceTable() const noexcept -> const SourceTable& { return m_sourceTable; }
+
 auto Output::beginDiags() const noexcept -> DiagIterator { return m_diags.begin(); }
 
 auto Output::endDiags() const noexcept -> DiagIterator { return m_diags.end(); }

--- a/src/frontend/output.cpp
+++ b/src/frontend/output.cpp
@@ -7,9 +7,11 @@ namespace frontend {
 Output::Output(
     std::unique_ptr<prog::Program> prog,
     std::forward_list<Source> importedSources,
+    SourceTable sourceTable,
     std::vector<Diag> diags) :
     m_prog{std::move(prog)},
     m_importedSources{std::move(importedSources)},
+    m_sourceTable{std::move(sourceTable)},
     m_diags{std::move(diags)} {}
 
 auto Output::isSuccess() const noexcept -> bool { return m_prog != nullptr; }
@@ -27,13 +29,15 @@ auto Output::endDiags() const noexcept -> DiagIterator { return m_diags.end(); }
 auto buildOutput(
     std::unique_ptr<prog::Program> prog,
     std::forward_list<Source> importedSources,
+    SourceTable sourceTable,
     std::vector<Diag> diags) -> Output {
 
   if (prog == nullptr && diags.empty()) {
     throw std::logic_error{
         "If not program could be constructed, at least one diagnostic should be present"};
   }
-  return Output{std::move(prog), std::move(importedSources), std::move(diags)};
+  return Output{
+      std::move(prog), std::move(importedSources), std::move(sourceTable), std::move(diags)};
 }
 
 } // namespace frontend

--- a/src/frontend/source_table.cpp
+++ b/src/frontend/source_table.cpp
@@ -1,0 +1,20 @@
+#include "frontend/source_table.hpp"
+#include "prog/sym/source_id.hpp"
+#include <stdexcept>
+
+namespace frontend {
+
+SourceTable::SourceTable(Map map) : m_map{std::move(map)} {}
+
+auto SourceTable::operator[](prog::sym::SourceId source) const -> SourceInfo {
+  if (source == prog::sym::SourceId::none()) {
+    throw std::logic_error{"The 'none' SourceId has no information associated with it"};
+  }
+  const auto itr = m_map.find(source);
+  if (itr == m_map.end()) {
+    throw std::logic_error{"SourceId is not present in this table"};
+  }
+  return itr->second;
+}
+
+} // namespace frontend

--- a/src/opt/internal/const_remapper.cpp
+++ b/src/opt/internal/const_remapper.cpp
@@ -1,4 +1,5 @@
 #include "internal/const_remapper.hpp"
+#include "internal/utilities.hpp"
 
 namespace opt::internal {
 
@@ -12,24 +13,30 @@ auto ConstRemapper::rewrite(const prog::expr::Node& expr) -> prog::expr::NodePtr
 
   switch (expr.getKind()) {
   case prog::expr::NodeKind::Assign: {
-    auto* assignExpr = expr.downcast<prog::expr::AssignExprNode>();
+    const auto* assignExpr = expr.downcast<prog::expr::AssignExprNode>();
 
-    m_modified = true;
-    return prog::expr::assignExprNode(
+    m_modified     = true;
+    auto newAssign = prog::expr::assignExprNode(
         m_consts, remap(assignExpr->getConst()), rewrite((*assignExpr)[0]));
+    copySourceAttr(*newAssign, expr);
+    return newAssign;
   }
   case prog::expr::NodeKind::Const: {
     auto* constExpr = expr.downcast<prog::expr::ConstExprNode>();
 
-    m_modified = true;
-    return prog::expr::constExprNode(m_consts, remap(constExpr->getId()));
+    m_modified    = true;
+    auto newConst = prog::expr::constExprNode(m_consts, remap(constExpr->getId()));
+    copySourceAttr(*newConst, expr);
+    return newConst;
   }
   case prog::expr::NodeKind::UnionGet: {
     auto* unionGetExpr = expr.downcast<prog::expr::UnionGetExprNode>();
 
-    m_modified = true;
-    return prog::expr::unionGetExprNode(
+    m_modified       = true;
+    auto newUnionGet = prog::expr::unionGetExprNode(
         m_prog, rewrite((*unionGetExpr)[0]), m_consts, remap(unionGetExpr->getConst()));
+    copySourceAttr(*newUnionGet, expr);
+    return newUnionGet;
   }
   default:
     return expr.clone(this);

--- a/src/opt/internal/utilities.hpp
+++ b/src/opt/internal/utilities.hpp
@@ -25,4 +25,8 @@ namespace opt::internal {
 rewriteAll(const std::vector<prog::expr::NodePtr>& nodes, prog::expr::Rewriter* rewriter)
     -> std::vector<prog::expr::NodePtr>;
 
+inline auto copySourceAttr(prog::expr::Node& to, const prog::expr::Node& from) -> void {
+  to.setSourceId(from.getSourceId());
+}
+
 } // namespace opt::internal

--- a/src/prog/expr/node.cpp
+++ b/src/prog/expr/node.cpp
@@ -1,10 +1,15 @@
 #include "prog/expr/node.hpp"
+#include "prog/sym/source_id.hpp"
 
 namespace prog::expr {
 
-Node::Node(NodeKind kind) { m_kind = kind; }
+Node::Node(NodeKind kind) : m_kind{kind}, m_sourceId(sym::SourceId::none()) {}
 
 auto Node::getKind() const -> NodeKind { return m_kind; }
+
+auto Node::getSourceId() const -> sym::SourceId { return m_sourceId; }
+
+auto Node::setSourceId(sym::SourceId source) -> void { m_sourceId = source; }
 
 auto operator<<(std::ostream& out, const Node& rhs) -> std::ostream& {
   return out << rhs.toString();

--- a/src/prog/expr/node_assign.cpp
+++ b/src/prog/expr/node_assign.cpp
@@ -36,8 +36,10 @@ auto AssignExprNode::toString() const -> std::string {
 }
 
 auto AssignExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<AssignExprNode>{new AssignExprNode{
-      m_constId, rewriter ? rewriter->rewrite(*m_expr) : m_expr->clone(nullptr)}};
+  auto* newExpr =
+      new AssignExprNode{m_constId, rewriter ? rewriter->rewrite(*m_expr) : m_expr->clone(nullptr)};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<AssignExprNode>{newExpr};
 }
 
 auto AssignExprNode::getConst() const noexcept -> sym::ConstId { return m_constId; }

--- a/src/prog/expr/node_call.cpp
+++ b/src/prog/expr/node_call.cpp
@@ -57,8 +57,10 @@ auto CallExprNode::toString() const -> std::string {
 }
 
 auto CallExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<CallExprNode>{new CallExprNode{
-      m_func, m_resultType, cloneNodes(m_args, rewriter), m_mode, m_needsPatching}};
+  auto* newExpr =
+      new CallExprNode{m_func, m_resultType, cloneNodes(m_args, rewriter), m_mode, m_needsPatching};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<CallExprNode>{newExpr};
 }
 
 auto CallExprNode::getFunc() const noexcept -> sym::FuncId { return m_func; }

--- a/src/prog/expr/node_call_dyn.cpp
+++ b/src/prog/expr/node_call_dyn.cpp
@@ -53,11 +53,13 @@ auto CallDynExprNode::toString() const -> std::string {
 }
 
 auto CallDynExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<CallDynExprNode>{new CallDynExprNode{
+  auto* newExpr = new CallDynExprNode{
       rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr),
       m_resultType,
       cloneNodes(m_args, rewriter),
-      m_mode}};
+      m_mode};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<CallDynExprNode>{newExpr};
 }
 
 auto CallDynExprNode::getArgs() const noexcept -> const std::vector<NodePtr>& { return m_args; }

--- a/src/prog/expr/node_call_self.cpp
+++ b/src/prog/expr/node_call_self.cpp
@@ -32,8 +32,9 @@ auto CallSelfExprNode::getType() const noexcept -> sym::TypeId { return m_result
 auto CallSelfExprNode::toString() const -> std::string { return "self-call"; }
 
 auto CallSelfExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<CallSelfExprNode>{
-      new CallSelfExprNode{m_resultType, cloneNodes(m_args, rewriter)}};
+  auto* newExpr = new CallSelfExprNode{m_resultType, cloneNodes(m_args, rewriter)};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<CallSelfExprNode>{newExpr};
 }
 
 auto CallSelfExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }

--- a/src/prog/expr/node_closure.cpp
+++ b/src/prog/expr/node_closure.cpp
@@ -36,8 +36,9 @@ auto ClosureNode::toString() const -> std::string {
 }
 
 auto ClosureNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<ClosureNode>{
-      new ClosureNode{m_type, m_func, cloneNodes(m_boundArgs, rewriter)}};
+  auto* newExpr = new ClosureNode{m_type, m_func, cloneNodes(m_boundArgs, rewriter)};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<ClosureNode>{newExpr};
 }
 
 auto ClosureNode::getFunc() const noexcept -> sym::FuncId { return m_func; }

--- a/src/prog/expr/node_const.cpp
+++ b/src/prog/expr/node_const.cpp
@@ -30,7 +30,9 @@ auto ConstExprNode::toString() const -> std::string {
 }
 
 auto ConstExprNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<ConstExprNode>{new ConstExprNode{m_id, m_type}};
+  auto* newExpr = new ConstExprNode{m_id, m_type};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<ConstExprNode>{newExpr};
 }
 
 auto ConstExprNode::getId() const noexcept -> sym::ConstId { return m_id; }

--- a/src/prog/expr/node_fail.cpp
+++ b/src/prog/expr/node_fail.cpp
@@ -24,7 +24,9 @@ auto FailNode::getType() const noexcept -> sym::TypeId { return m_type; }
 auto FailNode::toString() const -> std::string { return "fail"; }
 
 auto FailNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<FailNode>{new FailNode{m_type}};
+  auto* newExpr = new FailNode{m_type};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<FailNode>{newExpr};
 }
 
 auto FailNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }

--- a/src/prog/expr/node_field.cpp
+++ b/src/prog/expr/node_field.cpp
@@ -34,8 +34,10 @@ auto FieldExprNode::toString() const -> std::string {
 }
 
 auto FieldExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<FieldExprNode>{new FieldExprNode{
-      rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr), m_id, m_type}};
+  auto* newExpr =
+      new FieldExprNode{rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr), m_id, m_type};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<FieldExprNode>{newExpr};
 }
 
 auto FieldExprNode::getId() const noexcept -> sym::FieldId { return m_id; }

--- a/src/prog/expr/node_group.cpp
+++ b/src/prog/expr/node_group.cpp
@@ -30,7 +30,9 @@ auto GroupExprNode::getType() const noexcept -> sym::TypeId { return m_exprs.bac
 auto GroupExprNode::toString() const -> std::string { return "group"; }
 
 auto GroupExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<GroupExprNode>{new GroupExprNode{cloneNodes(m_exprs, rewriter)}};
+  auto* newExpr = new GroupExprNode{cloneNodes(m_exprs, rewriter)};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<GroupExprNode>{newExpr};
 }
 
 auto GroupExprNode::accept(NodeVisitor* visitor) const -> void { visitor->visit(*this); }

--- a/src/prog/expr/node_lit_bool.cpp
+++ b/src/prog/expr/node_lit_bool.cpp
@@ -26,7 +26,9 @@ auto LitBoolNode::getType() const noexcept -> sym::TypeId { return m_type; }
 auto LitBoolNode::toString() const -> std::string { return m_val ? "true" : "false"; }
 
 auto LitBoolNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitBoolNode>{new LitBoolNode{m_type, m_val}};
+  auto* newExpr = new LitBoolNode{m_type, m_val};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitBoolNode>{newExpr};
 }
 
 auto LitBoolNode::getVal() const noexcept -> bool { return m_val; }

--- a/src/prog/expr/node_lit_char.cpp
+++ b/src/prog/expr/node_lit_char.cpp
@@ -31,7 +31,9 @@ auto LitCharNode::toString() const -> std::string {
 }
 
 auto LitCharNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitCharNode>{new LitCharNode{m_type, m_val}};
+  auto* newExpr = new LitCharNode{m_type, m_val};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitCharNode>{newExpr};
 }
 
 auto LitCharNode::getVal() const noexcept -> uint8_t { return m_val; }

--- a/src/prog/expr/node_lit_enum.cpp
+++ b/src/prog/expr/node_lit_enum.cpp
@@ -26,7 +26,9 @@ auto LitEnumNode::getType() const noexcept -> sym::TypeId { return m_type; }
 auto LitEnumNode::toString() const -> std::string { return m_name; }
 
 auto LitEnumNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitEnumNode>{new LitEnumNode{m_type, m_name, m_val}};
+  auto* newExpr = new LitEnumNode{m_type, m_name, m_val};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitEnumNode>{newExpr};
 }
 
 auto LitEnumNode::getName() const noexcept -> const std::string& { return m_name; }

--- a/src/prog/expr/node_lit_float.cpp
+++ b/src/prog/expr/node_lit_float.cpp
@@ -42,7 +42,9 @@ auto LitFloatNode::toString() const -> std::string {
 }
 
 auto LitFloatNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitFloatNode>{new LitFloatNode{m_type, m_val}};
+  auto* newExpr = new LitFloatNode{m_type, m_val};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitFloatNode>{newExpr};
 }
 
 auto LitFloatNode::getVal() const noexcept -> float { return m_val; }

--- a/src/prog/expr/node_lit_func.cpp
+++ b/src/prog/expr/node_lit_func.cpp
@@ -32,7 +32,9 @@ auto LitFuncNode::toString() const -> std::string {
 }
 
 auto LitFuncNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitFuncNode>{new LitFuncNode{m_type, m_func}};
+  auto* newExpr = new LitFuncNode{m_type, m_func};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitFuncNode>{newExpr};
 }
 
 auto LitFuncNode::getFunc() const noexcept -> sym::FuncId { return m_func; }

--- a/src/prog/expr/node_lit_int.cpp
+++ b/src/prog/expr/node_lit_int.cpp
@@ -26,7 +26,9 @@ auto LitIntNode::getType() const noexcept -> sym::TypeId { return m_type; }
 auto LitIntNode::toString() const -> std::string { return std::to_string(m_val); }
 
 auto LitIntNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitIntNode>{new LitIntNode{m_type, m_val}};
+  auto* newExpr = new LitIntNode{m_type, m_val};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitIntNode>{newExpr};
 }
 
 auto LitIntNode::getVal() const noexcept -> int32_t { return m_val; }

--- a/src/prog/expr/node_lit_long.cpp
+++ b/src/prog/expr/node_lit_long.cpp
@@ -26,7 +26,9 @@ auto LitLongNode::getType() const noexcept -> sym::TypeId { return m_type; }
 auto LitLongNode::toString() const -> std::string { return std::to_string(m_val); }
 
 auto LitLongNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitLongNode>{new LitLongNode{m_type, m_val}};
+  auto* newExpr = new LitLongNode{m_type, m_val};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitLongNode>{newExpr};
 }
 
 auto LitLongNode::getVal() const noexcept -> int64_t { return m_val; }

--- a/src/prog/expr/node_lit_string.cpp
+++ b/src/prog/expr/node_lit_string.cpp
@@ -27,7 +27,9 @@ auto LitStringNode::getType() const noexcept -> sym::TypeId { return m_type; }
 auto LitStringNode::toString() const -> std::string { return m_val; }
 
 auto LitStringNode::clone(Rewriter* /*rewriter*/) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<LitStringNode>{new LitStringNode{m_type, m_val}};
+  auto* newExpr = new LitStringNode{m_type, m_val};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<LitStringNode>{newExpr};
 }
 
 auto LitStringNode::getVal() const noexcept -> const std::string& { return m_val; }

--- a/src/prog/expr/node_switch.cpp
+++ b/src/prog/expr/node_switch.cpp
@@ -41,8 +41,10 @@ auto SwitchExprNode::getType() const noexcept -> sym::TypeId {
 auto SwitchExprNode::toString() const -> std::string { return "switch"; }
 
 auto SwitchExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<SwitchExprNode>{
-      new SwitchExprNode{cloneNodes(m_conditions, rewriter), cloneNodes(m_branches, rewriter)}};
+  auto* newExpr =
+      new SwitchExprNode{cloneNodes(m_conditions, rewriter), cloneNodes(m_branches, rewriter)};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<SwitchExprNode>{newExpr};
 }
 
 auto SwitchExprNode::getConditions() const noexcept -> const std::vector<NodePtr>& {

--- a/src/prog/expr/node_union_check.cpp
+++ b/src/prog/expr/node_union_check.cpp
@@ -39,8 +39,10 @@ auto UnionCheckExprNode::toString() const -> std::string {
 }
 
 auto UnionCheckExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<UnionCheckExprNode>{new UnionCheckExprNode{
-      m_boolType, rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr), m_targetType}};
+  auto* newExpr = new UnionCheckExprNode{
+      m_boolType, rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr), m_targetType};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<UnionCheckExprNode>{newExpr};
 }
 
 auto UnionCheckExprNode::getTargetType() const noexcept -> sym::TypeId { return m_targetType; }

--- a/src/prog/expr/node_union_get.cpp
+++ b/src/prog/expr/node_union_get.cpp
@@ -42,11 +42,13 @@ auto UnionGetExprNode::toString() const -> std::string {
 }
 
 auto UnionGetExprNode::clone(Rewriter* rewriter) const -> std::unique_ptr<Node> {
-  return std::unique_ptr<UnionGetExprNode>{
-      new UnionGetExprNode{m_boolType,
-                           rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr),
-                           m_targetType,
-                           m_constId}};
+  auto* newExpr = new UnionGetExprNode{
+      m_boolType,
+      rewriter ? rewriter->rewrite(*m_lhs) : m_lhs->clone(nullptr),
+      m_targetType,
+      m_constId};
+  newExpr->setSourceId(getSourceId());
+  return std::unique_ptr<UnionGetExprNode>{newExpr};
 }
 
 auto UnionGetExprNode::getConst() const noexcept -> sym::ConstId { return m_constId; }

--- a/src/prog/sym/source_id.cpp
+++ b/src/prog/sym/source_id.cpp
@@ -12,6 +12,8 @@ auto SourceId::operator!=(const SourceId& rhs) const noexcept -> bool {
   return !SourceId::operator==(rhs);
 }
 
+auto SourceId::isSet() const noexcept -> bool { return m_id != 0; }
+
 auto SourceId::getNum() const noexcept -> unsigned int { return m_id; }
 
 auto operator<<(std::ostream& out, const SourceId& rhs) -> std::ostream& {

--- a/src/prog/sym/source_id.cpp
+++ b/src/prog/sym/source_id.cpp
@@ -1,0 +1,21 @@
+#include "prog/sym/source_id.hpp"
+
+namespace prog::sym {
+
+auto SourceId::none() noexcept -> SourceId { return SourceId{0}; };
+
+SourceId::SourceId(unsigned int id) : m_id{id} {}
+
+auto SourceId::operator==(const SourceId& rhs) const noexcept -> bool { return m_id == rhs.m_id; }
+
+auto SourceId::operator!=(const SourceId& rhs) const noexcept -> bool {
+  return !SourceId::operator==(rhs);
+}
+
+auto SourceId::getNum() const noexcept -> unsigned int { return m_id; }
+
+auto operator<<(std::ostream& out, const SourceId& rhs) -> std::ostream& {
+  return out << "source-" << rhs.m_id;
+}
+
+} // namespace prog::sym

--- a/src/prog/sym/source_id_hasher.cpp
+++ b/src/prog/sym/source_id_hasher.cpp
@@ -1,0 +1,10 @@
+#include "prog/sym/source_id_hasher.hpp"
+#include <functional>
+
+namespace prog::sym {
+
+auto SourceIdHasher::operator()(const SourceId& id) const -> std::size_t {
+  return std::hash<unsigned int>{}(id.m_id);
+}
+
+} // namespace prog::sym

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -212,38 +212,26 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG("fun f() lambda (b c) 1", errUndeclaredType(src, "b", 0, input::Span{16, 16}));
-    CHECK_DIAG(
-        "fun f() lambda (int a) -> b 1", errUndeclaredType(src, "b", 0, input::Span{26, 26}));
-    CHECK_DIAG(
-        "fun f() lambda (int int) 1",
-        errConstNameConflictsWithType(src, "int", input::Span{20, 22}));
-    CHECK_DIAG(
-        "fun f() lambda (int i, int i) 1",
-        errConstNameConflictsWithConst(src, "i", input::Span{27, 27}));
+    CHECK_DIAG("fun f() lambda (b c) 1", errUndeclaredType(NO_SRC, "b", 0));
+    CHECK_DIAG("fun f() lambda (int a) -> b 1", errUndeclaredType(NO_SRC, "b", 0));
+    CHECK_DIAG("fun f() lambda (int int) 1", errConstNameConflictsWithType(NO_SRC, "int"));
+    CHECK_DIAG("fun f() lambda (int i, int i) 1", errConstNameConflictsWithConst(NO_SRC, "i"));
     CHECK_DIAG(
         "fun f{T}() lambda (int T) 1 "
         "fun f() f{int}()",
-        errConstNameConflictsWithTypeSubstitution(src, "T", input::Span{23, 23}),
-        errInvalidFuncInstantiation(src, input::Span{36, 36}),
-        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{36, 43}));
-    CHECK_DIAG("fun f() lambda () b", errUndeclaredConst(src, "b", input::Span{18, 18}));
+        errConstNameConflictsWithTypeSubstitution(NO_SRC, "T"),
+        errInvalidFuncInstantiation(NO_SRC),
+        errNoPureFuncFoundToInstantiate(NO_SRC, "f", 1));
+    CHECK_DIAG("fun f() lambda () b", errUndeclaredConst(NO_SRC, "b"));
+    CHECK_DIAG("fun f() lambda () false ? i = 1 : i ", errUninitializedConst(NO_SRC, "i"));
+    CHECK_DIAG("fun f() false ? i = 1 : (lambda () i)() ", errUninitializedConst(NO_SRC, "i"));
     CHECK_DIAG(
-        "fun f() lambda () false ? i = 1 : i ",
-        errUninitializedConst(src, "i", input::Span{34, 34}));
-    CHECK_DIAG(
-        "fun f() false ? i = 1 : (lambda () i)() ",
-        errUninitializedConst(src, "i", input::Span{35, 35}));
-    CHECK_DIAG(
-        "fun f() lambda (int a) -> bool a",
-        errNoImplicitConversionFound(src, "int", "bool", input::Span{8, 31}));
+        "fun f() lambda (int a) -> bool a", errNoImplicitConversionFound(NO_SRC, "int", "bool"));
     CHECK_DIAG(
         "act a1() -> int 42 "
         "act a2() lambda () a1()",
-        errUndeclaredPureFunc(src, "a1", {}, input::Span{38, 41}));
-    CHECK_DIAG(
-        "fun f() lambda (int i = 0) i",
-        errUnsupportedArgInitializer(src, "i", input::Span{16, 24}));
+        errUndeclaredPureFunc(NO_SRC, "a1", {}));
+    CHECK_DIAG("fun f() lambda (int i = 0) i", errUnsupportedArgInitializer(NO_SRC, "i"));
   }
 }
 

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -144,60 +144,52 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
     CHECK_DIAG(
         "fun a() -> int 1 "
         "fun a() -> int 1",
-        errDuplicateFuncDeclaration(src, "a", input::Span{17, 32}));
-    CHECK_DIAG("fun a(b c) -> int 1", errUndeclaredType(src, "b", 0, input::Span{6, 6}));
-    CHECK_DIAG("fun a() -> b 1", errUndeclaredType(src, "b", 0, input::Span{11, 11}));
-    CHECK_DIAG(
-        "fun bool(int i) -> int i",
-        errIncorrectReturnTypeInConvFunc(src, "bool", "int", input::Span{4, 7}));
+        errDuplicateFuncDeclaration(NO_SRC, "a"));
+    CHECK_DIAG("fun a(b c) -> int 1", errUndeclaredType(NO_SRC, "b", 0));
+    CHECK_DIAG("fun a() -> b 1", errUndeclaredType(NO_SRC, "b", 0));
+    CHECK_DIAG("fun bool(int i) -> int i", errIncorrectReturnTypeInConvFunc(NO_SRC, "bool", "int"));
     CHECK_DIAG(
         "struct s{T1, T2} = T1 a, T2 b "
         "fun s{T}(T a) -> T a "
         "fun f() s{int}(1)",
-        errIncorrectReturnTypeInConvFunc(src, "s{int}", "int", input::Span{30, 49}),
-        errInvalidFuncInstantiation(src, input::Span{59, 59}),
-        errNoTypeOrConversionFoundToInstantiate(src, "s", 1, input::Span{59, 67}));
-    CHECK_DIAG(
-        "fun -(int i) -> int 1", errDuplicateFuncDeclaration(src, "operator-", input::Span{0, 20}));
-    CHECK_DIAG("fun &&() -> int 1", errNonOverloadableOperator(src, "&&", input::Span{4, 5}));
-    CHECK_DIAG(
-        "fun f{int}() -> int 1", errTypeParamNameConflictsWithType(src, "int", input::Span{6, 8}));
+        errIncorrectReturnTypeInConvFunc(NO_SRC, "s{int}", "int"),
+        errInvalidFuncInstantiation(NO_SRC),
+        errNoTypeOrConversionFoundToInstantiate(NO_SRC, "s", 1));
+    CHECK_DIAG("fun -(int i) -> int 1", errDuplicateFuncDeclaration(NO_SRC, "operator-"));
+    CHECK_DIAG("fun &&() -> int 1", errNonOverloadableOperator(NO_SRC, "&&"));
+    CHECK_DIAG("fun f{int}() -> int 1", errTypeParamNameConflictsWithType(NO_SRC, "int"));
     CHECK_DIAG(
         "fun f{T}(T{int} a) -> int i "
         "fun f() f{int}(1)",
-        errTypeParamOnSubstitutionType(src, "T", input::Span{9, 14}),
-        errUndeclaredType(src, "T", 1, input::Span{9, 14}));
+        errTypeParamOnSubstitutionType(NO_SRC, "T"),
+        errUndeclaredType(NO_SRC, "T", 1));
     CHECK_DIAG(
         "fun f{T}(T a) b "
         "fun f() f{int}(1)",
-        errUndeclaredConst(src, "b", input::Span{14, 14}),
-        errInvalidFuncInstantiation(src, input::Span{24, 24}),
-        errNoPureFuncFoundToInstantiate(src, "f", 1, input::Span{24, 32}));
+        errUndeclaredConst(NO_SRC, "b"),
+        errInvalidFuncInstantiation(NO_SRC),
+        errNoPureFuncFoundToInstantiate(NO_SRC, "f", 1));
+    CHECK_DIAG("fun +() -> int i", errOperatorOverloadWithoutArgs(NO_SRC, "operator+"));
+    CHECK_DIAG("fun +{T}() -> T T()", errOperatorOverloadWithoutArgs(NO_SRC, "operator+"));
+    CHECK_DIAG("fun f{T}(test a) -> int 1", errUndeclaredType(NO_SRC, "test", 0));
+    CHECK_DIAG("fun f{T}(int{M} a) -> int 1", errUndeclaredType(NO_SRC, "M", 0));
+    CHECK_DIAG("fun f{T}(int{T{M}} a) -> int 1", errUndeclaredType(NO_SRC, "M", 0));
     CHECK_DIAG(
-        "fun +() -> int i", errOperatorOverloadWithoutArgs(src, "operator+", input::Span{4, 4}));
-    CHECK_DIAG(
-        "fun +{T}() -> T T()", errOperatorOverloadWithoutArgs(src, "operator+", input::Span{4, 4}));
-    CHECK_DIAG("fun f{T}(test a) -> int 1", errUndeclaredType(src, "test", 0, input::Span{9, 12}));
-    CHECK_DIAG("fun f{T}(int{M} a) -> int 1", errUndeclaredType(src, "M", 0, input::Span{13, 13}));
-    CHECK_DIAG(
-        "fun f{T}(int{T{M}} a) -> int 1", errUndeclaredType(src, "M", 0, input::Span{15, 15}));
-    CHECK_DIAG(
-        "fun assert(bool cond, string msg) input",
-        errDuplicateFuncDeclaration(src, "assert", input::Span{0, 38}));
-    CHECK_DIAG("act +(int i) i + 1", errNonPureOperatorOverload(src, input::Span{4, 4}));
-    CHECK_DIAG("act +{T}(T t) t + 1", errNonPureOperatorOverload(src, input::Span{4, 4}));
+        "fun assert(bool cond, string msg) input", errDuplicateFuncDeclaration(NO_SRC, "assert"));
+    CHECK_DIAG("act +(int i) i + 1", errNonPureOperatorOverload(NO_SRC));
+    CHECK_DIAG("act +{T}(T t) t + 1", errNonPureOperatorOverload(NO_SRC));
     CHECK_DIAG(
         "struct S = int i, bool b "
         "act S() S(0, false)",
-        errNonPureConversion(src, input::Span{29, 29}));
+        errNonPureConversion(NO_SRC));
     CHECK_DIAG(
         "struct S{T} = int i, T t "
         "act S{T}() S{T}(0, T()) "
         "act a() S{int}()",
-        errNonPureConversion(src, input::Span{25, 47}),
-        errInvalidFuncInstantiation(src, input::Span{57, 57}),
-        errUndeclaredTypeOrConversion(src, "S{int}", {}, input::Span{57, 64}));
-    CHECK_DIAG("fun f(int a = 0, int b) a * b", errNonOptArgFollowingOpt(src, input::Span{17, 21}));
+        errNonPureConversion(NO_SRC),
+        errInvalidFuncInstantiation(NO_SRC),
+        errUndeclaredTypeOrConversion(NO_SRC, "S{int}", {}));
+    CHECK_DIAG("fun f(int a = 0, int b) a * b", errNonOptArgFollowingOpt(NO_SRC));
   }
 }
 

--- a/tests/frontend/declare_user_types_test.cpp
+++ b/tests/frontend/declare_user_types_test.cpp
@@ -76,40 +76,36 @@ TEST_CASE("[frontend] Analyzing user-type declarations", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG("struct int = bool i", errTypeAlreadyDeclared(src, "int", input::Span{7, 9}));
-    CHECK_DIAG("union int = int, bool", errTypeAlreadyDeclared(src, "int", input::Span{6, 8}));
-    CHECK_DIAG(
-        "struct function = bool i", errTypeNameIsReserved(src, "function", input::Span{7, 14}));
-    CHECK_DIAG("struct action = bool i", errTypeNameIsReserved(src, "action", input::Span{7, 12}));
-    CHECK_DIAG(
-        "struct assert = bool i", errTypeNameConflictsWithFunc(src, "assert", input::Span{7, 12}));
-    CHECK_DIAG(
-        "union assert = int, bool",
-        errTypeNameConflictsWithFunc(src, "assert", input::Span{6, 11}));
+    CHECK_DIAG("struct int = bool i", errTypeAlreadyDeclared(NO_SRC, "int"));
+    CHECK_DIAG("union int = int, bool", errTypeAlreadyDeclared(NO_SRC, "int"));
+    CHECK_DIAG("struct function = bool i", errTypeNameIsReserved(NO_SRC, "function"));
+    CHECK_DIAG("struct action = bool i", errTypeNameIsReserved(NO_SRC, "action"));
+    CHECK_DIAG("struct assert = bool i", errTypeNameConflictsWithFunc(NO_SRC, "assert"));
+    CHECK_DIAG("union assert = int, bool", errTypeNameConflictsWithFunc(NO_SRC, "assert"));
     CHECK_DIAG(
         "struct s = int i "
         "struct s = bool b",
-        errTypeAlreadyDeclared(src, "s", input::Span{24, 24}));
+        errTypeAlreadyDeclared(NO_SRC, "s"));
     CHECK_DIAG(
         "union u = int, bool "
         "union u = bool, int",
-        errTypeAlreadyDeclared(src, "u", input::Span{26, 26}));
+        errTypeAlreadyDeclared(NO_SRC, "u"));
     CHECK_DIAG(
         "union s = int, bool "
         "struct s = bool b",
-        errTypeAlreadyDeclared(src, "s", input::Span{27, 27}));
+        errTypeAlreadyDeclared(NO_SRC, "s"));
     CHECK_DIAG(
         "union s{T} = T, bool "
         "struct s = bool b",
-        errTypeTemplateAlreadyDeclared(src, "s", input::Span{28, 28}));
+        errTypeTemplateAlreadyDeclared(NO_SRC, "s"));
     CHECK_DIAG(
         "union s{T} = T, bool "
         "struct s{T} = T t",
-        errTypeTemplateAlreadyDeclared(src, "s", input::Span{28, 28}));
-    CHECK_DIAG("enum int = a", errTypeAlreadyDeclared(src, "int", input::Span{5, 7}));
-    CHECK_DIAG("enum function = a", errTypeNameIsReserved(src, "function", input::Span{5, 12}));
-    CHECK_DIAG("enum action = a", errTypeNameIsReserved(src, "action", input::Span{5, 10}));
-    CHECK_DIAG("enum assert = a", errTypeNameConflictsWithFunc(src, "assert", input::Span{5, 10}));
+        errTypeTemplateAlreadyDeclared(NO_SRC, "s"));
+    CHECK_DIAG("enum int = a", errTypeAlreadyDeclared(NO_SRC, "int"));
+    CHECK_DIAG("enum function = a", errTypeNameIsReserved(NO_SRC, "function"));
+    CHECK_DIAG("enum action = a", errTypeNameIsReserved(NO_SRC, "action"));
+    CHECK_DIAG("enum assert = a", errTypeNameConflictsWithFunc(NO_SRC, "assert"));
   }
 }
 

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -78,12 +78,11 @@ TEST_CASE("[frontend] Analyzing execute statements", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG("things()", errUndeclaredFuncOrAction(src, "things", {}, input::Span{0, 7}));
+    CHECK_DIAG("things()", errUndeclaredFuncOrAction(NO_SRC, "things", {}));
     CHECK_DIAG(
         "assert(1, 1)",
-        errUndeclaredFuncOrAction(
-            src, "assert", std::vector<std::string>{"int", "int"}, input::Span{0, 11}));
-    CHECK_DIAG("assert(test())", errUndeclaredFuncOrAction(src, "test", {}, input::Span{7, 12}));
+        errUndeclaredFuncOrAction(NO_SRC, "assert", std::vector<std::string>{"int", "int"}));
+    CHECK_DIAG("assert(test())", errUndeclaredFuncOrAction(NO_SRC, "test", {}));
   }
 }
 

--- a/tests/frontend/define_user_types_test.cpp
+++ b/tests/frontend/define_user_types_test.cpp
@@ -99,54 +99,46 @@ TEST_CASE("[frontend] Analyzing user-type definitions", "frontend") {
   }
 
   SECTION("Struct diagnostics") {
-    CHECK_DIAG(
-        "struct s = hello a, bool b", errUndeclaredType(src, "hello", 0, input::Span{11, 15}));
-    CHECK_DIAG(
-        "struct s = int a, bool a", errDuplicateFieldNameInStruct(src, "a", input::Span{23, 23}));
-    CHECK_DIAG(
-        "struct s = int int", errFieldNameConflictsWithType(src, "int", input::Span{15, 17}));
-    CHECK_DIAG(
-        "struct s = int function",
-        errFieldNameConflictsWithType(src, "function", input::Span{15, 22}));
-    CHECK_DIAG(
-        "struct s = int action", errFieldNameConflictsWithType(src, "action", input::Span{15, 20}));
-    CHECK_DIAG("struct s = s i", errCyclicStruct(src, "i", "s", input::Span{0, 13}));
+    CHECK_DIAG("struct s = hello a, bool b", errUndeclaredType(NO_SRC, "hello", 0));
+    CHECK_DIAG("struct s = int a, bool a", errDuplicateFieldNameInStruct(NO_SRC, "a"));
+    CHECK_DIAG("struct s = int int", errFieldNameConflictsWithType(NO_SRC, "int"));
+    CHECK_DIAG("struct s = int function", errFieldNameConflictsWithType(NO_SRC, "function"));
+    CHECK_DIAG("struct s = int action", errFieldNameConflictsWithType(NO_SRC, "action"));
+    CHECK_DIAG("struct s = s i", errCyclicStruct(NO_SRC, "i", "s"));
     CHECK_DIAG(
         "struct s1 = s2 a "
         "struct s2 = s1 b",
-        errCyclicStruct(src, "a", "s1", input::Span{0, 15}),
-        errCyclicStruct(src, "b", "s2", input::Span{17, 32}));
+        errCyclicStruct(NO_SRC, "a", "s1"),
+        errCyclicStruct(NO_SRC, "b", "s2"));
     CHECK_DIAG(
         "struct s1 = s2 a "
         "struct s2 = int a, s1 b "
         "struct s3 = s1 a, s2 b",
-        errCyclicStruct(src, "a", "s1", input::Span{0, 15}),
-        errCyclicStruct(src, "b", "s2", input::Span{17, 39}),
-        errCyclicStruct(src, "a", "s3", input::Span{41, 62}));
+        errCyclicStruct(NO_SRC, "a", "s1"),
+        errCyclicStruct(NO_SRC, "b", "s2"),
+        errCyclicStruct(NO_SRC, "a", "s3"));
     CHECK_DIAG(
         "struct s{T} = T T "
         "struct s2 = s{int} s",
-        errFieldNameConflictsWithTypeSubstitution(src, "T", input::Span{16, 16}),
-        errInvalidTypeInstantiation(src, input::Span{30, 30}),
-        errUndeclaredType(src, "s", 1, input::Span{30, 35}));
+        errFieldNameConflictsWithTypeSubstitution(NO_SRC, "T"),
+        errInvalidTypeInstantiation(NO_SRC),
+        errUndeclaredType(NO_SRC, "s", 1));
   }
 
   SECTION("Union diagnostics") {
-    CHECK_DIAG("union u = hello, bool", errUndeclaredType(src, "hello", 0, input::Span{10, 14}));
-    CHECK_DIAG(
-        "union u = int, int", errDuplicateTypeInUnion(src, "int", "int", input::Span{15, 17}));
+    CHECK_DIAG("union u = hello, bool", errUndeclaredType(NO_SRC, "hello", 0));
+    CHECK_DIAG("union u = int, int", errDuplicateTypeInUnion(NO_SRC, "int", "int"));
     CHECK_DIAG(
         "union u{T} = int, T "
         "fun f(u{int} in) -> int 1",
-        errDuplicateTypeInUnion(src, "T", "int", input::Span{18, 18}),
-        errInvalidTypeInstantiation(src, input::Span{26, 26}),
-        errUndeclaredType(src, "u", 1, input::Span{26, 31}));
+        errDuplicateTypeInUnion(NO_SRC, "T", "int"),
+        errInvalidTypeInstantiation(NO_SRC),
+        errUndeclaredType(NO_SRC, "u", 1));
   }
 
   SECTION("Enum diagnostics") {
-    CHECK_DIAG("enum e = a, b, a", errDuplicateEntryNameInEnum(src, "a", input::Span{15, 15}));
-    CHECK_DIAG(
-        "enum e = a : 1, b, c : 1", errDuplicateEntryValueInEnum(src, 1, input::Span{19, 23}));
+    CHECK_DIAG("enum e = a, b, a", errDuplicateEntryNameInEnum(NO_SRC, "a"));
+    CHECK_DIAG("enum e = a : 1, b, c : 1", errDuplicateEntryValueInEnum(NO_SRC, 1));
   }
 }
 

--- a/tests/frontend/get_binary_expr_test.cpp
+++ b/tests/frontend/get_binary_expr_test.cpp
@@ -139,14 +139,11 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
 
   SECTION("Diagnostics") {
     CHECK_DIAG(
-        "fun f() -> int true + false",
-        errUndeclaredBinOperator(src, "+", "bool", "bool", input::Span{20, 20}));
+        "fun f() -> int true + false", errUndeclaredBinOperator(NO_SRC, "+", "bool", "bool"));
     CHECK_DIAG(
-        "fun f(int a, bool b) -> bool a && b",
-        errNoImplicitConversionFound(src, "int", "bool", input::Span{29, 29}));
+        "fun f(int a, bool b) -> bool a && b", errNoImplicitConversionFound(NO_SRC, "int", "bool"));
     CHECK_DIAG(
-        "fun f(bool a, int b) -> bool a || b",
-        errNoImplicitConversionFound(src, "int", "bool", input::Span{34, 34}));
+        "fun f(bool a, int b) -> bool a || b", errNoImplicitConversionFound(NO_SRC, "int", "bool"));
   }
 }
 

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -220,38 +220,34 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
   SECTION("Diagnostics") {
     CHECK_DIAG(
         "fun f(function{int, float, bool} op) -> bool op(false, 1.0)",
-        errIncorrectArgsToDelegate(src, input::Span{45, 58}));
+        errIncorrectArgsToDelegate(NO_SRC));
     CHECK_DIAG(
         "fun f1(int v) -> int v "
         "fun f1(float v) -> float v "
         "fun f2() -> int op = f1; op()",
-        errAmbiguousFunction(src, "f1", input::Span{71, 72}),
-        errUndeclaredPureFunc(src, "op", {}, input::Span{75, 78}));
+        errAmbiguousFunction(NO_SRC, "f1"),
+        errUndeclaredPureFunc(NO_SRC, "op", {}));
     CHECK_DIAG(
         "fun f1{T}(int v) -> T T() "
         "fun f1{T}(float v) -> T T() "
         "fun f2() -> int op = f1{int}; op(1)",
-        errAmbiguousTemplateFunction(src, "f1", 1, input::Span{75, 81}),
-        errUndeclaredPureFunc(src, "op", {"int"}, input::Span{84, 88}));
-    CHECK_DIAG(
-        "fun f() f1{float}", errNoPureFuncFoundToInstantiate(src, "f1", 1, input::Span{8, 16}));
-    CHECK_DIAG(
-        "act a() f1{float}", errNoFuncOrActionFoundToInstantiate(src, "f1", 1, input::Span{8, 16}));
+        errAmbiguousTemplateFunction(NO_SRC, "f1", 1),
+        errUndeclaredPureFunc(NO_SRC, "op", {"int"}));
+    CHECK_DIAG("fun f() f1{float}", errNoPureFuncFoundToInstantiate(NO_SRC, "f1", 1));
+    CHECK_DIAG("act a() f1{float}", errNoFuncOrActionFoundToInstantiate(NO_SRC, "f1", 1));
     CHECK_DIAG(
         "fun f1{T}() -> T T() "
         "fun f2() -> int op = f1; op()",
-        errNoTypeParamsProvidedToTemplateFunction(src, "f1", input::Span{42, 43}),
-        errUndeclaredPureFunc(src, "op", {}, input::Span{46, 49}));
+        errNoTypeParamsProvidedToTemplateFunction(NO_SRC, "f1"),
+        errUndeclaredPureFunc(NO_SRC, "op", {}));
     CHECK_DIAG(
-        "fun f() -> function{string, string} conWrite",
-        errUndeclaredConst(src, "conWrite", input::Span{36, 43}));
+        "fun f() -> function{string, string} conWrite", errUndeclaredConst(NO_SRC, "conWrite"));
     CHECK_DIAG(
         "fun f() -> string op = conWrite; op(\"hello world\")",
-        errUndeclaredConst(src, "conWrite", input::Span{23, 30}),
-        errUndeclaredPureFunc(src, "op", {"string"}, input::Span{33, 49}));
-    CHECK_DIAG("fun f(action{int} a) a()", errIllegalDelegateCall(src, input::Span{21, 23}));
-    CHECK_DIAG(
-        "fun f(action{int} a) lambda () a()", errIllegalDelegateCall(src, input::Span{31, 33}));
+        errUndeclaredConst(NO_SRC, "conWrite"),
+        errUndeclaredPureFunc(NO_SRC, "op", {"string"}));
+    CHECK_DIAG("fun f(action{int} a) a()", errIllegalDelegateCall(NO_SRC));
+    CHECK_DIAG("fun f(action{int} a) lambda () a()", errIllegalDelegateCall(NO_SRC));
   }
 }
 

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -265,54 +265,48 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     CHECK_DIAG(
         "fun f1() -> int 1 "
         "fun f2() -> int f3()",
-        errUndeclaredPureFunc(src, "f3", {}, input::Span{34, 37}));
+        errUndeclaredPureFunc(NO_SRC, "f3", {}));
     CHECK_DIAG(
         "fun f1() -> int 1 "
         "fun f2() -> int f2(1)",
-        errUndeclaredPureFunc(src, "f2", {"int"}, input::Span{34, 38}));
-    CHECK_DIAG("fun f() -> int 1()", errUndeclaredCallOperator(src, {"int"}, input::Span{15, 17}));
-    CHECK_DIAG(
-        "fun f(int i) -> int i()", errUndeclaredCallOperator(src, {"int"}, input::Span{20, 22}));
-    CHECK_DIAG(
-        "fun f1(int i) -> int i.f2()",
-        errFieldNotFoundOnType(src, "f2", "int", input::Span{21, 24}));
+        errUndeclaredPureFunc(NO_SRC, "f2", {"int"}));
+    CHECK_DIAG("fun f() -> int 1()", errUndeclaredCallOperator(NO_SRC, {"int"}));
+    CHECK_DIAG("fun f(int i) -> int i()", errUndeclaredCallOperator(NO_SRC, {"int"}));
+    CHECK_DIAG("fun f1(int i) -> int i.f2()", errFieldNotFoundOnType(NO_SRC, "f2", "int"));
     CHECK_DIAG(
         "act length(string str) -> int intrinsic{string_length}(str) "
         "fun f() -> int (42).length()",
-        errUndeclaredPureFunc(src, "length", {"int"}, input::Span{75, 87}));
+        errUndeclaredPureFunc(NO_SRC, "length", {"int"}));
     CHECK_DIAG(
         "fun ()(string s) -> int intrinsic{string_length}(s) "
         "fun f() -> int 42()",
-        errUndeclaredCallOperator(src, {"int"}, input::Span{67, 70}));
+        errUndeclaredCallOperator(NO_SRC, {"int"}));
     CHECK_DIAG(
         "act a() -> int 1 "
         "fun f2() -> int a()",
-        errUndeclaredPureFunc(src, "a", {}, input::Span{33, 35}));
+        errUndeclaredPureFunc(NO_SRC, "a", {}));
     CHECK_DIAG(
         "act a{T}() -> T T() "
         "fun f2() -> int a{int}()",
-        errNoPureFuncFoundToInstantiate(src, "a", 1, input::Span{36, 43}));
+        errNoPureFuncFoundToInstantiate(NO_SRC, "a", 1));
     CHECK_DIAG(
         "act a(int i) -> int i * 2 "
         "fun f2(int i) -> int i.a()",
-        errUndeclaredPureFunc(src, "a", {"int"}, input::Span{47, 51}));
+        errUndeclaredPureFunc(NO_SRC, "a", {"int"}));
     CHECK_DIAG(
         "fun f(future{int} fi) -> int fork intrinsic{future_get}(fi)",
-        errForkedNonUserFunc(src, input::Span{29, 58}));
+        errForkedNonUserFunc(NO_SRC));
     CHECK_DIAG(
-        "fun f(future{int} fi) -> int lazy intrinsic{future_get}(fi)",
-        errLazyNonUserFunc(src, input::Span{29, 58}));
-    CHECK_DIAG(
-        "fun f() -> int fail{int}()",
-        errNoPureFuncFoundToInstantiate(src, "fail", 1, input::Span{15, 25}));
+        "fun f(future{int} fi) -> int lazy intrinsic{future_get}(fi)", errLazyNonUserFunc(NO_SRC));
+    CHECK_DIAG("fun f() -> int fail{int}()", errNoPureFuncFoundToInstantiate(NO_SRC, "fail", 1));
     CHECK_DIAG(
         "act f() -> int intrinsic{fail}()",
-        errInvalidFailIntrinsicCall(src, 0, 0, input::Span{15, 31}),
-        errUnknownIntrinsic(src, "fail", false, {}, input::Span{15, 31}));
+        errInvalidFailIntrinsicCall(NO_SRC, 0, 0),
+        errUnknownIntrinsic(NO_SRC, "fail", false, {}));
     CHECK_DIAG(
         "act f() -> int intrinsic{fail}(1)",
-        errInvalidFailIntrinsicCall(src, 0, 1, input::Span{15, 32}),
-        errUnknownIntrinsic(src, "fail", false, {"int"}, input::Span{15, 32}));
+        errInvalidFailIntrinsicCall(NO_SRC, 0, 1),
+        errUnknownIntrinsic(NO_SRC, "fail", false, {"int"}));
   }
 }
 

--- a/tests/frontend/get_call_self_expr_test.cpp
+++ b/tests/frontend/get_call_self_expr_test.cpp
@@ -39,20 +39,15 @@ TEST_CASE("[frontend] Analyzing self call expressions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG("conWrite(self())", errSelfCallInNonFunc(src, input::Span{9, 14}));
-    CHECK_DIAG(
-        "fun f(int i) i < 0 ? fork self(0) : i", errForkedSelfCall(src, input::Span{21, 32}));
-    CHECK_DIAG("fun f(int i) i < 0 ? lazy self(0) : i", errLazySelfCall(src, input::Span{21, 32}));
-    CHECK_DIAG("fun f() self()", errSelfCallWithoutInferredRetType(src, input::Span{8, 13}));
-    CHECK_DIAG(
-        "fun f(int i) i < 0 ? self() : i",
-        errIncorrectNumArgsInSelfCall(src, 1, 0, input::Span{21, 26}));
-    CHECK_DIAG(
-        "fun f(int i) i < 0 ? self(i, 1) : i",
-        errIncorrectNumArgsInSelfCall(src, 1, 2, input::Span{21, 30}));
+    CHECK_DIAG("conWrite(self())", errSelfCallInNonFunc(NO_SRC));
+    CHECK_DIAG("fun f(int i) i < 0 ? fork self(0) : i", errForkedSelfCall(NO_SRC));
+    CHECK_DIAG("fun f(int i) i < 0 ? lazy self(0) : i", errLazySelfCall(NO_SRC));
+    CHECK_DIAG("fun f() self()", errSelfCallWithoutInferredRetType(NO_SRC));
+    CHECK_DIAG("fun f(int i) i < 0 ? self() : i", errIncorrectNumArgsInSelfCall(NO_SRC, 1, 0));
+    CHECK_DIAG("fun f(int i) i < 0 ? self(i, 1) : i", errIncorrectNumArgsInSelfCall(NO_SRC, 1, 2));
     CHECK_DIAG(
         "fun f(int i) i < 0 ? self(\"hello\") : i",
-        errNoImplicitConversionFound(src, "string", "int", input::Span{26, 32}));
+        errNoImplicitConversionFound(NO_SRC, "string", "int"));
   }
 }
 

--- a/tests/frontend/get_conditional_expr_test.cpp
+++ b/tests/frontend/get_conditional_expr_test.cpp
@@ -83,11 +83,11 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
     CHECK_DIAG(
         "fun f(int a) -> int "
         "a ? 1 : 2",
-        errNoImplicitConversionFound(src, "int", "bool", input::Span{20, 20}));
+        errNoImplicitConversionFound(NO_SRC, "int", "bool"));
     CHECK_DIAG(
         "fun f() -> int "
         "true ? 1 : true",
-        errNoImplicitConversionFound(src, "bool", "int", input::Span{22, 22}));
+        errNoImplicitConversionFound(NO_SRC, "bool", "int"));
   }
 }
 

--- a/tests/frontend/get_const_expr_test.cpp
+++ b/tests/frontend/get_const_expr_test.cpp
@@ -54,31 +54,25 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG("fun f() -> int x", errUndeclaredConst(src, "x", input::Span{15, 15}));
-    CHECK_DIAG(
-        "fun f() -> int bool = 42",
-        errConstNameConflictsWithType(src, "bool", input::Span{15, 18}));
-    CHECK_DIAG(
-        "fun f(int a) -> int a = 42",
-        errConstNameConflictsWithConst(src, "a", input::Span{20, 20}));
+    CHECK_DIAG("fun f() -> int x", errUndeclaredConst(NO_SRC, "x"));
+    CHECK_DIAG("fun f() -> int bool = 42", errConstNameConflictsWithType(NO_SRC, "bool"));
+    CHECK_DIAG("fun f(int a) -> int a = 42", errConstNameConflictsWithConst(NO_SRC, "a"));
     CHECK_DIAG(
         "fun f(int a) -> int "
         "if a > 5  -> b = 1 "
         "else      -> b = 2",
-        errConstNameConflictsWithConst(src, "b", input::Span{52, 52}));
+        errConstNameConflictsWithConst(NO_SRC, "b"));
     CHECK_DIAG(
         "fun f(int a) -> int "
         "if a > 5  -> b = 1 "
         "else      -> b + 1",
-        errUninitializedConst(src, "b", input::Span{52, 52}));
+        errUninitializedConst(NO_SRC, "b"));
     CHECK_DIAG(
         "fun f(int a) -> int "
         "if b = a * a; b > 5  -> b "
         "else                 -> b + 1",
-        errUninitializedConst(src, "b", input::Span{70, 70}));
-    CHECK_DIAG(
-        "fun f() -> int (true && (x = 5; false)); x",
-        errUninitializedConst(src, "x", input::Span{41, 41}));
+        errUninitializedConst(NO_SRC, "b"));
+    CHECK_DIAG("fun f() -> int (true && (x = 5; false)); x", errUninitializedConst(NO_SRC, "x"));
   }
 }
 

--- a/tests/frontend/get_enum_expr_test.cpp
+++ b/tests/frontend/get_enum_expr_test.cpp
@@ -18,12 +18,11 @@ TEST_CASE("[frontend] Analyzing enum expressions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG(
-        "fun f() -> int int.a", errStaticFieldNotFoundOnType(src, "a", "int", input::Span{19, 19}));
+    CHECK_DIAG("fun f() -> int int.a", errStaticFieldNotFoundOnType(NO_SRC, "a", "int"));
     CHECK_DIAG(
         "enum E = a, c "
         "fun f() -> int E.b",
-        errValueNotFoundInEnum(src, "b", "E", input::Span{31, 31}));
+        errValueNotFoundInEnum(NO_SRC, "b", "E"));
   }
 }
 

--- a/tests/frontend/get_field_expr_test.cpp
+++ b/tests/frontend/get_field_expr_test.cpp
@@ -49,12 +49,11 @@ TEST_CASE("[frontend] Analyzing field expressions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG(
-        "fun f(int i) -> int i.a", errFieldNotFoundOnType(src, "a", "int", input::Span{20, 22}));
+    CHECK_DIAG("fun f(int i) -> int i.a", errFieldNotFoundOnType(NO_SRC, "a", "int"));
     CHECK_DIAG(
         "struct S = int a "
         "fun f(S s) -> int s.b",
-        errFieldNotFoundOnType(src, "b", "S", input::Span{35, 37}));
+        errFieldNotFoundOnType(NO_SRC, "b", "S"));
   }
 }
 

--- a/tests/frontend/get_index_expr_test.cpp
+++ b/tests/frontend/get_index_expr_test.cpp
@@ -55,16 +55,12 @@ TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG(
-        "fun f(int i) -> int i[.0]",
-        errUndeclaredIndexOperator(src, {"int", "float"}, input::Span{20, 24}));
+    CHECK_DIAG("fun f(int i) -> int i[.0]", errUndeclaredIndexOperator(NO_SRC, {"int", "float"}));
     CHECK_DIAG(
         "struct test = int i "
         "fun f(test t) -> int t[0]",
-        errUndeclaredIndexOperator(src, {"test", "int"}, input::Span{41, 44}));
-    CHECK_DIAG(
-        "fun f() -> int 42[0]",
-        errUndeclaredIndexOperator(src, {"int", "int"}, input::Span{15, 19}));
+        errUndeclaredIndexOperator(NO_SRC, {"test", "int"}));
+    CHECK_DIAG("fun f() -> int 42[0]", errUndeclaredIndexOperator(NO_SRC, {"int", "int"}));
   }
 }
 

--- a/tests/frontend/get_intrinsic_expr_test.cpp
+++ b/tests/frontend/get_intrinsic_expr_test.cpp
@@ -35,45 +35,43 @@ TEST_CASE("[frontend] Analyzing intrinsic expressions", "frontend") {
     CHECK_DIAG(
         "fun f() "
         "  intrinsic{test}",
-        errIntrinsicFuncLiteral(src, input::Span{10, 24}));
+        errIntrinsicFuncLiteral(NO_SRC));
     CHECK_DIAG(
         "fun f() -> int "
         "  intrinsic{test}",
-        errIntrinsicFuncLiteral(src, input::Span{17, 31}));
+        errIntrinsicFuncLiteral(NO_SRC));
     CHECK_DIAG(
         "fun f() "
         "  intrinsic{does_not_exist}()",
-        errUnknownIntrinsic(src, "does_not_exist", true, {}, input::Span{10, 36}));
+        errUnknownIntrinsic(NO_SRC, "does_not_exist", true, {}));
     CHECK_DIAG(
         "act a() "
         "  intrinsic{does_not_exist}()",
-        errUnknownIntrinsic(src, "does_not_exist", false, {}, input::Span{10, 36}));
+        errUnknownIntrinsic(NO_SRC, "does_not_exist", false, {}));
     CHECK_DIAG(
         "fun f() "
         "  intrinsic{does_not_exist}(1)",
-        errUnknownIntrinsic(src, "does_not_exist", true, {"int"}, input::Span{10, 37}));
+        errUnknownIntrinsic(NO_SRC, "does_not_exist", true, {"int"}));
     CHECK_DIAG(
         "act a() "
         "  intrinsic{does_not_exist}(1)",
-        errUnknownIntrinsic(src, "does_not_exist", false, {"int"}, input::Span{10, 37}));
+        errUnknownIntrinsic(NO_SRC, "does_not_exist", false, {"int"}));
     CHECK_DIAG(
         "fun f() "
         "  intrinsic{does_not_exist}(1, false)",
-        errUnknownIntrinsic(src, "does_not_exist", true, {"int", "bool"}, input::Span{10, 44}));
+        errUnknownIntrinsic(NO_SRC, "does_not_exist", true, {"int", "bool"}));
     CHECK_DIAG(
         "act a() "
         "  intrinsic{does_not_exist}(1, false)",
-        errUnknownIntrinsic(src, "does_not_exist", false, {"int", "bool"}, input::Span{10, 44}));
+        errUnknownIntrinsic(NO_SRC, "does_not_exist", false, {"int", "bool"}));
     CHECK_DIAG(
         "fun f() "
         "  intrinsic{platform_endianness_native}()",
-        errUnknownIntrinsic(src, "platform_endianness_native", true, {}, input::Span{10, 48}));
+        errUnknownIntrinsic(NO_SRC, "platform_endianness_native", true, {}));
     CHECK_DIAG(
-        "fun f() -> future{float} lazy intrinsic{float_sin}(42.0)",
-        errLazyNonUserFunc(src, input::Span{25, 55}));
+        "fun f() -> future{float} lazy intrinsic{float_sin}(42.0)", errLazyNonUserFunc(NO_SRC));
     CHECK_DIAG(
-        "fun f() -> future{float} fork intrinsic{float_sin}(42.0)",
-        errForkedNonUserFunc(src, input::Span{25, 55}));
+        "fun f() -> future{float} fork intrinsic{float_sin}(42.0)", errForkedNonUserFunc(NO_SRC));
   }
 }
 

--- a/tests/frontend/get_is_expr_test.cpp
+++ b/tests/frontend/get_is_expr_test.cpp
@@ -68,41 +68,41 @@ TEST_CASE("[frontend] Analyzing 'is' / 'as' expressions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG(" fun f(int i) i as bool b", errNonUnionIsExpression(src, input::Span{14, 14}));
+    CHECK_DIAG(" fun f(int i) i as bool b", errNonUnionIsExpression(NO_SRC));
     CHECK_DIAG(
         "struct S = int i "
         "fun f(S s) s as int i",
-        errNonUnionIsExpression(src, input::Span{28, 28}));
+        errNonUnionIsExpression(NO_SRC));
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) u as hello i",
-        errUndeclaredType(src, "hello", 0, input::Span{37, 41}));
+        errUndeclaredType(NO_SRC, "hello", 0));
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) u as bool b",
-        errTypeNotPartOfUnion(src, "bool", "U", input::Span{37, 40}));
+        errTypeNotPartOfUnion(NO_SRC, "bool", "U"));
 
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) !(u as int i) ? i : 42",
-        errUncheckedAsExpressionWithConst(src, input::Span{39, 41}));
+        errUncheckedAsExpressionWithConst(NO_SRC));
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) (u as int i; z = 4) ? i : 42",
-        errUncheckedAsExpressionWithConst(src, input::Span{38, 40}));
+        errUncheckedAsExpressionWithConst(NO_SRC));
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) -> int (u as int i || true) ? i : 42",
-        errUncheckedAsExpressionWithConst(src, input::Span{45, 47}));
+        errUncheckedAsExpressionWithConst(NO_SRC));
 
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) u as int int ? 1 : 2",
-        errConstNameConflictsWithType(src, "int", input::Span{41, 43}));
+        errConstNameConflictsWithType(NO_SRC, "int"));
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) u as int u ? 1 : 2",
-        errConstNameConflictsWithConst(src, "u", input::Span{41, 41}));
+        errConstNameConflictsWithConst(NO_SRC, "u"));
   }
 }
 

--- a/tests/frontend/get_switch_expr_test.cpp
+++ b/tests/frontend/get_switch_expr_test.cpp
@@ -113,32 +113,32 @@ TEST_CASE("[frontend] Analyzing switch expressions", "frontend") {
         "fun f(bool a) "
         "  if a   -> 1 "
         "  else   -> true",
-        errBranchesHaveNoCommonType(src, input::Span{16, 43}));
+        errBranchesHaveNoCommonType(NO_SRC));
     CHECK_DIAG(
         "fun f(int a) -> int "
         "  if a   -> 1 "
         "  else   -> 2",
-        errNoImplicitConversionFound(src, "int", "bool", input::Span{25, 25}));
+        errNoImplicitConversionFound(NO_SRC, "int", "bool"));
     CHECK_DIAG(
         "fun f() -> int "
         "  if true   -> 1 "
         "  else      -> true",
-        errNoImplicitConversionFound(src, "bool", "int", input::Span{34, 50}));
+        errNoImplicitConversionFound(NO_SRC, "bool", "int"));
     CHECK_DIAG(
         "fun f() -> int "
         "  if true   -> 1 "
         "  if false  -> false "
         "  else      -> 2",
-        errNoImplicitConversionFound(src, "bool", "int", input::Span{34, 51}));
+        errNoImplicitConversionFound(NO_SRC, "bool", "int"));
     CHECK_DIAG(
         "fun f() -> int "
         "  if false  -> 2 ",
-        errNonExhaustiveSwitchWithoutElse(src, input::Span{17, 30}));
+        errNonExhaustiveSwitchWithoutElse(NO_SRC));
     CHECK_DIAG(
         "union U = int, float "
         "fun f(U u) -> int "
         "  if u is float -> 1 ",
-        errNonExhaustiveSwitchWithoutElse(src, input::Span{41, 58}));
+        errNonExhaustiveSwitchWithoutElse(NO_SRC));
   }
 }
 

--- a/tests/frontend/get_unary_expr_test.cpp
+++ b/tests/frontend/get_unary_expr_test.cpp
@@ -24,8 +24,7 @@ TEST_CASE("[frontend] Analyzing unary expressions", "frontend") {
   }
 
   SECTION("Diagnostics") {
-    CHECK_DIAG(
-        "fun f() -> int -false", errUndeclaredUnaryOperator(src, "-", "bool", input::Span{15, 15}));
+    CHECK_DIAG("fun f() -> int -false", errUndeclaredUnaryOperator(NO_SRC, "-", "bool"));
   }
 }
 

--- a/tests/frontend/helpers.hpp
+++ b/tests/frontend/helpers.hpp
@@ -56,8 +56,7 @@ inline auto buildSource(std::string input) {
 
 #define CHECK_DIAG(INPUT, ...)                                                                     \
   {                                                                                                \
-    const auto src    = SRC(INPUT);                                                                \
-    const auto output = analyze(src);                                                              \
+    const auto output = analyze(SRC(INPUT));                                                       \
     const auto diags  = std::vector<frontend::Diag>{output.beginDiags(), output.endDiags()};       \
     const std::vector<frontend::Diag> expectedDiags = {__VA_ARGS__};                               \
     CHECK_THAT(diags, Catch::UnorderedEquals(expectedDiags));                                      \
@@ -105,5 +104,7 @@ inline auto arrayMoveToVec(Array c) {
 
 #define NO_EXPRS                                                                                   \
   std::vector<prog::expr::NodePtr> {}
+
+#define NO_SRC prog::sym::SourceId::none()
 
 } // namespace frontend

--- a/tests/frontend/import_test.cpp
+++ b/tests/frontend/import_test.cpp
@@ -7,9 +7,7 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing import statements", "frontend") {
 
   SECTION("Diagnostics") {
-    CHECK_DIAG(
-        "import \"nonexisting.ns\"",
-        errUnresolvedImport(src, "nonexisting.ns", input::Span{7, 22}));
+    CHECK_DIAG("import \"nonexisting.ns\"", errUnresolvedImport(NO_SRC, "nonexisting.ns"));
   }
 }
 

--- a/tests/frontend/opt_args_test.cpp
+++ b/tests/frontend/opt_args_test.cpp
@@ -123,43 +123,37 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
 
       CHECK_DIAG(
           "fun f(int a = \"Hello World\") a",
-          errNonMatchingInitializerType(src, "int", "string", input::Span{14, 26}));
+          errNonMatchingInitializerType(NO_SRC, "int", "string"));
       CHECK_DIAG(
           "struct S{T} = T t "
           "fun f(S{int} a = S(\"Hello World\")) a",
-          errNonMatchingInitializerType(src, "S{int}", "S{string}", input::Span{35, 50}));
+          errNonMatchingInitializerType(NO_SRC, "S{int}", "S{string}"));
 
-      CHECK_DIAG("fun f(int a = (b = 2)) a", errConstDeclareNotSupported(src, input::Span{15, 19}));
+      CHECK_DIAG("fun f(int a = (b = 2)) a", errConstDeclareNotSupported(NO_SRC));
       CHECK_DIAG(
           "fun f(int a = (b = 2; b * 2)) a",
-          errConstDeclareNotSupported(src, input::Span{15, 19}),
-          errUndeclaredConst(src, "b", input::Span{22, 22}));
+          errConstDeclareNotSupported(NO_SRC),
+          errUndeclaredConst(NO_SRC, "b"));
 
-      CHECK_DIAG(
-          "fun fb(int a = fb()) a", errUndeclaredPureFunc(src, "fb", {}, input::Span{15, 18}));
+      CHECK_DIAG("fun fb(int a = fb()) a", errUndeclaredPureFunc(NO_SRC, "fb", {}));
       CHECK_DIAG(
           "fun fa(int a = 0) a "
           "fun fb(int a = fa()) a",
-          errUndeclaredPureFunc(src, "fa", {}, input::Span{35, 38}));
+          errUndeclaredPureFunc(NO_SRC, "fa", {}));
       CHECK_DIAG(
           "fun fa(int a = fb()) a "
           "fun fb(int a = fa()) a",
-          errUndeclaredPureFunc(src, "fb", {}, input::Span{15, 18}),
-          errUndeclaredPureFunc(src, "fa", {}, input::Span{38, 41}));
+          errUndeclaredPureFunc(NO_SRC, "fb", {}),
+          errUndeclaredPureFunc(NO_SRC, "fa", {}));
 
-      CHECK_DIAG(
-          "fun f(int a = 0, int b) a + b", errNonOptArgFollowingOpt(src, input::Span{17, 21}));
-      CHECK_DIAG(
-          "fun f(int a = 0, int b, int c = 0) a + b + c",
-          errNonOptArgFollowingOpt(src, input::Span{17, 21}));
-      CHECK_DIAG(
-          "fun f(int a, int b = 0, int c) a + b + c",
-          errNonOptArgFollowingOpt(src, input::Span{24, 28}));
+      CHECK_DIAG("fun f(int a = 0, int b) a + b", errNonOptArgFollowingOpt(NO_SRC));
+      CHECK_DIAG("fun f(int a = 0, int b, int c = 0) a + b + c", errNonOptArgFollowingOpt(NO_SRC));
+      CHECK_DIAG("fun f(int a, int b = 0, int c) a + b + c", errNonOptArgFollowingOpt(NO_SRC));
 
       CHECK_DIAG(
           "act a() 42 "
           "fun f(int i = a()) i",
-          errUndeclaredPureFunc(src, "a", {}, input::Span{25, 27}));
+          errUndeclaredPureFunc(NO_SRC, "a", {}));
     }
   }
 
@@ -228,32 +222,31 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
       CHECK_DIAG(
           "fun ft{T}(T a = \"Hello World\") a "
           "fun f() ft{int}()",
-          errNonMatchingInitializerType(src, "int", "string", input::Span{16, 28}),
-          errInvalidFuncInstantiation(src, input::Span{41, 42}),
-          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{41, 49}));
+          errNonMatchingInitializerType(NO_SRC, "int", "string"),
+          errInvalidFuncInstantiation(NO_SRC),
+          errNoPureFuncFoundToInstantiate(NO_SRC, "ft", 1));
 
       CHECK_DIAG(
           "fun ft{T}(T a = (b = 2)) a "
           "fun f() ft{int}()",
-          errConstDeclareNotSupported(src, input::Span{17, 21}),
-          errInvalidFuncInstantiation(src, input::Span{35, 36}),
-          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{35, 43}));
+          errConstDeclareNotSupported(NO_SRC),
+          errInvalidFuncInstantiation(NO_SRC),
+          errNoPureFuncFoundToInstantiate(NO_SRC, "ft", 1));
 
       CHECK_DIAG(
           "fun ft{T}(T a = ft()) a "
           "fun f() ft{int}()",
-          errUndeclaredPureFunc(src, "ft", {}, input::Span{16, 19}),
-          errInvalidFuncInstantiation(src, input::Span{32, 33}),
-          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{32, 40}));
+          errUndeclaredPureFunc(NO_SRC, "ft", {}),
+          errInvalidFuncInstantiation(NO_SRC),
+          errNoPureFuncFoundToInstantiate(NO_SRC, "ft", 1));
 
       CHECK_DIAG(
           "fun ft{T}(T a = T(), T b) a + b "
           "fun f() ft{int}()",
-          errNonOptArgFollowingOpt(src, input::Span{21, 23}),
-          errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{40, 48}));
+          errNonOptArgFollowingOpt(NO_SRC),
+          errNoPureFuncFoundToInstantiate(NO_SRC, "ft", 1));
 
-      CHECK_DIAG(
-          "fun f(int a = 0, int b) a + b", errNonOptArgFollowingOpt(src, input::Span{17, 21}));
+      CHECK_DIAG("fun f(int a = 0, int b) a + b", errNonOptArgFollowingOpt(NO_SRC));
     }
   }
 
@@ -261,13 +254,11 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
 
     SECTION("Diagnostics") {
 
-      CHECK_DIAG(
-          "fun f() lambda (int i = 0) i",
-          errUnsupportedArgInitializer(src, "i", input::Span{16, 24}));
+      CHECK_DIAG("fun f() lambda (int i = 0) i", errUnsupportedArgInitializer(NO_SRC, "i"));
       CHECK_DIAG(
           "fun f() lambda (int a = 0, int b = 0) a + b",
-          errUnsupportedArgInitializer(src, "a", input::Span{16, 24}),
-          errUnsupportedArgInitializer(src, "b", input::Span{27, 35}));
+          errUnsupportedArgInitializer(NO_SRC, "a"),
+          errUnsupportedArgInitializer(NO_SRC, "b"));
     }
   }
 }

--- a/tests/frontend/parse_diags_test.cpp
+++ b/tests/frontend/parse_diags_test.cpp
@@ -5,7 +5,7 @@ namespace frontend {
 
 TEST_CASE("[frontend] Analyzing parse diagnostics", "frontend") {
 
-  CHECK_DIAG("conWrite(1 + `)", error(src, "Invalid character '`'", input::Span{13, 13}));
+  CHECK_DIAG("conWrite(1 + `)", error("Invalid character '`'", NO_SRC));
 }
 
 } // namespace frontend

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -435,7 +435,7 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
     CHECK_DIAG(
         "fun f1() f2() "
         "fun f2() f1()",
-        errUnableToInferFuncReturnType(src, "f1", input::Span{0, 12}));
+        errUnableToInferFuncReturnType(NO_SRC, "f1"));
   }
 }
 

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -268,21 +268,21 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
     CHECK_DIAG(
         "fun ft{T}(T a = T(), T b) a * b "
         "fun f() ft(1, 2)",
-        errNonOptArgFollowingOpt(src, input::Span{21, 23}));
+        errNonOptArgFollowingOpt(NO_SRC));
     CHECK_DIAG(
         "struct S = int i "
         "fun ft{T}() T() "
         "fun f() ft{S}()",
-        errUndeclaredTypeOrConversion(src, "S", {}, input::Span{29, 31}),
-        errInvalidFuncInstantiation(src, input::Span{41, 42}),
-        errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{41, 47}));
+        errUndeclaredTypeOrConversion(NO_SRC, "S", {}),
+        errInvalidFuncInstantiation(NO_SRC),
+        errNoPureFuncFoundToInstantiate(NO_SRC, "ft", 1));
     CHECK_DIAG(
         "struct S{T} = T t "
         "fun ft{T}() T() "
         "fun f() ft{S{int}}()",
-        errUndeclaredTypeOrConversion(src, "S{int}", {}, input::Span{30, 32}),
-        errInvalidFuncInstantiation(src, input::Span{42, 43}),
-        errNoPureFuncFoundToInstantiate(src, "ft", 1, input::Span{42, 53}));
+        errUndeclaredTypeOrConversion(NO_SRC, "S{int}", {}),
+        errInvalidFuncInstantiation(NO_SRC),
+        errNoPureFuncFoundToInstantiate(NO_SRC, "ft", 1));
   }
 }
 


### PR DESCRIPTION
Attach a opaque `SourceId` identifier to program expressions. Those `SourceId`s can be resolved to actual file-name, line number, column number etc using the `SourceTable`.

Example output from the `novdiag-prog` executable:
![image](https://user-images.githubusercontent.com/14230060/110024570-f52cec00-7d36-11eb-87cb-b792cd059b68.png)
At the moment this information is only used by `novdiag-prog` for debugging purposes, but in the future this information can be used for all kinds of tooling.