### PR TITLE
User defined implicit conversions

### DIFF
--- a/apps/novrt/main.cpp
+++ b/apps/novrt/main.cpp
@@ -9,7 +9,7 @@
 #include <fstream>
 
 auto main(int argc, const char** argv) noexcept -> int {
-  // Skip the first arg (path to this executable).
+  // Drop the first arg (path to this executable).
   if (argc > 0) {
     argc -= 1;
     argv += 1;
@@ -28,6 +28,11 @@ auto main(int argc, const char** argv) noexcept -> int {
     return 1;
   }
   auto relProgPath = filesystem::path(std::string(argv[0]));
+  // Drop the first arg (path to the novus executable).
+  if (argc > 0) {
+    argc -= 1;
+    argv += 1;
+  }
 
   // Open a handle to the program executable file.
   auto fs = std::ifstream{relProgPath.string(), std::ios::binary};

--- a/ide/nano/novus.nanorc
+++ b/ide/nano/novus.nanorc
@@ -4,7 +4,7 @@ syntax "ns" "\.ns$"
 comment "//"
 
 # Keywords.
-color brightblue "\b(intrinsic|import|struct|union|enum|fun|act|lambda|impure|fork|lazy|noinline)\b"
+color brightblue "\b(intrinsic|import|struct|union|enum|fun|act|lambda|impure|fork|lazy|noinline|implicit)\b"
 color red "(\b(if|else)\b)|(\?|\:)"
 color brightyellow "((\b(is|as)\b)|(\+\+)|(\-\-)|(\&\&)|(\|\|)|(\<\<)|(\>\>)|(\<\=)|(\>\=)|(\=\=)|(\!\=)|\+|\-|\*|(\/)|\^|\~|\%|\&|\!|<|>)"
 

--- a/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
+++ b/ide/textmate/Novus.tmbundle/Syntaxes/novus.tmLanguage
@@ -240,7 +240,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>\b(fun|act)\s+(noinline)?\s*(.+?)\s*(?=\{|\()</string>
+					<string>\b(fun|act)\s+((?:(?:noinline|implicit)\s+)*)(.+?)\s*(?=\{|\()</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -251,7 +251,7 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.noinline.source.novus</string>
+							<string>keyword.other.modifiers.source.novus</string>
 						</dict>
 						<key>3</key>
 						<dict>

--- a/ide/vscode/novus/syntaxes/novus.tmLanguage.json
+++ b/ide/vscode/novus/syntaxes/novus.tmLanguage.json
@@ -155,13 +155,13 @@
     "function_declaration": {
       "patterns": [
         {
-          "begin": "\\b(fun|act)\\s+(noinline)?\\s*(.+?)\\s*(?=\\{|\\()",
+          "begin": "\\b(fun|act)\\s+((?:(?:noinline|implicit)\\s+)*)(.+?)\\s*(?=\\{|\\()",
           "beginCaptures": {
             "1": {
               "name": "keyword.other.function.source.novus"
             },
             "2": {
-              "name": "keyword.other.noinline.source.novus"
+              "name": "keyword.other.modifiers.source.novus"
             },
             "3": {
               "name": "entity.name.function.source.novus"

--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -71,6 +71,12 @@ errDuplicateEntryNameInEnum(prog::sym::SourceId src, const std::string& entryNam
 [[nodiscard]] auto errOperatorOverloadWithoutArgs(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 
+[[nodiscard]] auto errTemplatedImplicitConversion(prog::sym::SourceId src) -> Diag;
+
+[[nodiscard]] auto errImplicitNonConv(prog::sym::SourceId src) -> Diag;
+
+[[nodiscard]] auto errToManyInputsInImplicitConv(prog::sym::SourceId src) -> Diag;
+
 [[nodiscard]] auto
 errTypeParamNameConflictsWithType(prog::sym::SourceId src, const std::string& name) -> Diag;
 

--- a/include/lex/keyword.hpp
+++ b/include/lex/keyword.hpp
@@ -22,7 +22,8 @@ enum class Keyword {
   Else,
   Is,
   As,
-  Noinline
+  Noinline,
+  Implicit,
 };
 
 auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream&;

--- a/include/parse/node_expr_anon_func.hpp
+++ b/include/parse/node_expr_anon_func.hpp
@@ -28,7 +28,7 @@ public:
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
   [[nodiscard]] auto isImpure() const -> bool;
-  [[nodiscard]] auto isNoinline() const -> bool;
+  [[nodiscard]] auto hasModifier(lex::Keyword keyword) const -> bool;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;
   [[nodiscard]] auto getRetType() const -> const std::optional<RetTypeSpec>&;
   [[nodiscard]] auto getBody() const -> const Node&;

--- a/include/parse/node_stmt_func_decl.hpp
+++ b/include/parse/node_stmt_func_decl.hpp
@@ -29,7 +29,7 @@ public:
   [[nodiscard]] auto getSpan() const -> input::Span override;
 
   [[nodiscard]] auto isAction() const -> bool;
-  [[nodiscard]] auto isNoinline() const -> bool;
+  [[nodiscard]] auto hasModifier(lex::Keyword keyword) const -> bool;
   [[nodiscard]] auto getId() const -> const lex::Token&;
   [[nodiscard]] auto getTypeSubs() const -> const std::optional<TypeSubstitutionList>&;
   [[nodiscard]] auto getArgList() const -> const ArgumentListDecl&;

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -158,6 +158,7 @@ public:
   auto
   declareAction(std::string name, sym::TypeSet input, sym::TypeId output, unsigned int numOptInputs)
       -> sym::FuncId;
+  auto declareImplicitConv(sym::TypeId input, sym::TypeId output) -> sym::FuncId;
   auto declareFailIntrinsic(std::string name, sym::TypeId output) -> sym::FuncId;
 
   auto defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void;

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -161,6 +161,24 @@ auto errOperatorOverloadWithoutArgs(prog::sym::SourceId src, const std::string& 
   return error(oss.str(), src);
 }
 
+auto errTemplatedImplicitConversion(prog::sym::SourceId src) -> Diag {
+  std::ostringstream oss;
+  oss << "Templated implicit conversions are not supported";
+  return error(oss.str(), src);
+}
+
+auto errImplicitNonConv(prog::sym::SourceId src) -> Diag {
+  std::ostringstream oss;
+  oss << "Implicit modifier is only valid on conversions";
+  return error(oss.str(), src);
+}
+
+auto errToManyInputsInImplicitConv(prog::sym::SourceId src) -> Diag {
+  std::ostringstream oss;
+  oss << "Implicit conversions can only take a single argument";
+  return error(oss.str(), src);
+}
+
 auto errTypeParamNameConflictsWithType(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Type parameter name '" << name << "' conflicts with a type with the same name";

--- a/src/frontend/internal/define_user_funcs.cpp
+++ b/src/frontend/internal/define_user_funcs.cpp
@@ -123,8 +123,9 @@ auto defineFunc(
     return false;
   }
 
+  const auto isNoInline = n.hasModifier(lex::Keyword::Noinline);
   const auto funcDefFlags =
-      n.isNoinline() ? prog::sym::FuncDef::Flags::NoInline : prog::sym::FuncDef::Flags::None;
+      isNoInline ? prog::sym::FuncDef::Flags::NoInline : prog::sym::FuncDef::Flags::None;
 
   if (bodyExpr->getType() == funcRetType) {
     ctx->getProg()->defineFunc(

--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -136,8 +136,9 @@ auto GetExpr::visit(const parse::AnonFuncExprNode& n) -> void {
       : m_ctx->getProg()->declarePureFunc(
             nameoss.str(), prog::sym::TypeSet{inputTypes}, *retType, 0u);
 
+  const auto isNoInline = n.hasModifier(lex::Keyword::Noinline);
   const auto funcDefFlags =
-      n.isNoinline() ? prog::sym::FuncDef::Flags::NoInline : prog::sym::FuncDef::Flags::None;
+      isNoInline ? prog::sym::FuncDef::Flags::NoInline : prog::sym::FuncDef::Flags::None;
 
   // Define the function in the program.
   m_ctx->getProg()->defineFunc(funcId, std::move(consts), std::move(expr), {}, funcDefFlags);

--- a/src/lex/keyword.cpp
+++ b/src/lex/keyword.cpp
@@ -56,6 +56,9 @@ auto operator<<(std::ostream& out, const Keyword& rhs) -> std::ostream& {
   case Keyword::Noinline:
     out << "noinline";
     break;
+  case Keyword::Implicit:
+    out << "implicit";
+    break;
   }
   return out;
 }
@@ -79,6 +82,7 @@ auto getKeyword(const std::string& str) -> std::optional<Keyword> {
       {"is", Keyword::Is},
       {"as", Keyword::As},
       {"noinline", Keyword::Noinline},
+      {"implicit", Keyword::Implicit},
   };
 
   const auto keywordSearch = keywordTable.find(str);

--- a/src/novasm/serialization.cpp
+++ b/src/novasm/serialization.cpp
@@ -16,7 +16,7 @@ namespace novasm {
  *
  * More info: https://en.wikipedia.org/wiki/Shebang_(Unix)
  */
-static const std::string g_shebangLine = "#!/usr/bin/env novrt\n";
+static std::string_view g_shebangLine = "#!/usr/bin/env novrt\n";
 
 template <typename ValueType, typename OutputItr>
 using Writer = void(const ValueType& val, OutputItr& outItr);

--- a/src/parse/node_expr_anon_func.cpp
+++ b/src/parse/node_expr_anon_func.cpp
@@ -53,7 +53,7 @@ auto AnonFuncExprNode::isImpure() const -> bool {
   });
 }
 
-auto AnonFuncExprNode::isNoinline() const -> bool { return false; }
+auto AnonFuncExprNode::hasModifier(lex::Keyword /*unused*/) const -> bool { return false; }
 
 auto AnonFuncExprNode::getArgList() const -> const ArgumentListDecl& { return m_argList; }
 

--- a/src/parse/node_stmt_func_decl.cpp
+++ b/src/parse/node_stmt_func_decl.cpp
@@ -52,9 +52,9 @@ auto FuncDeclStmtNode::getSpan() const -> input::Span {
   return input::Span::combine(m_kw.getSpan(), m_body->getSpan());
 }
 
-auto FuncDeclStmtNode::isNoinline() const -> bool {
-  return std::any_of(m_modifiers.begin(), m_modifiers.end(), [](const lex::Token& t) {
-    return getKw(t) == lex::Keyword::Noinline;
+auto FuncDeclStmtNode::hasModifier(lex::Keyword keyword) const -> bool {
+  return std::any_of(m_modifiers.begin(), m_modifiers.end(), [keyword](const lex::Token& t) {
+    return getKw(t) == keyword;
   });
 }
 

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -79,6 +79,7 @@ auto ParserImpl::nextStmtFuncDecl() -> NodePtr {
   while (auto kw = getKw(peekToken(0))) {
     switch (*kw) {
     case lex::Keyword::Noinline:
+    case lex::Keyword::Implicit:
       modifiers.push_back(consumeToken());
       continue;
     default:
@@ -91,8 +92,8 @@ auto ParserImpl::nextStmtFuncDecl() -> NodePtr {
   auto typeSubs = peekToken(0).getKind() == lex::TokenKind::SepOpenCurly
       ? std::optional<TypeSubstitutionList>{nextTypeSubstitutionList()}
       : std::nullopt;
-  auto argList = nextArgDeclList();
-  auto retType = std::optional<RetTypeSpec>{};
+  auto argList  = nextArgDeclList();
+  auto retType  = std::optional<RetTypeSpec>{};
   if (peekToken(0).getKind() == lex::TokenKind::SepArrow) {
     retType = nextRetTypeSpec();
   }
@@ -130,10 +131,10 @@ auto ParserImpl::nextStmtStructDecl() -> NodePtr {
   auto typeSubs = peekToken(0).getKind() == lex::TokenKind::SepOpenCurly
       ? std::optional<TypeSubstitutionList>{nextTypeSubstitutionList()}
       : std::nullopt;
-  auto isEmpty = peekToken(0).getKind() != lex::TokenKind::OpEq;
-  auto eq      = isEmpty ? std::nullopt : std::optional{consumeToken()};
-  auto fields  = std::vector<StructDeclStmtNode::FieldSpec>{};
-  auto commas  = std::vector<lex::Token>{};
+  auto isEmpty  = peekToken(0).getKind() != lex::TokenKind::OpEq;
+  auto eq       = isEmpty ? std::nullopt : std::optional{consumeToken()};
+  auto fields   = std::vector<StructDeclStmtNode::FieldSpec>{};
+  auto commas   = std::vector<lex::Token>{};
   if (!isEmpty) {
     while (peekToken(0).getKind() == lex::TokenKind::Identifier ||
            peekToken(0).getKind() == lex::TokenKind::Keyword) {
@@ -178,9 +179,9 @@ auto ParserImpl::nextStmtUnionDecl() -> NodePtr {
   auto typeSubs = peekToken(0).getKind() == lex::TokenKind::SepOpenCurly
       ? std::optional<TypeSubstitutionList>{nextTypeSubstitutionList()}
       : std::nullopt;
-  auto eq     = consumeToken();
-  auto types  = std::vector<Type>{};
-  auto commas = std::vector<lex::Token>{};
+  auto eq       = consumeToken();
+  auto types    = std::vector<Type>{};
+  auto commas   = std::vector<lex::Token>{};
   while (peekToken(0).getKind() == lex::TokenKind::Identifier ||
          peekToken(0).getKind() == lex::TokenKind::Keyword) {
 

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -528,6 +528,10 @@ auto Program::declareAction(
       *this, sym::FuncKind::User, std::move(name), std::move(input), output, numOptInputs);
 }
 
+auto Program::declareImplicitConv(sym::TypeId input, sym::TypeId output) -> sym::FuncId {
+  return m_funcDecls.registerImplicitConv(*this, sym::FuncKind::User, input, output);
+}
+
 auto Program::declareFailIntrinsic(std::string name, sym::TypeId output) -> sym::FuncId {
   return m_funcDecls.registerIntrinsicAction(
       *this, sym::FuncKind::ActionFail, std::move(name), sym::TypeSet{}, output);

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -185,13 +185,13 @@ Program::Program() :
       sym::TypeSet{m_string, m_int, m_int},
       m_string);
 
-  // Register build-in implicit conversions.
-  m_funcDecls.registerImplicitConv(*this, Fk::NoOp, m_char, m_int);
-  m_funcDecls.registerImplicitConv(*this, Fk::ConvIntLong, m_int, m_long);
-  m_funcDecls.registerImplicitConv(*this, Fk::ConvCharLong, m_char, m_long);
-  m_funcDecls.registerImplicitConv(*this, Fk::ConvIntFloat, m_int, m_float);
-
   // Register conversion intrinsics.
+  m_funcDecls.registerIntrinsic(*this, Fk::NoOp, "char_to_int", sym::TypeSet{m_char}, m_int);
+  m_funcDecls.registerIntrinsic(*this, Fk::ConvIntLong, "int_to_long", sym::TypeSet{m_int}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ConvCharLong, "char_to_long", sym::TypeSet{m_char}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ConvIntFloat, "int_to_float", sym::TypeSet{m_int}, m_float);
   m_funcDecls.registerIntrinsic(
       *this, Fk::ConvFloatInt, "float_to_int", sym::TypeSet{m_float}, m_int);
   m_funcDecls.registerIntrinsic(*this, Fk::ConvLongInt, "long_to_int", sym::TypeSet{m_long}, m_int);

--- a/std/prim/float.ns
+++ b/std/prim/float.ns
@@ -17,6 +17,9 @@ fun float(float f) f
 fun float(long l)
   intrinsic{long_to_float}(l)
 
+fun implicit float(int i)
+  intrinsic{int_to_float}(i)
+
 fun asFloat(int i) -> float
   intrinsic{int_as_float}(i)
 

--- a/std/prim/int.ns
+++ b/std/prim/int.ns
@@ -21,6 +21,9 @@ fun int(float f)
 fun int(long l)
   intrinsic{long_to_int}(l)
 
+fun implicit int(char c)
+  intrinsic{char_to_int}(c)
+
 fun asInt(float f) -> int
   intrinsic{float_as_int}(f)
 

--- a/std/prim/long.ns
+++ b/std/prim/long.ns
@@ -16,6 +16,12 @@ fun long(long l) l
 fun long(float f)
   intrinsic{float_to_long}(f)
 
+fun implicit long(int i)
+  intrinsic{int_to_long}(i)
+
+fun implicit long(char c)
+  intrinsic{char_to_long}(c)
+
 // -- Operators
 
 fun +(long l) l

--- a/tests/backend/call_dyn_expr_test.cpp
+++ b/tests/backend/call_dyn_expr_test.cpp
@@ -80,7 +80,7 @@ TEST_CASE("[backend] Generate assembly for dynamic call expressions", "backend")
   SECTION("Closure") {
     CHECK_PROG(
         "fun test(bool b) b "
-        "test(i = 1337; (lambda (float f) f == i)(.1))",
+        "test(i = 1337.0; (lambda (float f) f == i)(.1))",
         [](novasm::Assembler* asmb) -> void {
           // --- test function start.
           asmb->label("func-test");
@@ -91,14 +91,13 @@ TEST_CASE("[backend] Generate assembly for dynamic call expressions", "backend")
           asmb->label("anon func");
           asmb->addStackLoad(0);
           asmb->addStackLoad(1);
-          asmb->addConvIntFloat();
           asmb->addCheckEqFloat();
           asmb->addRet();
 
           asmb->label("prog");
           asmb->addStackAlloc(1);
 
-          asmb->addLoadLitInt(1337);
+          asmb->addLoadLitFloat(1337.0f);
           asmb->addStackStore(0);
 
           asmb->addLoadLitFloat(.1F); // NOLINT: Magic numbers

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -174,18 +174,6 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitFloat(3.42F);
       asmb->addDivFloat();
     });
-    CHECK_EXPR_FLOAT("1.0 / 2", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitFloat(1.0F);
-      asmb->addLoadLitInt(2);
-      asmb->addConvIntFloat();
-      asmb->addDivFloat();
-    });
-    CHECK_EXPR_FLOAT("1 / 2.0", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addConvIntFloat();
-      asmb->addLoadLitFloat(2.0F);
-      asmb->addDivFloat();
-    });
     CHECK_EXPR_FLOAT("6.0 % 2.0", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(6.0F);
       asmb->addLoadLitFloat(2.0F);
@@ -425,7 +413,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("Conversions") {
-    CHECK_EXPR_FLOAT("float(42)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_FLOAT("intrinsic{int_to_float}(42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(42);
       asmb->addConvIntFloat();
     });
@@ -437,11 +425,11 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitLong(42);
       asmb->addConvLongInt();
     });
-    CHECK_EXPR_LONG("long(42)", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{int_to_long}(42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(42);
       asmb->addConvIntLong();
     });
-    CHECK_EXPR_LONG("long('a')", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{char_to_long}('a')", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt('a');
       asmb->addConvIntLong();
     });

--- a/tests/frontend/anon_func_test.cpp
+++ b/tests/frontend/anon_func_test.cpp
@@ -204,7 +204,8 @@ TEST_CASE("[frontend] Analyzing anonymous functions", "frontend") {
   }
 
   SECTION("Anonymous function with conversion") {
-    const auto& output = ANALYZE("fun f() lambda () -> float 2");
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f() lambda () -> float 2");
     REQUIRE(output.isSuccess());
     const auto& anonFuncDef = findAnonFuncDef(output, 0);
 

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -142,6 +142,17 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
     }
   }
 
+  SECTION("Implicit conversions") {
+
+    SECTION("Declare implicit conversion") {
+      const auto& output = ANALYZE("fun implicit bool(int i) i == 0");
+      REQUIRE(output.isSuccess());
+      const auto& funcDecl = GET_FUNC_DECL(output, "bool", GET_TYPE_ID(output, "int"));
+      CHECK(funcDecl.getOutput() == GET_TYPE_ID(output, "bool"));
+      CHECK(funcDecl.isImplicitConv());
+    }
+  }
+
   SECTION("Diagnostics") {
     CHECK_DIAG(
         "fun a() -> int 1 "
@@ -194,6 +205,10 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
         errInvalidFuncInstantiation(NO_SRC),
         errUndeclaredTypeOrConversion(NO_SRC, "S{int}", {}));
     CHECK_DIAG("fun f(int a = 0, int b) a * b", errNonOptArgFollowingOpt(NO_SRC));
+    CHECK_DIAG("fun implicit int{T}(T v) int(v)", errTemplatedImplicitConversion(NO_SRC));
+    CHECK_DIAG("fun implicit f(int i) i", errImplicitNonConv(NO_SRC));
+    CHECK_DIAG("fun implicit bool(int i, int j) i == 0", errToManyInputsInImplicitConv(NO_SRC));
+    CHECK_DIAG("fun implicit bool(int i = 0) i == 0", errToManyInputsInImplicitConv(NO_SRC));
   }
 }
 

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -21,7 +21,8 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
   }
 
   SECTION("Define function with conversion") {
-    const auto& output = ANALYZE("fun f() -> float 2");
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f() -> float 2");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 

--- a/tests/frontend/get_binary_expr_test.cpp
+++ b/tests/frontend/get_binary_expr_test.cpp
@@ -31,7 +31,8 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
   }
 
   SECTION("Get binary expression with conversion on lhs") {
-    const auto& output = ANALYZE("fun f(float a) 2 * a");
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f(float a) 2 * a");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "float"));
 
@@ -51,7 +52,8 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
   }
 
   SECTION("Get binary expression with conversion on rhs") {
-    const auto& output = ANALYZE("fun f(float a) a * 2");
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f(float a) a * 2");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "float"));
 

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -37,7 +37,8 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
   }
 
   SECTION("Get delegate call with args") {
-    const auto& output = ANALYZE("fun f1(bool b, float v) -> int b ? 1 : 0 "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f1(bool b, float v) -> int b ? 1 : 0 "
                                  "fun f2(function{bool, float, int} op) -> int op(false, 1) "
                                  "fun f() -> int f2(f1)");
     REQUIRE(output.isSuccess());

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -48,7 +48,8 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
   }
 
   SECTION("Get call with conversion") {
-    const auto& output = ANALYZE("fun f1(float a) a "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f1(float a) a "
                                  "fun f2() f1(1)");
     REQUIRE(output.isSuccess());
 

--- a/tests/frontend/get_conditional_expr_test.cpp
+++ b/tests/frontend/get_conditional_expr_test.cpp
@@ -30,7 +30,8 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
   }
 
   SECTION("Get conditional expression with conversion on the lhs branch") {
-    const auto& output = ANALYZE("fun f() true ? 0 : 1.0");
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f() true ? 0 : 1.0");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 
@@ -45,7 +46,8 @@ TEST_CASE("[frontend] Analyzing conditional expressions", "frontend") {
   }
 
   SECTION("Get conditional expression with conversion on the rhs branch") {
-    const auto& output = ANALYZE("fun f() true ? 1.0 : 0");
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f() true ? 1.0 : 0");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
 

--- a/tests/frontend/get_switch_expr_test.cpp
+++ b/tests/frontend/get_switch_expr_test.cpp
@@ -38,7 +38,8 @@ TEST_CASE("[frontend] Analyzing switch expressions", "frontend") {
   }
 
   SECTION("Get switch expression with conversion on the branches") {
-    const auto& output = ANALYZE("fun f() "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f() "
                                  "  if true   -> 1 "
                                  "  if false  -> 1.0 "
                                  "  else      -> 3");

--- a/tests/frontend/opt_args_test.cpp
+++ b/tests/frontend/opt_args_test.cpp
@@ -27,7 +27,8 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Declare a function with a normal argument and a optional argument") {
-      const auto& output = ANALYZE("fun f(float a, int b = 0) a + b");
+      const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                   "fun f(float a, int b = 0) a + b");
       REQUIRE(output.isSuccess());
 
       const auto& funcDecl =
@@ -40,7 +41,8 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Declare a function with a conversion on the optional arg initializer") {
-      const auto& output = ANALYZE("fun f(float a = 2) false");
+      const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                   "fun f(float a = 2) false");
       REQUIRE(output.isSuccess());
 
       const auto& funcDecl = GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float"));
@@ -69,7 +71,7 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Declare a function with an optional arg initializer that calls an intrinsic") {
-      const auto& output = ANALYZE("act a(long time = intrinsic{clock_nanosteady}()) time * 2");
+      const auto& output = ANALYZE("act a(long time = intrinsic{clock_nanosteady}()) time * 2L");
       REQUIRE(output.isSuccess());
 
       const auto& funcDecl = GET_FUNC_DECL(output, "a", GET_TYPE_ID(output, "long"));
@@ -107,7 +109,8 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Call a function with an optional argument with a conversion") {
-      const auto& output = ANALYZE("fun fa(int a, float b = 2) a + b "
+      const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                   "fun fa(int a, float b = 2) a + b "
                                    "fun fb() fa(2)");
       REQUIRE(output.isSuccess());
       CHECK(
@@ -173,7 +176,8 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Type parameter can be inferred from an initializer") {
-      const auto& output = ANALYZE("fun string(int i) intrinsic{int_to_string}(i) "
+      const auto& output = ANALYZE("fun implicit int(char c) intrinsic{char_to_int}(c) "
+                                   "fun string(int i) intrinsic{int_to_string}(i) "
                                    "fun ft{TX, TY}(TX a = \"World\", TY b = 'W') a + string(b) "
                                    "fun f1() ft() "
                                    "fun f2() ft(\"Hello\", 42) "

--- a/tests/frontend/overload_test.cpp
+++ b/tests/frontend/overload_test.cpp
@@ -6,14 +6,16 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing overloads", "frontend") {
 
   SECTION("Allow conversion") {
-    const auto& output = ANALYZE("fun f1(float a, float b) a + b "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f1(float a, float b) a + b "
                                  "fun f2() f1(42, 1337)");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DEF(output, "f2").getBody().getType() == GET_TYPE_ID(output, "float"));
   }
 
   SECTION("Prefer overload with no conversion") {
-    const auto& output = ANALYZE("fun f1(float f) f "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f1(float f) f "
                                  "fun f1(int i) i "
                                  "fun f2() f1(1337)");
     REQUIRE(output.isSuccess());
@@ -21,7 +23,8 @@ TEST_CASE("[frontend] Analyzing overloads", "frontend") {
   }
 
   SECTION("Prefer overload with less conversions") {
-    const auto& output = ANALYZE("fun f1(float a, float b) b "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun f1(float a, float b) b "
                                  "fun f1(float a, int b) b "
                                  "fun f2() f1(42, 1337)");
     REQUIRE(output.isSuccess());
@@ -29,7 +32,8 @@ TEST_CASE("[frontend] Analyzing overloads", "frontend") {
   }
 
   SECTION("Allow conversion in binary operator") {
-    const auto& output = ANALYZE("fun a(bool b) b "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun a(bool b) b "
                                  "a(1.0 / 2 == .5)");
     REQUIRE(output.isSuccess());
   }

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -51,7 +51,8 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Overload templated functions") {
-    const auto& output = ANALYZE("fun ft{T}(int a, T b) a + b "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun ft{T}(int a, T b) a + b "
                                  "fun ft{T}(float a, T b) a + b "
                                  "fun f() -> float ft{int}(1.0, 2)");
     REQUIRE(output.isSuccess());
@@ -69,7 +70,8 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Return type as parameter") {
-    const auto& output = ANALYZE("fun string(int i) intrinsic{int_to_string}(i) "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun string(int i) intrinsic{int_to_string}(i) "
                                  "fun int(int i) i "
                                  "fun ft{T}(int a) -> T T(a) "
                                  "fun f1() -> int ft{int}(1) "
@@ -119,7 +121,8 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Infer type-parameter in templated call") {
-    const auto& output = ANALYZE("fun ft{T, Y}(T a, Y b) "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun ft{T, Y}(T a, Y b) "
                                  "  a + b "
                                  "fun f() ft(2, 1.0)");
     REQUIRE(output.isSuccess());
@@ -137,7 +140,8 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Infer type-parameter supports implicit conversion") {
-    const auto& output = ANALYZE("fun ft{T}(T a, T b) "
+    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                 "fun ft{T}(T a, T b) "
                                  "  a + b "
                                  "fun f() ft(1.0, 2)");
     REQUIRE(output.isSuccess());

--- a/tests/lex/keyword_test.cpp
+++ b/tests/lex/keyword_test.cpp
@@ -20,6 +20,7 @@ TEST_CASE("[lex] Lexing keywords", "lex") {
   CHECK_TOKENS("is", keywordToken(Keyword::Is));
   CHECK_TOKENS("as", keywordToken(Keyword::As));
   CHECK_TOKENS("noinline", keywordToken(Keyword::Noinline));
+  CHECK_TOKENS("implicit", keywordToken(Keyword::Implicit));
 }
 
 } // namespace lex

--- a/tests/novasm/serialization_test.cpp
+++ b/tests/novasm/serialization_test.cpp
@@ -20,7 +20,8 @@ static auto testSerializeAndDeserializeAsm(Executable a) {
 TEST_CASE("[novasm] Assembly serialization", "novasm") {
 
   SECTION("Basic program") {
-    testSerializeAndDeserializeAsm(GEN_ASM("act main(int i, float f) -> float"
+    testSerializeAndDeserializeAsm(GEN_ASM("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                                           "act main(int i, float f) -> float"
                                            "  intrinsic{float_pow}(i, f) + intrinsic{float_sin}(f) "
                                            "main(42, 1.337)"));
   }

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -84,8 +84,8 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_BOOL(precomputeLiterals, "1 <= 2", litBoolNode(prog, true));
     ASSERT_EXPR_BOOL(precomputeLiterals, "1 > 2", litBoolNode(prog, false));
     ASSERT_EXPR_BOOL(precomputeLiterals, "1 >= 2", litBoolNode(prog, false));
-    ASSERT_EXPR_LONG(precomputeLiterals, "long(137)", litLongNode(prog, 137));
-    ASSERT_EXPR_FLOAT(precomputeLiterals, "float(137)", litFloatNode(prog, 137));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{int_to_long}(137)", litLongNode(prog, 137));
+    ASSERT_EXPR_FLOAT(precomputeLiterals, "intrinsic{int_to_float}(137)", litFloatNode(prog, 137));
     ASSERT_EXPR_STRING(
         precomputeLiterals, "intrinsic{int_to_string}(1337)", litStringNode(prog, "1337"));
     ASSERT_EXPR_CHAR(precomputeLiterals, "intrinsic{int_to_char}(137)", litCharNode(prog, 137));

--- a/tests/parse/helpers.hpp
+++ b/tests/parse/helpers.hpp
@@ -57,6 +57,7 @@ namespace parse {
 #define LAMBDA lex::keywordToken(lex::Keyword::Lambda)
 #define IMPURE lex::keywordToken(lex::Keyword::Impure)
 #define NOINLINE lex::keywordToken(lex::Keyword::Noinline)
+#define IMPLICIT lex::keywordToken(lex::Keyword::Implicit)
 #define FORK lex::keywordToken(lex::Keyword::Fork)
 #define STRUCT lex::keywordToken(lex::Keyword::Struct)
 #define UNION lex::keywordToken(lex::Keyword::Union)

--- a/tests/parse/stmt_func_decl_test.cpp
+++ b/tests/parse/stmt_func_decl_test.cpp
@@ -195,6 +195,26 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
             ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
             std::nullopt,
             INT(1)));
+    CHECK_STMT(
+        "fun implicit a() 1",
+        funcDeclStmtNode(
+            FUN,
+            {IMPLICIT},
+            ID("a"),
+            std::nullopt,
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
+            std::nullopt,
+            INT(1)));
+    CHECK_STMT(
+        "fun noinline implicit a() 1",
+        funcDeclStmtNode(
+            FUN,
+            {NOINLINE, IMPLICIT},
+            ID("a"),
+            std::nullopt,
+            ArgumentListDecl(OPAREN, NO_ARGS, COMMAS(0), CPAREN),
+            std::nullopt,
+            INT(1)));
   }
 
   SECTION("Actions") {

--- a/tests/vm/io_process_test.cpp
+++ b/tests/vm/io_process_test.cpp
@@ -440,7 +440,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->addDup(); // Duplicate the process.
 
           // Wait a few seconds to give the process time to start.
-          asmb->addLoadLitLong(3'000'000'000);
+          asmb->addLoadLitLong(5'000'000'000);
           asmb->addPCall(novasm::PCallCode::SleepNano);
           asmb->addPop(); // Ignore sleep return value.
 

--- a/tests/vm/io_process_test.cpp
+++ b/tests/vm/io_process_test.cpp
@@ -65,69 +65,113 @@ auto compileProg(std::string_view name, std::string_view srcText) -> filesystem:
 
 auto novrtPath = (input::getExecutablePath().parent_path() / "novrt").string();
 
-auto hello_world_nx = compileProg(
-    "hello_world.nx",
-    "import \"std/io.ns\" "
-    "print(\"Hello world\")");
+auto helloWorldNx() -> const std::string& {
+  static auto path = compileProg(
+                         "hello_world.nx",
+                         "import \"std/io.ns\" "
+                         "print(\"Hello world\")")
+                         .string();
+  return path;
+}
 
-auto hello_world_err_nx = compileProg(
-    "hello_world_err.nx",
-    "import \"std/io.ns\" "
-    "printErr(\"Hello world\")");
+auto helloWorldErrNx() -> const std::string& {
+  static auto path = compileProg(
+                         "hello_world_err.nx",
+                         "import \"std/io.ns\" "
+                         "printErr(\"Hello world\")")
+                         .string();
+  return path;
+}
 
-auto read_line_nx = compileProg(
-    "read_line.nx",
-    "import \"std/io.ns\" "
-    "print(readLine())");
+auto readLineNx() -> const std::string& {
+  static auto path = compileProg(
+                         "read_line.nx",
+                         "import \"std/io.ns\" "
+                         "print(readLine())")
+                         .string();
+  return path;
+}
 
-auto print_num_env_args_nx = compileProg(
-    "print_num_env_args.nx",
-    "import \"std/io.ns\" "
-    "import \"std/sys.ns\" "
-    "print(intrinsic{env_argument_count}())");
+auto printNumEnvArgsNx() -> const std::string& {
+  static auto path = compileProg(
+                         "print_num_env_args.nx",
+                         "import \"std/io.ns\" "
+                         "import \"std/sys.ns\" "
+                         "print(intrinsic{env_argument_count}())")
+                         .string();
+  return path;
+}
 
-auto print_test_env_opt_nx = compileProg(
-    "print_test_env_opt.nx",
-    "import \"std/io.ns\" "
-    "import \"std/sys.ns\" "
-    "print(getEnvOpt(\"test\"))");
+auto printTestEnvOptNx() -> const std::string& {
+  static auto path = compileProg(
+                         "print_test_env_opt.nx",
+                         "import \"std/io.ns\" "
+                         "import \"std/sys.ns\" "
+                         "print(getEnvOpt(\"test\"))")
+                         .string();
+  return path;
+}
 
-auto print_first_arg_nx = compileProg(
-    "print_first_arg.nx",
-    "import \"std/io.ns\" "
-    "import \"std/sys.ns\" "
-    "print(intrinsic{env_argument}(0))");
+auto printFirstArgNx() -> const std::string& {
+  static auto path = compileProg(
+                         "print_first_arg.nx",
+                         "import \"std/io.ns\" "
+                         "import \"std/sys.ns\" "
+                         "print(intrinsic{env_argument}(0))")
+                         .string();
+  return path;
+}
 
-auto assert_true_nx = compileProg(
-    "assert_true.nx",
-    "import \"std/diag.ns\" "
-    "assert(true)");
+auto assertTrueNx() -> const std::string& {
+  static auto path = compileProg(
+                         "assert_true.nx",
+                         "import \"std/diag.ns\" "
+                         "assert(true)")
+                         .string();
+  return path;
+}
 
-auto fail_nx = compileProg(
-    "fail.nx",
-    "import \"std/sys.ns\" "
-    "fail(\"Failed on purpose\")");
+auto failNx() -> const std::string& {
+  static auto path = compileProg(
+                         "fail.nx",
+                         "import \"std/sys.ns\" "
+                         "fail(\"Failed on purpose\")")
+                         .string();
+  return path;
+}
 
-auto div_by_zero_nx = compileProg(
-    "div_by_zero.nx",
-    "import \"std/diag.ns\" "
-    "assert(1 / 0 == 1)");
+auto divByZeroNx() -> const std::string& {
+  static auto path = compileProg(
+                         "div_by_zero.nx",
+                         "import \"std/diag.ns\" "
+                         "assert(1 / 0 == 1)")
+                         .string();
+  return path;
+}
 
-auto wait_for_interupt_nx = compileProg(
-    "wait_for_interupt.nx",
-    "import \"std/core.ns\" "
-    "import \"std/io.ns\" "
-    "import \"std/sys.ns\" "
-    "print(invoke( "
-    "   impure lambda() "
-    "     if interuptIsRequested() -> \"Received interupt\" "
-    "     else -> sleep(millisecond()); self() ))");
+auto waitForInteruptNx() -> const std::string& {
+  static auto path = compileProg(
+                         "wait_for_interupt.nx",
+                         "import \"std/core.ns\" "
+                         "import \"std/io.ns\" "
+                         "import \"std/sys.ns\" "
+                         "print(invoke( "
+                         "   impure lambda() "
+                         "     if interuptIsRequested() -> \"Received interupt\" "
+                         "     else -> sleep(millisecond()); self() ))")
+                         .string();
+  return path;
+}
 
-auto infinite_loop_nx = compileProg(
-    "infinite_loop.nx",
-    "import \"std/core.ns\" "
-    "import \"std/sys.ns\" "
-    "invoke(impure lambda() -> bool sleep(millisecond()); self())");
+auto infiniteLoopNx() -> const std::string& {
+  static auto path = compileProg(
+                         "infinite_loop.nx",
+                         "import \"std/core.ns\" "
+                         "import \"std/sys.ns\" "
+                         "invoke(impure lambda() -> bool sleep(millisecond()); self())")
+                         .string();
+  return path;
+}
 
 } // namespace
 
@@ -140,7 +184,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           // Run a program that exits with code 0.
-          asmb->addLoadLitString(novrtPath + " " + assert_true_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + assertTrueNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -149,7 +193,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           ADD_PRINT(asmb);
 
           // Run a program that exits with code 1.
-          asmb->addLoadLitString(novrtPath + " " + fail_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + failNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -158,7 +202,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           ADD_PRINT(asmb);
 
           // Run a program that exits with code 14.
-          asmb->addLoadLitString(novrtPath + " " + div_by_zero_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + divByZeroNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -179,7 +223,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           // Run a program that prints to stdOut.
-          asmb->addLoadLitString(novrtPath + " " + hello_world_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -209,7 +253,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           // Run a program that prints to stdErr.
-          asmb->addLoadLitString(novrtPath + " " + hello_world_err_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + helloWorldErrNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -239,7 +283,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           // Run a program that reads a line from stdIn and write to stdOut.
-          asmb->addLoadLitString(novrtPath + " " + read_line_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + readLineNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.
@@ -270,7 +314,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that prints the number of environment arguments.
           asmb->addLoadLitString(
-              novrtPath + " " + print_num_env_args_nx.string() + " a --b -ce hello 'hello world'");
+              novrtPath + " " + printNumEnvArgsNx() + " a --b -ce hello 'hello world'");
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -282,8 +326,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that the argument after --test.
           asmb->addLoadLitString(
-              novrtPath + " " + print_test_env_opt_nx.string() +
-              " --something --test 'hello world' else");
+              novrtPath + " " + printTestEnvOptNx() + " --something --test 'hello world' else");
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -305,7 +348,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->label("entry");
           asmb->setEntrypoint("entry");
 
-          asmb->addLoadLitString(novrtPath + " " + hello_world_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessGetId);
 
@@ -326,7 +369,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->label("entry");
           asmb->setEntrypoint("entry");
 
-          asmb->addLoadLitString(novrtPath + " " + hello_world_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addPop();
@@ -342,7 +385,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->label("entry");
           asmb->setEntrypoint("entry");
 
-          asmb->addLoadLitString(novrtPath + " " + hello_world_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           // Sleep for 500 ms to give the child-process time to finish.
@@ -369,7 +412,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           // Stack var 2 - ( numForks + 2 ):  future handles to the forked workers.
 
           // Start a process and save it in a variable.
-          asmb->addLoadLitString(novrtPath + " " + hello_world_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addStackStore(0);
 
@@ -467,7 +510,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->label("entry");
           asmb->setEntrypoint("entry");
 
-          asmb->addLoadLitString(" \t \n \r " + novrtPath + " " + hello_world_nx.string());
+          asmb->addLoadLitString(" \t \n \r " + novrtPath + " " + helloWorldNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -485,8 +528,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->label("entry");
           asmb->setEntrypoint("entry");
 
-          asmb->addLoadLitString(
-              novrtPath + " " + print_first_arg_nx.string() + " non-quoted\\'quoted\\'");
+          asmb->addLoadLitString(novrtPath + " " + printFirstArgNx() + " non-quoted\\'quoted\\'");
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -508,7 +550,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           // Run a program that waits until its interupted.
-          asmb->addLoadLitString(novrtPath + " " + wait_for_interupt_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + waitForInteruptNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.
@@ -546,7 +588,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           // Run a program that runs an infinite loop.
-          asmb->addLoadLitString(novrtPath + " " + infinite_loop_nx.string());
+          asmb->addLoadLitString(novrtPath + " " + infiniteLoopNx());
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.

--- a/tests/vm/io_tcp_test.cpp
+++ b/tests/vm/io_tcp_test.cpp
@@ -5,10 +5,14 @@
 
 namespace vm {
 
-TEST_CASE("[vm] Execute tcp platform-calls", "vm") {
+namespace {
 
-  auto loopbackAddrIpV4 = std::string{127, 0, 0, 1};
-  auto loopbackAddrIpV6 = std::string{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+auto loopbackAddrIpV4 = std::string{127, 0, 0, 1};
+auto loopbackAddrIpV6 = std::string{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+
+} // namespace
+
+TEST_CASE("[vm] Execute tcp platform-calls", "vm") {
 
   SECTION("Send and receive message IpV4") {
     CHECK_PROG(


### PR DESCRIPTION
Support defining implicit conversions
![img](https://user-images.githubusercontent.com/14230060/110998337-54b67780-8387-11eb-88a7-02f5b6c81679.jpeg)

Allows us to move the definition of certain primitive implicit conversions to the library, instead of being build-in to the compiler.

For example:
![image](https://user-images.githubusercontent.com/14230060/110998500-90514180-8387-11eb-92c0-1f0d29864116.png)
