### PR TITLE
No longer optimize programs when running the evaluator

### DIFF
--- a/apps/nove/main.cpp
+++ b/apps/nove/main.cpp
@@ -31,8 +31,7 @@ auto run(
 
   if (frontendOutput.isSuccess()) {
 
-    const auto optProg   = opt::optimize(frontendOutput.getProg());
-    const auto asmOutput = backend::generate(optProg);
+    const auto asmOutput = backend::generate(frontendOutput.getProg());
 
     auto progPath = inputPath ? inputPath->string() : std::string{};
     auto iface    = vm::PlatformInterface{


### PR DESCRIPTION
Now that programs are getting larger, the optimization step is slowing down the evaluator considerably. To remedy this we simply no longer run the optimization step in the evaluator.

For optimized programs the compiler should be used.