### PR TITLE
Type name

### DIFF
--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -212,10 +212,6 @@ errUndeclaredIndexOperator(prog::sym::SourceId src, const std::vector<std::strin
 [[nodiscard]] auto errIncorrectNumArgsInSelfCall(
     prog::sym::SourceId src, unsigned int expectedNumArgs, unsigned int actualNumArgs) -> Diag;
 
-[[nodiscard]] auto
-errInvalidFailIntrinsicCall(prog::sym::SourceId src, unsigned int typeParams, unsigned int argCount)
-    -> Diag;
-
 [[nodiscard]] auto errIntrinsicFuncLiteral(prog::sym::SourceId src) -> Diag;
 
 [[nodiscard]] auto errUnsupportedArgInitializer(prog::sym::SourceId src, const std::string& name)

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -574,19 +574,6 @@ auto errIncorrectNumArgsInSelfCall(
   return error(oss.str(), src);
 }
 
-auto errInvalidFailIntrinsicCall(
-    prog::sym::SourceId src, unsigned int typeParams, unsigned int argCount) -> Diag {
-  std::ostringstream oss;
-  oss << "Invalid fail intrinsic action call";
-  if (typeParams != 1) {
-    oss << ", requires '1' type parameter but got '" << typeParams << "'";
-  }
-  if (argCount != 0) {
-    oss << ", requires '0' arguments but got '" << argCount << "'";
-  }
-  return error(oss.str(), src);
-}
-
 auto errIntrinsicFuncLiteral(prog::sym::SourceId src) -> Diag {
   std::ostringstream oss;
   oss << "Compiler intrinsic cannot be used as a function literal";

--- a/src/frontend/internal/intrinsic_call_hooks.cpp
+++ b/src/frontend/internal/intrinsic_call_hooks.cpp
@@ -1,6 +1,9 @@
+#include "internal/intrinsic_call_hooks.hpp"
 #include "frontend/diag_defs.hpp"
-#include "internal/call_modifiers.hpp"
 #include "internal/utilities.hpp"
+#include "parse/nodes.hpp"
+#include "prog/expr/node_call.hpp"
+#include "prog/expr/node_lit_string.hpp"
 #include <cassert>
 #include <sstream>
 
@@ -8,44 +11,62 @@ namespace frontend::internal {
 
 namespace {
 
-auto injectFailIntrinsic(
+using OptNodeExpr = std::optional<prog::expr::NodePtr>;
+
+auto resolveTypeNameIntrinsic(
     Context* ctx,
     const TypeSubstitutionTable* subTable,
-    input::Span callSpan,
     const std::optional<parse::TypeParamList>& typeParams,
-    const std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args,
-    std::vector<prog::sym::FuncId>& possibleFuncs) -> void {
+    const IntrinsicArgs& args) -> OptNodeExpr {
 
   if (!typeParams || typeParams->getCount() != 1 || args.first.size() != 0) {
-    // Invalid fail intrinsic, expects 1 type parameter and 0 normal arguments.
-    ctx->reportDiag(
-        errInvalidFailIntrinsicCall,
-        callSpan,
-        typeParams ? typeParams->getCount() : 0u,
-        args.first.size());
-    return;
+    return std::nullopt;
   }
+  const auto type = getOrInstType(ctx, subTable, (*typeParams)[0]);
+  if (!type) {
+    return std::nullopt;
+  }
+  return prog::expr::litStringNode(*ctx->getProg(), getDisplayName(*ctx, *type));
+}
 
+auto resolveFailIntrinsic(
+    Context* ctx,
+    const TypeSubstitutionTable* subTable,
+    bool allowActions,
+    const std::optional<parse::TypeParamList>& typeParams,
+    const IntrinsicArgs& args) -> OptNodeExpr {
+
+  if (!allowActions || !typeParams || typeParams->getCount() != 1 || args.first.size() != 0) {
+    return std::nullopt;
+  }
   const auto resultType = getOrInstType(ctx, subTable, (*typeParams)[0]);
-  possibleFuncs.push_back(ctx->getFails()->getFailIntrinsic(ctx, *resultType));
+  if (!resultType) {
+    return std::nullopt;
+  }
+  const auto funcId = ctx->getFails()->getFailIntrinsic(ctx, *resultType);
+  return prog::expr::callExprNode(*ctx->getProg(), funcId, {});
 }
 
 } // namespace
 
-auto injectPossibleIntrinsicFunctions(
+auto resolveMetaIntrinsic(
     Context* ctx,
     const TypeSubstitutionTable* subTable,
+    bool allowActions,
     const lex::Token& nameToken,
-    const input::Span callSpan,
     const std::optional<parse::TypeParamList>& typeParams,
-    const std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args,
-    std::vector<prog::sym::FuncId>& possibleFuncs) -> void {
+    const IntrinsicArgs& args) -> OptNodeExpr {
 
   assert(ctx);
 
-  if (getName(nameToken) == "fail") {
-    injectFailIntrinsic(ctx, subTable, callSpan, typeParams, args, possibleFuncs);
+  const auto name = getName(nameToken);
+  if (name == "type_name") {
+    return resolveTypeNameIntrinsic(ctx, subTable, typeParams, args);
   }
+  if (name == "fail") {
+    return resolveFailIntrinsic(ctx, subTable, allowActions, typeParams, args);
+  }
+  return std::nullopt;
 }
 
 } // namespace frontend::internal

--- a/src/frontend/internal/intrinsic_call_hooks.hpp
+++ b/src/frontend/internal/intrinsic_call_hooks.hpp
@@ -1,18 +1,20 @@
 #pragma once
 #include "internal/context.hpp"
 #include "lex/token.hpp"
+#include <optional>
 #include <utility>
 #include <vector>
 
 namespace frontend::internal {
 
-auto injectPossibleIntrinsicFunctions(
+using IntrinsicArgs = std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>;
+
+auto resolveMetaIntrinsic(
     Context* ctx,
     const TypeSubstitutionTable* subTable,
+    bool allowActions,
     const lex::Token& nameToken,
-    input::Span callSpan,
     const std::optional<parse::TypeParamList>& typeParams,
-    const std::pair<std::vector<prog::expr::NodePtr>, prog::sym::TypeSet>& args,
-    std::vector<prog::sym::FuncId>& possibleFuncs) -> void;
+    const IntrinsicArgs& args) -> std::optional<prog::expr::NodePtr>;
 
 } // namespace frontend::internal

--- a/std/console.ns
+++ b/std/console.ns
@@ -105,6 +105,9 @@ act noinline printHex{T}(T mask, bool includeLeadingZeroes = false) -> Option{Er
 act noinline printHex(float f, bool includeLeadingZeroes = false) -> Option{Error}
   print(toHexString(asInt(f), includeLeadingZeroes))
 
+act printType{T}(Type{T} t) -> Option{Error}
+  print(t)
+
 act printType{T}(T val) -> Option{Error}
   print(val.getType())
 

--- a/std/console.ns
+++ b/std/console.ns
@@ -1,3 +1,4 @@
+import "std/type.ns"
 import "std/bits.ns"
 import "std/error.ns"
 import "std/parser.ns"
@@ -103,6 +104,9 @@ act noinline printHex{T}(T mask, bool includeLeadingZeroes = false) -> Option{Er
 
 act noinline printHex(float f, bool includeLeadingZeroes = false) -> Option{Error}
   print(toHexString(asInt(f), includeLeadingZeroes))
+
+act printType{T}(T val) -> Option{Error}
+  print(val.getType())
 
 // -- Meta
 

--- a/std/type.ns
+++ b/std/type.ns
@@ -2,38 +2,58 @@ import "std/char.ns"
 
 // -- Type tag
 
-struct TypeTag{T}
+struct Type{T}
+
+// -- Utilities
+
+fun getType{T}(T val)
+  Type{T}()
+
+fun typeName{T}(Type{T} t)
+  typeName{T}()
+
+fun typeName{T}() -> string
+  intrinsic{type_name}{T}()
+
+// -- Conversions
+
+fun string{T}(Type{T} t)
+  t.typeName()
 
 // -- Traits
 
-fun isIntegral(TypeTag{int} t)  true
-fun isIntegral(TypeTag{char} t) true
-fun isIntegral(TypeTag{long} t) true
-fun isIntegral{T}(TypeTag{T} t) false
-fun isIntegral{T}() isIntegral(TypeTag{T}())
+fun isIntegral(Type{int} t)   true
+fun isIntegral(Type{char} t)  true
+fun isIntegral(Type{long} t)  true
+fun isIntegral{T}(Type{T} t)  false
+fun isIntegral{T}()           isIntegral(Type{T}())
 
-fun byteSize(TypeTag{char} t)   1
-fun byteSize(TypeTag{int} t)    4
-fun byteSize(TypeTag{float} t)  4
-fun byteSize(TypeTag{long} t)   8
-fun byteSize{T}()   byteSize(TypeTag{T}())
-fun bitSize{T}()    byteSize{T}() * 8
-fun nibbleSize{T}() byteSize{T}() * 2
+fun byteSize(Type{char} t)    1
+fun byteSize(Type{int} t)     4
+fun byteSize(Type{float} t)   4
+fun byteSize(Type{long} t)    8
+fun byteSize{T}()             byteSize(Type{T}())
 
-fun lowBit{T}()   T(1)
-fun highBit{T}()  lowBit{T}() << (bitSize{T}() - 1)
+fun bitSize{T}(Type{T} t)     byteSize(t) * 8
+fun bitSize{T}()              bitSize(Type{T}())
 
-fun minVal(TypeTag{char} t)  '\0'
-fun minVal(TypeTag{int} t)   0x8000_0000
-fun minVal(TypeTag{long} t)  0x8000_0000_0000_0000L
-fun minVal(TypeTag{float} t) asFloat(0xFF7F_FFFF)
-fun minVal{T}() minVal(TypeTag{T}())
+fun nibbleSize{T}(Type{T} t)  byteSize(t) * 2
+fun nibbleSize{T}()           nibbleSize(Type{T}())
 
-fun maxVal(TypeTag{char} t)  char(255)
-fun maxVal(TypeTag{int} t)   0x7FFF_FFFF
-fun maxVal(TypeTag{long} t)  0x7FFF_FFFF_FFFF_FFFFL
-fun maxVal(TypeTag{float} t) asFloat(0x7F7F_FFFF)
-fun maxVal{T}() maxVal(TypeTag{T}())
+fun lowBit{T}()               T(1)
+fun highBit{T}()              lowBit{T}() << (bitSize{T}() - 1)
+
+fun minVal(Type{char} t)      '\0'
+fun minVal(Type{int} t)       0x8000_0000
+fun minVal(Type{long} t)      0x8000_0000_0000_0000L
+fun minVal(Type{float} t)     asFloat(0xFF7F_FFFF)
+fun minVal{T}()               minVal(Type{T}())
+
+fun maxVal(Type{char} t)      char(255)
+fun maxVal(Type{int} t)       0x7FFF_FFFF
+fun maxVal(Type{long} t)      0x7FFF_FFFF_FFFF_FFFFL
+fun maxVal(Type{float} t)     asFloat(0x7F7F_FFFF)
+fun maxVal{T}()               maxVal(Type{T}())
 
 // -- Tests
 
@@ -46,3 +66,10 @@ assert(bitSize{long}()  == 64)
 
 assert(lowBit{int}() == 1)
 assert(highBit{int}() == 1 << 31)
+
+assert(getType(42).string() == "int")
+assert(getType(42L).string() == "long")
+assert(getType('a').string() == "char")
+assert(getType(42.0).string() == "float")
+assert(getType(42).getType().string() == "Type{int}")
+assert(getType(42).getType().getType().string() == "Type{Type{int}}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(novtests
   frontend/get_intrinsic_expr_test.cpp
   frontend/get_is_expr_test.cpp
   frontend/get_lit_expr_test.cpp
+  frontend/get_meta_intrinsic_test.cpp
   frontend/get_paren_expr_test.cpp
   frontend/get_switch_expr_test.cpp
   frontend/get_unary_expr_test.cpp

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -251,16 +251,6 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
     CHECK(GET_FUNC_DEF(output, "a2").getBody() == *callExpr);
   }
 
-  SECTION("Get fail intrinsic action call") {
-    const auto& output = ANALYZE("act a() -> int intrinsic{fail}{int}()");
-    REQUIRE(output.isSuccess());
-
-    auto callExpr = prog::expr::callExprNode(
-        output.getProg(), GET_INTRINSIC_ID(output, "__fail_int"), NO_EXPRS);
-
-    CHECK(GET_FUNC_DEF(output, "a").getBody() == *callExpr);
-  }
-
   SECTION("Diagnostics") {
     CHECK_DIAG(
         "fun f1() -> int 1 "
@@ -298,15 +288,6 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         errForkedNonUserFunc(NO_SRC));
     CHECK_DIAG(
         "fun f(future{int} fi) -> int lazy intrinsic{future_get}(fi)", errLazyNonUserFunc(NO_SRC));
-    CHECK_DIAG("fun f() -> int fail{int}()", errNoPureFuncFoundToInstantiate(NO_SRC, "fail", 1));
-    CHECK_DIAG(
-        "act f() -> int intrinsic{fail}()",
-        errInvalidFailIntrinsicCall(NO_SRC, 0, 0),
-        errUnknownIntrinsic(NO_SRC, "fail", false, {}));
-    CHECK_DIAG(
-        "act f() -> int intrinsic{fail}(1)",
-        errInvalidFailIntrinsicCall(NO_SRC, 0, 1),
-        errUnknownIntrinsic(NO_SRC, "fail", false, {"int"}));
   }
 }
 

--- a/tests/frontend/get_meta_intrinsic_test.cpp
+++ b/tests/frontend/get_meta_intrinsic_test.cpp
@@ -1,0 +1,53 @@
+#include "catch2/catch.hpp"
+#include "frontend/diag_defs.hpp"
+#include "helpers.hpp"
+#include "prog/expr/node_lit_string.hpp"
+
+namespace frontend {
+
+TEST_CASE("[frontend] Analyzing meta intrinsics", "frontend") {
+
+  SECTION("Get typename intrinsic") {
+    const auto& output = ANALYZE("fun f() -> string intrinsic{type_name}{int}()");
+    REQUIRE(output.isSuccess());
+
+    CHECK(
+        GET_FUNC_DEF(output, "f").getBody() == *prog::expr::litStringNode(output.getProg(), "int"));
+  }
+
+  SECTION("Get typename intrinsic for custom type") {
+    const auto& output = ANALYZE("struct HelloWorld "
+                                 "fun f() -> string intrinsic{type_name}{HelloWorld}()");
+    REQUIRE(output.isSuccess());
+
+    CHECK(
+        GET_FUNC_DEF(output, "f").getBody() ==
+        *prog::expr::litStringNode(output.getProg(), "HelloWorld"));
+  }
+
+  SECTION("Get typename intrinsic for templated type") {
+    const auto& output = ANALYZE("struct Hello{T} "
+                                 "fun f() -> string intrinsic{type_name}{Hello{int}}()");
+    REQUIRE(output.isSuccess());
+
+    CHECK(
+        GET_FUNC_DEF(output, "f").getBody() ==
+        *prog::expr::litStringNode(output.getProg(), "Hello{int}"));
+  }
+
+  SECTION("Get fail intrinsic") {
+    const auto& output = ANALYZE("act a() -> int intrinsic{fail}{int}()");
+    REQUIRE(output.isSuccess());
+
+    auto callExpr = prog::expr::callExprNode(
+        output.getProg(), GET_INTRINSIC_ID(output, "__fail_int"), NO_EXPRS);
+
+    CHECK(GET_FUNC_DEF(output, "a").getBody() == *callExpr);
+  }
+
+  SECTION("Diagnostics") {
+    CHECK_DIAG("fun f() -> int fail{int}()", errNoPureFuncFoundToInstantiate(NO_SRC, "fail", 1));
+  }
+}
+
+} // namespace frontend


### PR DESCRIPTION
Adds an intrinsic to get the name of a type (`intrinsic{type_name}{T}()`).

Also adds proper api's for it in `std/type.ns` and a `printType()` utility in `std/console.ns`.

![image](https://user-images.githubusercontent.com/14230060/110245078-7d470780-7f6a-11eb-9a70-020cf6d2e86b.png)