### PR TITLE
Move equality operators to library

### DIFF
--- a/include/novasm/assembler.hpp
+++ b/include/novasm/assembler.hpp
@@ -69,7 +69,6 @@ public:
   auto addNegInt() -> void;
   auto addNegLong() -> void;
   auto addNegFloat() -> void;
-  auto addLogicInvInt() -> void;
   auto addShiftLeftInt() -> void;
   auto addShiftLeftLong() -> void;
   auto addShiftRightInt() -> void;
@@ -99,6 +98,7 @@ public:
   auto addCheckLeLong() -> void;
   auto addCheckLeFloat() -> void;
   auto addCheckStructNull() -> void;
+  auto addCheckIntZero() -> void;
 
   auto addConvIntLong() -> void;
   auto addConvIntFloat() -> void;

--- a/include/novasm/op_code.hpp
+++ b/include/novasm/op_code.hpp
@@ -57,22 +57,21 @@ enum class OpCode : uint8_t {
   NegInt         = 66, // [] (int)              -> (int)    Negate an int.
   NegLong        = 67, // [] (long)             -> (long)   Negate a long.
   NegFloat       = 68, // [] (float)            -> (float)  Negate a float.
-  LogicInvInt    = 69, // [] (int)              -> (int)    Logic invert, (0 to 1) & (1 to 0).
-  ShiftLeftInt   = 70, // [] (int, int)         -> (int)    Bitwise shift an int x to left.
-  ShiftLeftLong  = 71, // [] (int, long)        -> (int)    Bitwise shift an long x to left.
-  ShiftRightInt  = 72, // [] (int, int)         -> (int)    Bitwise shift an int x to right.
-  ShiftRightLong = 73, // [] (int, long)        -> (int)    Bitwise shift an long x to right.
-  AndInt         = 74, // [] (int, int)         -> (int)    Bitwise and two ints.
-  AndLong        = 75, // [] (long, long)       -> (long)   Bitwise and two longs.
-  OrInt          = 76, // [] (int, int)         -> (int)    Bitwise or two ints.
-  OrLong         = 77, // [] (long, long)       -> (long)   Bitwise or two longs.
-  XorInt         = 78, // [] (int, int)         -> (int)    Bitwise exclusive-or two ints.
-  XorLong        = 79, // [] (long, long)       -> (long)   Bitwise exclusive-or two longs.
-  InvInt         = 80, // [] (int)              -> (int)    Bitwise invert an int.
-  InvLong        = 81, // [] (long)             -> (long)   Bitwise invert an long.
-  LengthString   = 82, // [] (string)           -> (int)    Calc length of a string.
-  IndexString    = 83, // [] (int, string)      -> (int)    Get char at index in string (ascii).
-  SliceString    = 84, // [] (int, int, string) -> (string) Substring from start to end (exclusive).
+  ShiftLeftInt   = 69, // [] (int, int)         -> (int)    Bitwise shift an int x to left.
+  ShiftLeftLong  = 70, // [] (int, long)        -> (int)    Bitwise shift an long x to left.
+  ShiftRightInt  = 71, // [] (int, int)         -> (int)    Bitwise shift an int x to right.
+  ShiftRightLong = 72, // [] (int, long)        -> (int)    Bitwise shift an long x to right.
+  AndInt         = 73, // [] (int, int)         -> (int)    Bitwise and two ints.
+  AndLong        = 74, // [] (long, long)       -> (long)   Bitwise and two longs.
+  OrInt          = 75, // [] (int, int)         -> (int)    Bitwise or two ints.
+  OrLong         = 76, // [] (long, long)       -> (long)   Bitwise or two longs.
+  XorInt         = 77, // [] (int, int)         -> (int)    Bitwise exclusive-or two ints.
+  XorLong        = 78, // [] (long, long)       -> (long)   Bitwise exclusive-or two longs.
+  InvInt         = 79, // [] (int)              -> (int)    Bitwise invert an int.
+  InvLong        = 80, // [] (long)             -> (long)   Bitwise invert an long.
+  LengthString   = 81, // [] (string)           -> (int)    Calc length of a string.
+  IndexString    = 82, // [] (int, string)      -> (int)    Get char at index in string (ascii).
+  SliceString    = 83, // [] (int, int, string) -> (string) Substring from start to end (exclusive).
 
   CheckEqInt        = 90, //  [] (int, int)               -> (int) Check ints equal.
   CheckEqLong       = 91, //  [] (long, long)             -> (int) Check long equal.
@@ -87,6 +86,7 @@ enum class OpCode : uint8_t {
   CheckLeLong       = 100, // [] (long, long)             -> (int) Check int is less.
   CheckLeFloat      = 101, // [] (float, float)           -> (int) Check float is less.
   CheckStructNull   = 102, // [] (struct)                 -> (int) Check if struct is null.
+  CheckIntZero      = 103, // [] (int)                    -> (int) Check if integer is zero.
 
   ConvIntLong     = 111, // [] (int)   -> (long)     Convert int to long.
   ConvIntFloat    = 112, // [] (int)   -> (float)    Convert int to float.

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -7,7 +7,7 @@ namespace novasm {
 // Version number for the binary representation of the novus assembly format.
 // Increase this when performing breaking changes to the format.
 // TODO(bastian): Add system for defining migrations.
-const uint16_t executableFormatVersion = 9U;
+const uint16_t executableFormatVersion = 10U;
 
 // Write a binary representation of the executable file to the output iterator.
 template <typename OutputItr>

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -66,8 +66,7 @@ enum class FuncKind {
   CheckGtFloat,   // Check if a float is greater then another float.
   CheckGtEqFloat, // Check if a float is greater then or equal to another float.
 
-  InvBool,     // Logic invert a boolean, true -> false, false -> true.
-  CheckEqBool, // Check if two booleans are equal.
+  InvBool, // Logic invert a boolean, true -> false, false -> true.
 
   AddString,     // Combine two strings.
   LengthString,  // Return the length of a string.

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -22,7 +22,6 @@ enum class FuncKind {
   XorInt,        // Bitwise xor two integers.
   InvInt,        // Bitwise invert an integer.
   CheckEqInt,    // Check if two integers are equal.
-  CheckNEqInt,   // Check if two integers are not equal.
   CheckLeInt,    // Check if an integer is less then another integer.
   CheckLeEqInt,  // Check if an integer is less then or equal to another integer.
   CheckGtInt,    // Check if an integer is greater then another integer.
@@ -41,7 +40,6 @@ enum class FuncKind {
   XorLong,        // Bitwise xor two longs.
   InvLong,        // Bitwise invert an long.
   CheckEqLong,    // Check if two longs are equal.
-  CheckNEqLong,   // Check if two longs are not equal.
   CheckLeLong,    // Check if a long is less then another long.
   CheckLeEqLong,  // Check if a long is less then or equal to another long.
   CheckGtLong,    // Check if a long is greater then another long.
@@ -63,22 +61,19 @@ enum class FuncKind {
   ATan2Float,     // Compute the arc tangent of two floats.
   NegateFloat,    // Negate a float.
   CheckEqFloat,   // Check if two floats are equal.
-  CheckNEqFloat,  // Check if two floats are not equal.
   CheckLeFloat,   // Check if a float is less then another float.
   CheckLeEqFloat, // Check if a float is less then or equal to another float.
   CheckGtFloat,   // Check if a float is greater then another float.
   CheckGtEqFloat, // Check if a float is greater then or equal to another float.
 
-  InvBool,      // Logic invert a boolean, true -> false, false -> true.
-  CheckEqBool,  // Check if two booleans are equal.
-  CheckNEqBool, // Check if two booleans are not equal.
+  InvBool,     // Logic invert a boolean, true -> false, false -> true.
+  CheckEqBool, // Check if two booleans are equal.
 
-  AddString,      // Combine two strings.
-  LengthString,   // Return the length of a string.
-  IndexString,    // Return the character at a specific index into a string.
-  SliceString,    // Return a subsection of a string, indicated by start and end.
-  CheckEqString,  // Check if two strings are equal.
-  CheckNEqString, // Check if two strings are not equal.
+  AddString,     // Combine two strings.
+  LengthString,  // Return the length of a string.
+  IndexString,   // Return the character at a specific index into a string.
+  SliceString,   // Return a subsection of a string, indicated by start and end.
+  CheckEqString, // Check if two strings are equal.
 
   AppendChar, // Append a character to a string.
 
@@ -105,9 +100,8 @@ enum class FuncKind {
 
   LazyGet, // Retreive the value for a lazy value.
 
-  CheckEqUserType,  // Check if two user types are equal. Note: Backend will generate equality for
-                    // all user-types.
-  CheckNEqUserType, // Check if two user-types are not equal.
+  CheckEqUserType, // Check if two user types are equal.
+                   // Note: Backend will generate equality for all user-types.
 
   // NOTE: The source-location functions are no-ops that just return 'unknown' and '-1' at runtime.
   // If used in a supported context (like in an optional argument initializer the frontend will

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -26,6 +26,7 @@ enum class FuncKind {
   CheckLeEqInt,  // Check if an integer is less then or equal to another integer.
   CheckGtInt,    // Check if an integer is greater then another integer.
   CheckGtEqInt,  // Check if an integer is greater then or equal to another integer.
+  CheckIntZero,  // Check if an integer is zero.
 
   AddLong,        // Add two longs.
   SubLong,        // Substract two longs.
@@ -65,8 +66,6 @@ enum class FuncKind {
   CheckLeEqFloat, // Check if a float is less then or equal to another float.
   CheckGtFloat,   // Check if a float is greater then another float.
   CheckGtEqFloat, // Check if a float is greater then or equal to another float.
-
-  InvBool, // Logic invert a boolean, true -> false, false -> true.
 
   AddString,     // Combine two strings.
   LengthString,  // Return the length of a string.

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -303,9 +303,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::InvBool:
     m_asmb->addLogicInvInt();
     break;
-  case prog::sym::FuncKind::CheckEqBool:
-    m_asmb->addCheckEqInt();
-    break;
 
   case prog::sym::FuncKind::AddString:
     m_asmb->addAddString();

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -166,10 +166,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::CheckEqInt:
     m_asmb->addCheckEqInt();
     break;
-  case prog::sym::FuncKind::CheckNEqInt:
-    m_asmb->addCheckEqInt();
-    m_asmb->addLogicInvInt();
-    break;
   case prog::sym::FuncKind::CheckLeInt:
     m_asmb->addCheckLeInt();
     break;
@@ -224,10 +220,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
 
   case prog::sym::FuncKind::CheckEqLong:
     m_asmb->addCheckEqLong();
-    break;
-  case prog::sym::FuncKind::CheckNEqLong:
-    m_asmb->addCheckEqLong();
-    m_asmb->addLogicInvInt();
     break;
   case prog::sym::FuncKind::CheckLeLong:
     m_asmb->addCheckLeLong();
@@ -293,10 +285,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::CheckEqFloat:
     m_asmb->addCheckEqFloat();
     break;
-  case prog::sym::FuncKind::CheckNEqFloat:
-    m_asmb->addCheckEqFloat();
-    m_asmb->addLogicInvInt();
-    break;
   case prog::sym::FuncKind::CheckLeFloat:
     m_asmb->addCheckLeFloat();
     break;
@@ -318,10 +306,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::CheckEqBool:
     m_asmb->addCheckEqInt();
     break;
-  case prog::sym::FuncKind::CheckNEqBool:
-    m_asmb->addCheckEqInt();
-    m_asmb->addLogicInvInt();
-    break;
 
   case prog::sym::FuncKind::AddString:
     m_asmb->addAddString();
@@ -337,10 +321,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   case prog::sym::FuncKind::CheckEqString:
     m_asmb->addCheckEqString();
-    break;
-  case prog::sym::FuncKind::CheckNEqString:
-    m_asmb->addCheckEqString();
-    m_asmb->addLogicInvInt();
     break;
 
   case prog::sym::FuncKind::AppendChar:
@@ -426,21 +406,16 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   }
 
-  case prog::sym::FuncKind::CheckEqUserType:
-  case prog::sym::FuncKind::CheckNEqUserType: {
+  case prog::sym::FuncKind::CheckEqUserType: {
     auto lhsType = n[0].getType();
     auto rhsType = n[1].getType();
     if (lhsType != rhsType) {
       throw std::logic_error{"User-type equality function requires args to have the same type"};
     }
-    auto invert = funcDecl.getKind() == prog::sym::FuncKind::CheckNEqUserType;
     m_asmb->addCall(
         getUserTypeEqLabel(m_prog, lhsType),
         2,
-        (m_tail && !invert) ? novasm::CallMode::Tail : novasm::CallMode::Normal);
-    if (invert) {
-      m_asmb->addLogicInvInt();
-    }
+        m_tail ? novasm::CallMode::Tail : novasm::CallMode::Normal);
     break;
   }
 

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -171,14 +171,17 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   case prog::sym::FuncKind::CheckLeEqInt:
     m_asmb->addCheckGtInt();
-    m_asmb->addLogicInvInt();
+    m_asmb->addCheckIntZero(); // Invert.
     break;
   case prog::sym::FuncKind::CheckGtInt:
     m_asmb->addCheckGtInt();
     break;
   case prog::sym::FuncKind::CheckGtEqInt:
     m_asmb->addCheckLeInt();
-    m_asmb->addLogicInvInt();
+    m_asmb->addCheckIntZero(); // Invert.
+    break;
+  case prog::sym::FuncKind::CheckIntZero:
+    m_asmb->addCheckIntZero();
     break;
 
   case prog::sym::FuncKind::AddLong:
@@ -226,14 +229,14 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   case prog::sym::FuncKind::CheckLeEqLong:
     m_asmb->addCheckGtLong();
-    m_asmb->addLogicInvInt();
+    m_asmb->addCheckIntZero(); // Invert.
     break;
   case prog::sym::FuncKind::CheckGtLong:
     m_asmb->addCheckGtLong();
     break;
   case prog::sym::FuncKind::CheckGtEqLong:
     m_asmb->addCheckLeLong();
-    m_asmb->addLogicInvInt();
+    m_asmb->addCheckIntZero(); // Invert.
     break;
 
   case prog::sym::FuncKind::AddFloat:
@@ -290,18 +293,14 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   case prog::sym::FuncKind::CheckLeEqFloat:
     m_asmb->addCheckGtFloat();
-    m_asmb->addLogicInvInt();
+    m_asmb->addCheckIntZero(); // Invert.
     break;
   case prog::sym::FuncKind::CheckGtFloat:
     m_asmb->addCheckGtFloat();
     break;
   case prog::sym::FuncKind::CheckGtEqFloat:
     m_asmb->addCheckLeFloat();
-    m_asmb->addLogicInvInt();
-    break;
-
-  case prog::sym::FuncKind::InvBool:
-    m_asmb->addLogicInvInt();
+    m_asmb->addCheckIntZero(); // Invert.
     break;
 
   case prog::sym::FuncKind::AddString:
@@ -682,7 +681,7 @@ auto GenExpr::visit(const prog::expr::UnionCheckExprNode& n) -> void {
       m_asmb->addCheckStructNull();
     } else {
       m_asmb->addCheckStructNull();
-      m_asmb->addLogicInvInt();
+      m_asmb->addCheckIntZero(); // Invert.
     }
     return;
   }
@@ -709,7 +708,7 @@ auto GenExpr::visit(const prog::expr::UnionGetExprNode& n) -> void {
       m_asmb->addDup();
       m_asmb->addStackStore(getConstOffset(m_constTable, n.getConst()));
       m_asmb->addCheckStructNull();
-      m_asmb->addLogicInvInt();
+      m_asmb->addCheckIntZero(); // Invert.
     }
     return;
   }

--- a/src/backend/internal/gen_type_eq.cpp
+++ b/src/backend/internal/gen_type_eq.cpp
@@ -296,7 +296,7 @@ auto genUserTypeEquality(novasm::Assembler* asmb, const prog::Program& prog) -> 
   for (auto fItr = prog.beginFuncDecls(); fItr != prog.endFuncDecls(); ++fItr) {
     using fk  = prog::sym::FuncKind;
     auto kind = fItr->second.getKind();
-    if (kind == fk::CheckEqUserType || kind == fk::CheckNEqUserType) {
+    if (kind == fk::CheckEqUserType) {
       addTypeAndNestedTypes(prog, &types, *fItr->second.getInput().begin());
     }
   }

--- a/src/frontend/internal/get_expr.hpp
+++ b/src/frontend/internal/get_expr.hpp
@@ -120,13 +120,15 @@ private:
   [[nodiscard]] auto getFunctionsInclConversions(
       const lex::Token& nameToken,
       const std::optional<parse::TypeParamList>& typeParams,
-      const prog::sym::TypeSet& argTypes) -> std::vector<prog::sym::FuncId>;
+      const prog::sym::TypeSet& argTypes,
+      prog::OvOptions ovOptions) -> std::vector<prog::sym::FuncId>;
 
   [[nodiscard]] auto getFunctions(
       const std::string& funcName,
       const std::optional<parse::TypeParamList>& typeParams,
       const prog::sym::TypeSet& argTypes,
-      input::Span span) -> std::vector<prog::sym::FuncId>;
+      input::Span span,
+      prog::OvOptions ovOptions) -> std::vector<prog::sym::FuncId>;
 
   template <Flags F>
   [[nodiscard]] inline auto hasFlag() const noexcept {

--- a/src/novasm/assembler.cpp
+++ b/src/novasm/assembler.cpp
@@ -144,8 +144,6 @@ auto Assembler::addNegLong() -> void { writeOpCode(OpCode::NegLong); }
 
 auto Assembler::addNegFloat() -> void { writeOpCode(OpCode::NegFloat); }
 
-auto Assembler::addLogicInvInt() -> void { writeOpCode(OpCode::LogicInvInt); }
-
 auto Assembler::addShiftLeftInt() -> void { writeOpCode(OpCode::ShiftLeftInt); }
 
 auto Assembler::addShiftLeftLong() -> void { writeOpCode(OpCode::ShiftLeftLong); }
@@ -201,6 +199,8 @@ auto Assembler::addCheckLeLong() -> void { writeOpCode(OpCode::CheckLeLong); }
 auto Assembler::addCheckLeFloat() -> void { writeOpCode(OpCode::CheckLeFloat); }
 
 auto Assembler::addCheckStructNull() -> void { writeOpCode(OpCode::CheckStructNull); }
+
+auto Assembler::addCheckIntZero() -> void { writeOpCode(OpCode::CheckIntZero); }
 
 auto Assembler::addConvIntLong() -> void { writeOpCode(OpCode::ConvIntLong); }
 

--- a/src/novasm/disassembler.cpp
+++ b/src/novasm/disassembler.cpp
@@ -162,7 +162,6 @@ auto disassembleInstructions(
     case OpCode::NegInt:
     case OpCode::NegLong:
     case OpCode::NegFloat:
-    case OpCode::LogicInvInt:
     case OpCode::ShiftLeftInt:
     case OpCode::ShiftLeftLong:
     case OpCode::ShiftRightInt:
@@ -191,6 +190,7 @@ auto disassembleInstructions(
     case OpCode::CheckLeLong:
     case OpCode::CheckLeFloat:
     case OpCode::CheckStructNull:
+    case OpCode::CheckIntZero:
     case OpCode::ConvIntLong:
     case OpCode::ConvIntFloat:
     case OpCode::ConvLongInt:

--- a/src/novasm/op_code.cpp
+++ b/src/novasm/op_code.cpp
@@ -135,9 +135,6 @@ auto operator<<(std::ostream& out, const OpCode& rhs) noexcept -> std::ostream& 
   case OpCode::NegFloat:
     out << "neg-float";
     break;
-  case OpCode::LogicInvInt:
-    out << "logicinvert-int";
-    break;
   case OpCode::ShiftLeftInt:
     out << "shiftleft-int";
     break;
@@ -222,6 +219,9 @@ auto operator<<(std::ostream& out, const OpCode& rhs) noexcept -> std::ostream& 
     break;
   case OpCode::CheckStructNull:
     out << "check-struct-null";
+    break;
+  case OpCode::CheckIntZero:
+    out << "check-int-zero";
     break;
 
   case OpCode::ConvIntLong:

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -35,6 +35,7 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::CheckLeEqInt:
   case prog::sym::FuncKind::CheckGtInt:
   case prog::sym::FuncKind::CheckGtEqInt:
+  case prog::sym::FuncKind::CheckIntZero:
   case prog::sym::FuncKind::ConvIntLong:
   case prog::sym::FuncKind::ConvCharLong:
   case prog::sym::FuncKind::ConvIntFloat:
@@ -89,9 +90,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::ConvLongFloat:
   case prog::sym::FuncKind::ConvLongString:
   case prog::sym::FuncKind::ConvLongChar:
-
-  // Bool
-  case prog::sym::FuncKind::InvBool:
 
   // Char
   case prog::sym::FuncKind::ConvCharString:
@@ -202,6 +200,10 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::CheckGtEqInt: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getInt(*args[0]) >= getInt(*args[1]));
+  }
+  case prog::sym::FuncKind::CheckIntZero: {
+    assert(args.size() == 1);
+    return prog::expr::litBoolNode(prog, getInt(*args[0]) == 0);
   }
   case prog::sym::FuncKind::ConvIntLong:
   case prog::sym::FuncKind::ConvCharLong: {
@@ -423,12 +425,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::ConvLongChar: {
     assert(args.size() == 1);
     return prog::expr::litCharNode(prog, static_cast<uint8_t>(getLong(*args[0])));
-  }
-
-  // Bool
-  case prog::sym::FuncKind::InvBool: {
-    assert(args.size() == 1);
-    return prog::expr::litBoolNode(prog, !getBool(*args[0]));
   }
 
   // Char

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -92,7 +92,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
 
   // Bool
   case prog::sym::FuncKind::InvBool:
-  case prog::sym::FuncKind::CheckEqBool:
 
   // Char
   case prog::sym::FuncKind::ConvCharString:
@@ -430,10 +429,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::InvBool: {
     assert(args.size() == 1);
     return prog::expr::litBoolNode(prog, !getBool(*args[0]));
-  }
-  case prog::sym::FuncKind::CheckEqBool: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getBool(*args[0]) == getBool(*args[1]));
   }
 
   // Char

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -31,7 +31,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::XorInt:
   case prog::sym::FuncKind::InvInt:
   case prog::sym::FuncKind::CheckEqInt:
-  case prog::sym::FuncKind::CheckNEqInt:
   case prog::sym::FuncKind::CheckLeInt:
   case prog::sym::FuncKind::CheckLeEqInt:
   case prog::sym::FuncKind::CheckGtInt:
@@ -59,7 +58,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::ATan2Float:
   case prog::sym::FuncKind::NegateFloat:
   case prog::sym::FuncKind::CheckEqFloat:
-  case prog::sym::FuncKind::CheckNEqFloat:
   case prog::sym::FuncKind::CheckLeFloat:
   case prog::sym::FuncKind::CheckLeEqFloat:
   case prog::sym::FuncKind::CheckGtFloat:
@@ -83,7 +81,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::XorLong:
   case prog::sym::FuncKind::InvLong:
   case prog::sym::FuncKind::CheckEqLong:
-  case prog::sym::FuncKind::CheckNEqLong:
   case prog::sym::FuncKind::CheckLeLong:
   case prog::sym::FuncKind::CheckLeEqLong:
   case prog::sym::FuncKind::CheckGtLong:
@@ -96,7 +93,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   // Bool
   case prog::sym::FuncKind::InvBool:
   case prog::sym::FuncKind::CheckEqBool:
-  case prog::sym::FuncKind::CheckNEqBool:
 
   // Char
   case prog::sym::FuncKind::ConvCharString:
@@ -108,7 +104,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::SliceString:
   case prog::sym::FuncKind::AppendChar:
   case prog::sym::FuncKind::CheckEqString:
-  case prog::sym::FuncKind::CheckNEqString:
 
   // Source location
   // NOTE: These are only present if the frontend was unable to replace it with valid literals.
@@ -192,10 +187,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::CheckEqInt: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getInt(*args[0]) == getInt(*args[1]));
-  }
-  case prog::sym::FuncKind::CheckNEqInt: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getInt(*args[0]) != getInt(*args[1]));
   }
   case prog::sym::FuncKind::CheckLeInt: {
     assert(args.size() == 2);
@@ -297,10 +288,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::CheckEqFloat: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getFloat(*args[0]) == getFloat(*args[1]));
-  }
-  case prog::sym::FuncKind::CheckNEqFloat: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getFloat(*args[0]) != getFloat(*args[1]));
   }
   case prog::sym::FuncKind::CheckLeFloat: {
     assert(args.size() == 2);
@@ -404,10 +391,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getLong(*args[0]) == getLong(*args[1]));
   }
-  case prog::sym::FuncKind::CheckNEqLong: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getLong(*args[0]) != getLong(*args[1]));
-  }
   case prog::sym::FuncKind::CheckLeLong: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getLong(*args[0]) < getLong(*args[1]));
@@ -451,10 +434,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::CheckEqBool: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getBool(*args[0]) == getBool(*args[1]));
-  }
-  case prog::sym::FuncKind::CheckNEqBool: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getBool(*args[0]) != getBool(*args[1]));
   }
 
   // Char
@@ -510,10 +489,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::CheckEqString: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getString(*args[0]) == getString(*args[1]));
-  }
-  case prog::sym::FuncKind::CheckNEqString: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getString(*args[0]) != getString(*args[1]));
   }
 
   case prog::sym::FuncKind::SourceLocFile: {

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -61,10 +61,6 @@ Program::Program() :
   m_funcDecls.registerFunc(
       *this, Fk::XorInt, getFuncName(Op::Hat), sym::TypeSet{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
-      *this, Fk::CheckEqInt, getFuncName(Op::EqEq), sym::TypeSet{m_int, m_int}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckNEqInt, getFuncName(Op::BangEq), sym::TypeSet{m_int, m_int}, m_bool);
-  m_funcDecls.registerFunc(
       *this, Fk::CheckLeInt, getFuncName(Op::Le), sym::TypeSet{m_int, m_int}, m_bool);
   m_funcDecls.registerFunc(
       *this, Fk::CheckLeEqInt, getFuncName(Op::LeEq), sym::TypeSet{m_int, m_int}, m_bool);
@@ -72,6 +68,10 @@ Program::Program() :
       *this, Fk::CheckGtInt, getFuncName(Op::Gt), sym::TypeSet{m_int, m_int}, m_bool);
   m_funcDecls.registerFunc(
       *this, Fk::CheckGtEqInt, getFuncName(Op::GtEq), sym::TypeSet{m_int, m_int}, m_bool);
+
+  // Register int intrinsics.
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckEqInt, "int_eq_int", sym::TypeSet{m_int, m_int}, m_bool);
 
   // Register build-in unary long operators.
   m_funcDecls.registerFunc(
@@ -101,10 +101,6 @@ Program::Program() :
   m_funcDecls.registerFunc(
       *this, Fk::XorLong, getFuncName(Op::Hat), sym::TypeSet{m_long, m_long}, m_long);
   m_funcDecls.registerFunc(
-      *this, Fk::CheckEqLong, getFuncName(Op::EqEq), sym::TypeSet{m_long, m_long}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckNEqLong, getFuncName(Op::BangEq), sym::TypeSet{m_long, m_long}, m_bool);
-  m_funcDecls.registerFunc(
       *this, Fk::CheckLeLong, getFuncName(Op::Le), sym::TypeSet{m_long, m_long}, m_bool);
   m_funcDecls.registerFunc(
       *this, Fk::CheckLeEqLong, getFuncName(Op::LeEq), sym::TypeSet{m_long, m_long}, m_bool);
@@ -112,6 +108,10 @@ Program::Program() :
       *this, Fk::CheckGtLong, getFuncName(Op::Gt), sym::TypeSet{m_long, m_long}, m_bool);
   m_funcDecls.registerFunc(
       *this, Fk::CheckGtEqLong, getFuncName(Op::GtEq), sym::TypeSet{m_long, m_long}, m_bool);
+
+  // Register long intrinsics.
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckEqLong, "long_eq_long", sym::TypeSet{m_long, m_long}, m_bool);
 
   // Register build-in unary float operators.
   m_funcDecls.registerFunc(
@@ -129,10 +129,6 @@ Program::Program() :
   m_funcDecls.registerFunc(
       *this, Fk::ModFloat, getFuncName(Op::Rem), sym::TypeSet{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
-      *this, Fk::CheckEqFloat, getFuncName(Op::EqEq), sym::TypeSet{m_float, m_float}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckNEqFloat, getFuncName(Op::BangEq), sym::TypeSet{m_float, m_float}, m_bool);
-  m_funcDecls.registerFunc(
       *this, Fk::CheckLeFloat, getFuncName(Op::Le), sym::TypeSet{m_float, m_float}, m_bool);
   m_funcDecls.registerFunc(
       *this, Fk::CheckLeEqFloat, getFuncName(Op::LeEq), sym::TypeSet{m_float, m_float}, m_bool);
@@ -141,7 +137,9 @@ Program::Program() :
   m_funcDecls.registerFunc(
       *this, Fk::CheckGtEqFloat, getFuncName(Op::GtEq), sym::TypeSet{m_float, m_float}, m_bool);
 
-  // Register build-in float functions.
+  // Register float intrinsics.
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckEqFloat, "float_eq_float", sym::TypeSet{m_float, m_float}, m_bool);
   m_funcDecls.registerIntrinsic(
       *this, Fk::PowFloat, "float_pow", sym::TypeSet{m_float, m_float}, m_float);
   m_funcDecls.registerIntrinsic(*this, Fk::SqrtFloat, "float_sqrt", sym::TypeSet{m_float}, m_float);
@@ -157,21 +155,19 @@ Program::Program() :
   // Register build-in unary bool operators.
   m_funcDecls.registerFunc(*this, Fk::InvBool, getFuncName(Op::Bang), sym::TypeSet{m_bool}, m_bool);
 
-  // Register build-in binary bool operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckEqBool, getFuncName(Op::EqEq), sym::TypeSet{m_bool, m_bool}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckNEqBool, getFuncName(Op::BangEq), sym::TypeSet{m_bool, m_bool}, m_bool);
+  // Register bool intrinsics.
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckEqBool, "bool_eq_bool", sym::TypeSet{m_bool, m_bool}, m_bool);
 
   // Register build-in binary string operators.
   m_funcDecls.registerFunc(
       *this, Fk::AddString, getFuncName(Op::Plus), sym::TypeSet{m_string, m_string}, m_string);
   m_funcDecls.registerFunc(
       *this, Fk::AppendChar, getFuncName(Op::Plus), sym::TypeSet{m_string, m_char}, m_string);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckEqString, getFuncName(Op::EqEq), sym::TypeSet{m_string, m_string}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckNEqString, getFuncName(Op::BangEq), sym::TypeSet{m_string, m_string}, m_bool);
+
+  // Register string intrinsics.
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckEqString, "string_eq_string", sym::TypeSet{m_string, m_string}, m_bool);
 
   // Register build-in string functions.
   m_funcDecls.registerIntrinsic(
@@ -547,19 +543,9 @@ auto Program::defineStruct(sym::TypeId id, sym::FieldDeclTable fields) -> void {
   const auto& name = m_typeDecls[id].getName();
   m_funcDecls.registerFunc(*this, sym::FuncKind::MakeStruct, name, sym::TypeSet{fieldTypes}, id);
 
-  // Register (in)equality functions.
-  m_funcDecls.registerFunc(
-      *this,
-      sym::FuncKind::CheckEqUserType,
-      getFuncName(Operator::EqEq),
-      sym::TypeSet{id, id},
-      m_bool);
-  m_funcDecls.registerFunc(
-      *this,
-      sym::FuncKind::CheckNEqUserType,
-      getFuncName(Operator::BangEq),
-      sym::TypeSet{id, id},
-      m_bool);
+  // Register equality intrinsic.
+  m_funcDecls.registerIntrinsic(
+      *this, sym::FuncKind::CheckEqUserType, "usertype_eq_usertype", sym::TypeSet{id, id}, m_bool);
 
   // Register struct definition.
   m_typeDefs.registerStruct(m_typeDecls, id, std::move(fields));
@@ -572,19 +558,9 @@ auto Program::defineUnion(sym::TypeId id, std::vector<sym::TypeId> types) -> voi
     m_funcDecls.registerImplicitConv(*this, sym::FuncKind::MakeUnion, type, id);
   }
 
-  // Register (in)equality functions.
-  m_funcDecls.registerFunc(
-      *this,
-      sym::FuncKind::CheckEqUserType,
-      getFuncName(Operator::EqEq),
-      sym::TypeSet{id, id},
-      m_bool);
-  m_funcDecls.registerFunc(
-      *this,
-      sym::FuncKind::CheckNEqUserType,
-      getFuncName(Operator::BangEq),
-      sym::TypeSet{id, id},
-      m_bool);
+  // Register equality intrinsic.
+  m_funcDecls.registerIntrinsic(
+      *this, sym::FuncKind::CheckEqUserType, "usertype_eq_usertype", sym::TypeSet{id, id}, m_bool);
 
   // Register union definition.
   m_typeDefs.registerUnion(m_typeDecls, id, std::move(types));
@@ -615,11 +591,9 @@ auto Program::defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t
   m_funcDecls.registerFunc(*this, fk::OrInt, getFuncName(Operator::Pipe), sym::TypeSet{id, id}, id);
   m_funcDecls.registerFunc(*this, fk::AndInt, getFuncName(Operator::Amp), sym::TypeSet{id, id}, id);
 
-  // Register (in)equality functions.
-  m_funcDecls.registerFunc(
-      *this, fk::CheckEqInt, getFuncName(Operator::EqEq), sym::TypeSet{id, id}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, fk::CheckNEqInt, getFuncName(Operator::BangEq), sym::TypeSet{id, id}, m_bool);
+  // Register equality intrinsic.
+  m_funcDecls.registerIntrinsic(
+      *this, fk::CheckEqInt, "usertype_eq_usertype", sym::TypeSet{id, id}, m_bool);
 
   // Register enum definition.
   m_typeDefs.registerEnum(m_typeDecls, id, std::move(entries));

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -155,10 +155,6 @@ Program::Program() :
   // Register build-in unary bool operators.
   m_funcDecls.registerFunc(*this, Fk::InvBool, getFuncName(Op::Bang), sym::TypeSet{m_bool}, m_bool);
 
-  // Register bool intrinsics.
-  m_funcDecls.registerIntrinsic(
-      *this, Fk::CheckEqBool, "bool_eq_bool", sym::TypeSet{m_bool, m_bool}, m_bool);
-
   // Register build-in binary string operators.
   m_funcDecls.registerFunc(
       *this, Fk::AddString, getFuncName(Op::Plus), sym::TypeSet{m_string, m_string}, m_string);
@@ -182,7 +178,6 @@ Program::Program() :
       m_string);
 
   // Register conversion intrinsics.
-  m_funcDecls.registerIntrinsic(*this, Fk::NoOp, "char_to_int", sym::TypeSet{m_char}, m_int);
   m_funcDecls.registerIntrinsic(*this, Fk::ConvIntLong, "int_to_long", sym::TypeSet{m_int}, m_long);
   m_funcDecls.registerIntrinsic(
       *this, Fk::ConvCharLong, "char_to_long", sym::TypeSet{m_char}, m_long);
@@ -208,8 +203,10 @@ Program::Program() :
       *this, Fk::ConvFloatString, "float_to_string", sym::TypeSet{m_float}, m_string);
   m_funcDecls.registerIntrinsic(
       *this, Fk::ConvCharString, "char_to_string", sym::TypeSet{m_char}, m_string);
+  m_funcDecls.registerIntrinsic(*this, Fk::NoOp, "char_as_int", sym::TypeSet{m_char}, m_int);
   m_funcDecls.registerIntrinsic(*this, Fk::NoOp, "int_as_float", sym::TypeSet{m_int}, m_float);
   m_funcDecls.registerIntrinsic(*this, Fk::NoOp, "float_as_int", sym::TypeSet{m_float}, m_int);
+  m_funcDecls.registerIntrinsic(*this, Fk::NoOp, "bool_as_int", sym::TypeSet{m_bool}, m_int);
 
   // Source-location intrinsics.
   m_funcDecls.registerIntrinsic(

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -72,6 +72,8 @@ Program::Program() :
   // Register int intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqInt, "int_eq_int", sym::TypeSet{m_int, m_int}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckIntZero, "int_eq_zero", sym::TypeSet{m_int}, m_bool);
 
   // Register build-in unary long operators.
   m_funcDecls.registerFunc(
@@ -151,9 +153,6 @@ Program::Program() :
   m_funcDecls.registerIntrinsic(*this, Fk::ATanFloat, "float_atan", sym::TypeSet{m_float}, m_float);
   m_funcDecls.registerIntrinsic(
       *this, Fk::ATan2Float, "float_atan2", sym::TypeSet{m_float, m_float}, m_float);
-
-  // Register build-in unary bool operators.
-  m_funcDecls.registerFunc(*this, Fk::InvBool, getFuncName(Op::Bang), sym::TypeSet{m_bool}, m_bool);
 
   // Register build-in binary string operators.
   m_funcDecls.registerFunc(

--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -505,9 +505,6 @@ auto execute(
     case OpCode::NegFloat: {
       PUSH_FLOAT(-POP_FLOAT());
     } break;
-    case OpCode::LogicInvInt: {
-      PUSH_BOOL(POP_INT() == 0);
-    } break;
     case OpCode::ShiftLeftInt: {
       auto b = POP_UINT();
       auto a = POP_UINT();
@@ -654,6 +651,9 @@ auto execute(
     } break;
     case OpCode::CheckStructNull: {
       PUSH_BOOL(POP().isNullRef());
+    } break;
+    case OpCode::CheckIntZero: {
+      PUSH_BOOL(POP_INT() == 0);
     } break;
 
     case OpCode::ConvIntLong: {

--- a/std/core/func.ns
+++ b/std/core/func.ns
@@ -77,9 +77,6 @@ fun !{T1, T2, T3, T4}(function{T1, T2, T3, T4, bool} pred)
 
 // -- Functions
 
-fun equals{T}(T a, T b)
-  a == b
-
 fun construct{TR}()
   TR()
 
@@ -209,17 +206,6 @@ act invoke{T1, T2, T3, T4, T5, TR}(action{T1, T2, T3, T4, T5, TR} func, T1 a1, T
   func(a1, a2, a3, a4, a5)
 
 // -- Tests
-
-assert(equals(1, 1))
-assertNot(equals(1, 2))
-
-assert(
-  eq42 = equals{int}[42];
-  eq42(42))
-
-assert(
-  eq42 = equals{int}[42];
-  (!eq42)(43))
 
 assertEq(
   funcRet = (lambda (int x) x);

--- a/std/core/list.ns
+++ b/std/core/list.ns
@@ -47,6 +47,11 @@ fun []{T}(List{T} l, int idx) -> Option{T}
 fun []{T}(List{T} l, int startIdx, int endIdx) -> List{T}
   l.pop(startIdx).take(endIdx - startIdx)
 
+fun =={T}(List{T} l1, List{T} l2)
+  if l1 as LNode{T} n1 && l2 as LNode{T} n2 && n1.val == n2.val   -> self(n1.next, n2.next)
+  if l1 is LEnd && l2 is LEnd                                     -> true
+  else                                                            -> false
+
 // -- Conversions
 
 fun string{T}(List{T} l, string start = "[", string sep = ",", string end = "]")
@@ -274,14 +279,6 @@ fun splitReverse{T1, T2}(List{Either{T1, T2}} l)
         elem as T2 t2 ? (t2 :: res.second)  : res.second
       )
     , makePair(List{T1}(), List{T2}()))
-
-// The default equality uses stack size linear with the list length, so for large lists its
-// ineffiecient / impossible to use the default equality. This is an alternative that uses
-// constant stack space.
-fun listEqual{T}(List{T} l1, List{T} l2)
-  if l1 as LNode{T} n1 && l2 as LNode{T} n2 && n1.val == n2.val   -> self(n1.next, n2.next)
-  if l1 is LEnd && l2 is LEnd                                     -> true
-  else                                                            -> false
 
 // -- Impure
 
@@ -667,12 +664,12 @@ assertEq(
   splitReverse(l),
   makePair(4 :: 3 :: 2 :: 1, "world" :: "hello"))
 
-assert(listEqual(0 :: 1 :: 4 :: 9, 0 :: 1 :: 4 :: 9))
-assert(listEqual(0 :: 1 :: 4 :: 9, 0 :: 1 :: 4 :: 9))
-assertNot(listEqual(0 :: 1 :: 4 :: 9, 0 :: 1 :: 5 :: 9))
-assertNot(listEqual(0 :: 1 :: 4 :: 9, 0 :: 1))
-assertNot(listEqual(0 :: 1 :: 4 :: 9, List{int}()))
-assert(listEqual(List{int}(), List{int}()))
+assertEq(0 :: 1 :: 4 :: 9, 0 :: 1 :: 4 :: 9)
+assertEq(0 :: 1 :: 4 :: 9, 0 :: 1 :: 4 :: 9)
+assertNotEq(0 :: 1 :: 4 :: 9, 0 :: 1 :: 5 :: 9)
+assertNotEq(0 :: 1 :: 4 :: 9, 0 :: 1)
+assertNotEq(0 :: 1 :: 4 :: 9, List{int}())
+assertEq(List{int}(), List{int}())
 
 // -- Impure Tests
 

--- a/std/format/parser.ns
+++ b/std/format/parser.ns
@@ -641,11 +641,11 @@ assertEq(txtHexParser()("12345678"), 0x12345678)
 assertEq(txtHexParser()("23456789"), 0x23456789)
 assertEq(txtHexParser()("539"), 0x539)
 
-assert(
+assertEq(
   inputs  = rangeList(0, 1337);
   hexStrs = inputs.map(lambda (int i) toHexString(i));
   parser  = txtHexParser();
-  listEqual(hexStrs.map(lambda (string str) parser(str) ?? -1), inputs))
+  makePair(hexStrs.map(lambda (string str) parser(str) ?? -1), inputs))
 
 assertIs(txtHexParser()(""), Type{ParseFailure}())
 assertIs(txtHexParser()("g"), Type{ParseFailure}())

--- a/std/format/utf8.ns
+++ b/std/format/utf8.ns
@@ -129,10 +129,10 @@ assert(utf8Validate(string(char(0b1100_0000), char(0b1000_0001)), 0, true))
 assert(utf8Validate(string(char(0b1110_0000), char(0b1000_0001), char(0b1000_0001)), 0, true))
 assert(utf8Validate(string(char(0b1111_0000), char(0b1000_0001), char(0b1000_0001), char(0b1000_0001)), 0, true))
 
-assert(
+assertEq(
   allCodePoints   = rangeList(minUnicodePoint(), maxUnicodePoint());
   allUtf8Strs     = allCodePoints.mapReverse(toUtf8);
   codePointParser = utf8CodePointParser();
-  listEqual(
+  makePair(
     allUtf8Strs.mapReverse(lambda (string str) codePointParser(str) ?? errorUnicodePoint()),
     allCodePoints))

--- a/std/prim.ns
+++ b/std/prim.ns
@@ -22,6 +22,20 @@ fun highBit{T}()              lowBit{T}() << (bitSize{T}() - 1)
 fun minVal{T}()               minVal(Type{T}())
 fun maxVal{T}()               maxVal(Type{T}())
 
+// -- Equality
+
+fun =={T}(T x, T y) -> bool
+  intrinsic{usertype_eq_usertype}(x, y)
+
+fun !={T1, T2}(T1 x, T2 y) -> bool
+  !(x == y)
+
+fun equals{T1, T2}(T1 x, T2 y) -> bool
+  x == y
+
+fun equals{T}(T x, T y) -> bool
+  x == y
+
 // -- Tests
 
 assert(isIntegral{int}())
@@ -33,3 +47,14 @@ assertEq(bitSize{long}(), 64)
 
 assertEq(lowBit{int}(), 1)
 assertEq(highBit{int}(), 1 << 31)
+
+assert(equals(1, 1))
+assertNot(equals(1, 2))
+
+assert(
+  eq42 = equals{int}[42];
+  eq42(42))
+
+assert(
+  eq42 = equals{int}[42];
+  (!eq42)(43))

--- a/std/prim/bool.ns
+++ b/std/prim/bool.ns
@@ -8,5 +8,8 @@ fun bool(bool b) b
 
 // -- Operators
 
+fun !(bool b) -> bool
+  intrinsic{int_eq_zero}(intrinsic{bool_as_int}(b))
+
 fun ==(bool x, bool y) -> bool
   intrinsic{int_eq_int}(intrinsic{bool_as_int}(x), intrinsic{bool_as_int}(y))

--- a/std/prim/bool.ns
+++ b/std/prim/bool.ns
@@ -5,3 +5,8 @@ import "type.ns"
 fun bool() false
 
 fun bool(bool b) b
+
+// -- Operators
+
+fun ==(bool x, bool y) -> bool
+  intrinsic{bool_eq_bool}(x, y)

--- a/std/prim/bool.ns
+++ b/std/prim/bool.ns
@@ -9,4 +9,4 @@ fun bool(bool b) b
 // -- Operators
 
 fun ==(bool x, bool y) -> bool
-  intrinsic{bool_eq_bool}(x, y)
+  intrinsic{int_eq_int}(intrinsic{bool_as_int}(x), intrinsic{bool_as_int}(y))

--- a/std/prim/char.ns
+++ b/std/prim/char.ns
@@ -33,43 +33,40 @@ fun ++(char c) c + char(1)
 fun --(char c) c - char(1)
 
 fun <<(char x, int y)
-  char(int(x) << y)
+  char(intrinsic{char_to_int}(x) << y)
 
 fun >>(char x, int y)
-  char(int(x) >> y)
+  char(intrinsic{char_to_int}(x) >> y)
 
 fun &(char x, char y)
-  char(int(x) & int(y))
+  char(intrinsic{char_to_int}(x) & intrinsic{char_to_int}(y))
 
 fun |(char x, char y)
-  char(int(x) | int(y))
+  char(intrinsic{char_to_int}(x) | intrinsic{char_to_int}(y))
 
 fun ~(char x)
-  char(~int(x))
+  char(~intrinsic{char_to_int}(x))
 
 fun +(char x, char y)
-  char(int(x) + int(y))
+  char(intrinsic{char_to_int}(x) + intrinsic{char_to_int}(y))
 
 fun -(char x, char y)
-  char(int(x) - char(y))
+  char(intrinsic{char_to_int}(x) - char(y))
 
-fun ==(char x, char y)
-  int(x) == int(y)
+fun ==(char x, char y) -> bool
+  intrinsic{int_eq_int}(intrinsic{char_to_int}(x), intrinsic{char_to_int}(y))
 
-fun !=(char x, char y)
-  int(x) != int(y)
+fun <(char x, char y) -> bool
+  intrinsic{char_to_int}(x) < intrinsic{char_to_int}(y)
 
-fun <(char x, char y)
-  int(x) < int(y)
+fun <=(char x, char y) -> bool
+  intrinsic{char_to_int}(x) <= intrinsic{char_to_int}(y)
 
-fun <=(char x, char y)
-  int(x) <= int(y)
+fun >(char x, char y) -> bool
+  intrinsic{char_to_int}(x) > intrinsic{char_to_int}(y)
 
-fun >(char x, char y)
-  int(x) > int(y)
-
-fun >=(char x, char y)
-  int(x) >= int(y)
+fun >=(char x, char y) -> bool
+  intrinsic{char_to_int}(x) >= intrinsic{char_to_int}(y)
 
 // -- Tests
 

--- a/std/prim/char.ns
+++ b/std/prim/char.ns
@@ -33,40 +33,40 @@ fun ++(char c) c + char(1)
 fun --(char c) c - char(1)
 
 fun <<(char x, int y)
-  char(intrinsic{char_to_int}(x) << y)
+  char(intrinsic{char_as_int}(x) << y)
 
 fun >>(char x, int y)
-  char(intrinsic{char_to_int}(x) >> y)
+  char(intrinsic{char_as_int}(x) >> y)
 
 fun &(char x, char y)
-  char(intrinsic{char_to_int}(x) & intrinsic{char_to_int}(y))
+  char(intrinsic{char_as_int}(x) & intrinsic{char_as_int}(y))
 
 fun |(char x, char y)
-  char(intrinsic{char_to_int}(x) | intrinsic{char_to_int}(y))
+  char(intrinsic{char_as_int}(x) | intrinsic{char_as_int}(y))
 
 fun ~(char x)
-  char(~intrinsic{char_to_int}(x))
+  char(~intrinsic{char_as_int}(x))
 
 fun +(char x, char y)
-  char(intrinsic{char_to_int}(x) + intrinsic{char_to_int}(y))
+  char(intrinsic{char_as_int}(x) + intrinsic{char_as_int}(y))
 
 fun -(char x, char y)
-  char(intrinsic{char_to_int}(x) - char(y))
+  char(intrinsic{char_as_int}(x) - char(y))
 
 fun ==(char x, char y) -> bool
-  intrinsic{int_eq_int}(intrinsic{char_to_int}(x), intrinsic{char_to_int}(y))
+  intrinsic{int_eq_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y))
 
 fun <(char x, char y) -> bool
-  intrinsic{char_to_int}(x) < intrinsic{char_to_int}(y)
+  intrinsic{char_as_int}(x) < intrinsic{char_as_int}(y)
 
 fun <=(char x, char y) -> bool
-  intrinsic{char_to_int}(x) <= intrinsic{char_to_int}(y)
+  intrinsic{char_as_int}(x) <= intrinsic{char_as_int}(y)
 
 fun >(char x, char y) -> bool
-  intrinsic{char_to_int}(x) > intrinsic{char_to_int}(y)
+  intrinsic{char_as_int}(x) > intrinsic{char_as_int}(y)
 
 fun >=(char x, char y) -> bool
-  intrinsic{char_to_int}(x) >= intrinsic{char_to_int}(y)
+  intrinsic{char_as_int}(x) >= intrinsic{char_as_int}(y)
 
 // -- Tests
 

--- a/std/prim/float.ns
+++ b/std/prim/float.ns
@@ -31,6 +31,9 @@ fun ++(float f) f + 1.0
 
 fun --(float f) f - 1.0
 
+fun ==(float x, float y) -> bool
+  intrinsic{float_eq_float}(x, y)
+
 // -- Utilities
 
 fun nan()

--- a/std/prim/int.ns
+++ b/std/prim/int.ns
@@ -22,7 +22,7 @@ fun int(long l)
   intrinsic{long_to_int}(l)
 
 fun implicit int(char c)
-  intrinsic{char_to_int}(c)
+  intrinsic{char_as_int}(c)
 
 fun asInt(float f) -> int
   intrinsic{float_as_int}(f)

--- a/std/prim/int.ns
+++ b/std/prim/int.ns
@@ -34,3 +34,6 @@ fun +(int i) i
 fun ++(int i) i + 1
 
 fun --(int i) i - 1
+
+fun ==(int x, int y) -> bool
+  intrinsic{int_eq_int}(x, y)

--- a/std/prim/long.ns
+++ b/std/prim/long.ns
@@ -29,3 +29,6 @@ fun +(long l) l
 fun ++(long l) l + 1L
 
 fun --(long l) l - 1L
+
+fun ==(long x, long y) -> bool
+  intrinsic{long_eq_long}(x, y)

--- a/std/prim/string.ns
+++ b/std/prim/string.ns
@@ -54,6 +54,9 @@ fun string(long i, int minDigits)
 fun +{T}(string s, T v)
   s + v.string()
 
+fun ==(string x, string y) -> bool
+  intrinsic{string_eq_string}(x, y)
+
 // -- Utilities
 
 fun isEmpty(string str)

--- a/tests/backend/call_dyn_expr_test.cpp
+++ b/tests/backend/call_dyn_expr_test.cpp
@@ -8,7 +8,7 @@ TEST_CASE("[backend] Generate assembly for dynamic call expressions", "backend")
 
   SECTION("User functions") {
     CHECK_PROG(
-        "fun funcA(int a, int b) -> bool a == b "
+        "fun funcA(int a, int b) -> bool intrinsic{int_eq_int}(a, b) "
         "fun test(bool b) b "
         "test(op = funcA; op(42, 1337))",
         [](novasm::Assembler* asmb) -> void {
@@ -45,7 +45,7 @@ TEST_CASE("[backend] Generate assembly for dynamic call expressions", "backend")
   SECTION("Closure") {
     CHECK_PROG(
         "fun test(bool b) b "
-        "test(i = 1337; (lambda () i == 42)())",
+        "test(i = 1337; (lambda () -> bool intrinsic{int_eq_int}(i, 42))())",
         [](novasm::Assembler* asmb) -> void {
           // --- test function start.
           asmb->label("func-test");
@@ -80,7 +80,7 @@ TEST_CASE("[backend] Generate assembly for dynamic call expressions", "backend")
   SECTION("Closure") {
     CHECK_PROG(
         "fun test(bool b) b "
-        "test(i = 1337.0; (lambda (float f) f == i)(.1))",
+        "test(i = 1337.0; (lambda (float f) -> bool intrinsic{float_eq_float}(f, i))(.1))",
         [](novasm::Assembler* asmb) -> void {
           // --- test function start.
           asmb->label("func-test");

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -211,22 +211,16 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("Int checks") {
-    CHECK_EXPR("1 == 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{int_eq_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addCheckEqInt();
     });
-    CHECK_EXPR("1 == -3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{int_eq_int}(1, -3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addNegInt();
       asmb->addCheckEqInt();
-    });
-    CHECK_EXPR("1 != 3", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addLoadLitInt(3);
-      asmb->addCheckEqInt();
-      asmb->addLogicInvInt();
     });
     CHECK_EXPR("1 < 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
@@ -253,22 +247,16 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("Long checks") {
-    CHECK_EXPR("1L == 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{long_eq_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addCheckEqLong();
     });
-    CHECK_EXPR("1L == -3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{long_eq_long}(1L, -3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addNegLong();
       asmb->addCheckEqLong();
-    });
-    CHECK_EXPR("1L != 3L", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitLong(1);
-      asmb->addLoadLitLong(3);
-      asmb->addCheckEqLong();
-      asmb->addLogicInvInt();
     });
     CHECK_EXPR("1L < 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
@@ -295,16 +283,10 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("Float checks") {
-    CHECK_EXPR("1.42 == 3.42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{float_eq_float}(1.42, 3.42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addCheckEqFloat();
-    });
-    CHECK_EXPR("1.42 != 3.42", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitFloat(1.42F);
-      asmb->addLoadLitFloat(3.42F);
-      asmb->addCheckEqFloat();
-      asmb->addLogicInvInt();
     });
     CHECK_EXPR("1.42 < 3.42", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
@@ -342,16 +324,10 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("Bool checks") {
-    CHECK_EXPR("false == true", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{bool_eq_bool}(false, true)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(0);
       asmb->addLoadLitInt(1);
       asmb->addCheckEqInt();
-    });
-    CHECK_EXPR("false != true", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(0);
-      asmb->addLoadLitInt(1);
-      asmb->addCheckEqInt();
-      asmb->addLogicInvInt();
     });
   }
 
@@ -379,11 +355,10 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addAppendChar();
     });
 
-    CHECK_EXPR_INT(
-        "intrinsic{string_length}(\"hello world\")", [](novasm::Assembler* asmb) -> void {
-          asmb->addLoadLitString("hello world");
-          asmb->addLengthString();
-        });
+    CHECK_EXPR_INT("intrinsic{string_length}(\"hello\")", [](novasm::Assembler* asmb) -> void {
+      asmb->addLoadLitString("hello");
+      asmb->addLengthString();
+    });
 
     CHECK_EXPR("\"hello world\"[6]", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitString("hello world");
@@ -399,17 +374,12 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("String checks") {
-    CHECK_EXPR("\"hello\" == \"world\"", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitString("hello");
-      asmb->addLoadLitString("world");
-      asmb->addCheckEqString();
-    });
-    CHECK_EXPR("\"hello\" != \"world\"", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitString("hello");
-      asmb->addLoadLitString("world");
-      asmb->addCheckEqString();
-      asmb->addLogicInvInt();
-    });
+    CHECK_EXPR_BOOL(
+        "intrinsic{string_eq_string}(\"hello\", \"world\")", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("hello");
+          asmb->addLoadLitString("world");
+          asmb->addCheckEqString();
+        });
   }
 
   SECTION("Conversions") {
@@ -469,7 +439,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
 
   SECTION("User functions") {
     CHECK_PROG(
-        "fun funcA(int a, int b) -> bool a == b "
+        "fun funcA(int a, int b) -> bool intrinsic{int_eq_int}(a, b) "
         "fun test(bool b) b "
         "test(funcA(42, 1337))",
         [](novasm::Assembler* asmb) -> void {

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -323,14 +323,6 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
     });
   }
 
-  SECTION("Bool checks") {
-    CHECK_EXPR_BOOL("intrinsic{bool_eq_bool}(false, true)", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(0);
-      asmb->addLoadLitInt(1);
-      asmb->addCheckEqInt();
-    });
-  }
-
   SECTION("Bool operations") {
     CHECK_EXPR("!false", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(0);

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -231,7 +231,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addCheckGtInt();
-      asmb->addLogicInvInt();
+      asmb->addCheckIntZero(); // Invert.
     });
     CHECK_EXPR("1 > 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
@@ -242,7 +242,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addCheckLeInt();
-      asmb->addLogicInvInt();
+      asmb->addCheckIntZero(); // Invert.
     });
   }
 
@@ -267,7 +267,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addCheckGtLong();
-      asmb->addLogicInvInt();
+      asmb->addCheckIntZero(); // Invert.
     });
     CHECK_EXPR("1L > 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
@@ -278,7 +278,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addCheckLeLong();
-      asmb->addLogicInvInt();
+      asmb->addCheckIntZero(); // Invert.
     });
   }
 
@@ -297,7 +297,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addCheckGtFloat();
-      asmb->addLogicInvInt();
+      asmb->addCheckIntZero(); // Invert.
     });
     CHECK_EXPR("1.42 > 3.42", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
@@ -308,29 +308,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addCheckLeFloat();
-      asmb->addLogicInvInt();
-    });
-  }
-
-  SECTION("Bool operations") {
-    CHECK_EXPR("!false", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(0);
-      asmb->addLogicInvInt();
-    });
-    CHECK_EXPR("!true", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addLogicInvInt();
-    });
-  }
-
-  SECTION("Bool operations") {
-    CHECK_EXPR("!false", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(0);
-      asmb->addLogicInvInt();
-    });
-    CHECK_EXPR("!true", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addLogicInvInt();
+      asmb->addCheckIntZero(); // Invert.
     });
   }
 

--- a/tests/backend/call_self_expr_test.cpp
+++ b/tests/backend/call_self_expr_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("[backend] Generate assembly for self call expressions", "backend") {
 
   SECTION("Closure") {
     CHECK_PROG(
-        "fun f(int i) lambda (bool b) b ? i : self(!b) ", [](novasm::Assembler* asmb) -> void {
+        "fun f(int i) lambda (bool b) b ? i : self(b) ", [](novasm::Assembler* asmb) -> void {
           // Function.
           asmb->addStackLoad(0); // Load arg 'i'.
           asmb->addLoadLitIp("lambda");
@@ -45,9 +45,8 @@ TEST_CASE("[backend] Generate assembly for self call expressions", "backend") {
           asmb->addStackLoad(0); // Load arg 'b'.
           asmb->addJumpIf("bTrue");
 
-          asmb->addStackLoad(0);  // Load arg 'b'.
-          asmb->addLogicInvInt(); // !b
-          asmb->addStackLoad(1);  // Load closure arg 'i'.
+          asmb->addStackLoad(0); // Load arg 'b'.
+          asmb->addStackLoad(1); // Load closure arg 'i'.
           asmb->addCall("lambda", 2, novasm::CallMode::Tail);
           asmb->addJump("lambdaEnd");
 

--- a/tests/backend/enum_test.cpp
+++ b/tests/backend/enum_test.cpp
@@ -9,7 +9,7 @@ TEST_CASE("[backend] Generate assembly for enums", "backend") {
     CHECK_PROG(
         "enum E = a : 42 "
         "fun test(bool b) b "
-        "test(E.a == 1337)",
+        "test(intrinsic{int_eq_int}(E.a, 1337))",
         [](novasm::Assembler* asmb) -> void {
           // --- test function start.
           asmb->label("func-test");
@@ -35,7 +35,7 @@ TEST_CASE("[backend] Generate assembly for enums", "backend") {
     CHECK_PROG(
         "enum E = a:0b01, b:0b10, ab:0b11 "
         "fun test(bool b) b "
-        "test((E.a | E.b) == E.ab)",
+        "test(intrinsic{int_eq_int}(E.a | E.b, E.ab))",
         [](novasm::Assembler* asmb) -> void {
           // --- test function start.
           asmb->label("func-test");
@@ -64,7 +64,7 @@ TEST_CASE("[backend] Generate assembly for enums", "backend") {
     CHECK_PROG(
         "enum E = a "
         "fun test(bool b) b "
-        "test(E(0) == E.a)",
+        "test(intrinsic{int_eq_int}(E(0), E.a))",
         [](novasm::Assembler* asmb) -> void {
           // --- test function start.
           asmb->label("func-test");

--- a/tests/backend/helpers.hpp
+++ b/tests/backend/helpers.hpp
@@ -45,6 +45,9 @@ inline auto buildExecutable(const std::function<void(novasm::Assembler*)>& build
 #define CHECK_EXPR(INPUT, BUILD_EXPECTED_ASM)                                                      \
   CHECK_ASM("act test() " + std::string(INPUT), buildExecutableExpr(BUILD_EXPECTED_ASM))
 
+#define CHECK_EXPR_BOOL(INPUT, BUILD_EXPECTED_ASM)                                                 \
+  CHECK_ASM("act test() -> bool " + std::string(INPUT), buildExecutableExpr(BUILD_EXPECTED_ASM))
+
 #define CHECK_EXPR_FLOAT(INPUT, BUILD_EXPECTED_ASM)                                                \
   CHECK_ASM("act test() -> float " + std::string(INPUT), buildExecutableExpr(BUILD_EXPECTED_ASM))
 

--- a/tests/backend/struct_test.cpp
+++ b/tests/backend/struct_test.cpp
@@ -9,7 +9,7 @@ TEST_CASE("[backend] Generate assembly for structs", "backend") {
     CHECK_PROG(
         "struct User = string name, int age "
         "fun test(bool b) b "
-        "test(User(\"hello\", 42) == User(\"world\", 1337))",
+        "test(intrinsic{usertype_eq_usertype}(User(\"hello\", 42), User(\"world\", 1337)))",
         [](novasm::Assembler* asmb) -> void {
           // --- Struct equality function start.
           asmb->label("UserEq");
@@ -76,7 +76,7 @@ TEST_CASE("[backend] Generate assembly for structs", "backend") {
     CHECK_PROG(
         "struct Empty "
         "fun test(bool b) b "
-        "test(Empty() == Empty())",
+        "test(intrinsic{usertype_eq_usertype}(Empty(), Empty()))",
         [](novasm::Assembler* asmb) -> void {
           // --- Struct equality function start.
           asmb->label("UserEq");
@@ -112,8 +112,8 @@ TEST_CASE("[backend] Generate assembly for structs", "backend") {
       CHECK_PROG(
           "struct Age = int years "
           "fun test(bool b) b "
-          "test(Age(42) == Age(1337)) "
-          "test(Age(42).years == 0)",
+          "test(intrinsic{usertype_eq_usertype}(Age(42), Age(1337))) "
+          "test(intrinsic{int_eq_int}(Age(42).years, 0))",
           [](novasm::Assembler* asmb) -> void {
             // --- Struct equality function start.
             asmb->label("UserEq");

--- a/tests/backend/tail_calls_test.cpp
+++ b/tests/backend/tail_calls_test.cpp
@@ -40,7 +40,7 @@ TEST_CASE("[backend] Generate assembly for tail calls", "backend") {
         "fun f1() -> int 42 "
         "fun f2() -> int f1() "
         "fun test(bool b) b "
-        "test(f2() == 0)",
+        "test(intrinsic{int_eq_int}(f2(), 0))",
         [](novasm::Assembler* asmb) -> void {
           asmb->label("f1");
           asmb->addLoadLitInt(42);
@@ -73,7 +73,7 @@ TEST_CASE("[backend] Generate assembly for tail calls", "backend") {
         "fun f1(int i) -> int i "
         "fun f2() -> int v = 42; f1(v) "
         "fun test(bool b) b "
-        "test(f2() == 0)",
+        "test(intrinsic{int_eq_int}(f2(), 0))",
         [](novasm::Assembler* asmb) -> void {
           asmb->label("f1");
           asmb->addStackLoad(0);
@@ -112,7 +112,7 @@ TEST_CASE("[backend] Generate assembly for tail calls", "backend") {
         "fun f1() -> int 42 "
         "fun f2(function{int} func) -> int func() "
         "fun test(bool b) b "
-        "test(f2(f1) == 0)",
+        "test(intrinsic{int_eq_int}(f2(f1), 0))",
         [](novasm::Assembler* asmb) -> void {
           asmb->label("f1");
           asmb->addLoadLitInt(42);

--- a/tests/backend/union_test.cpp
+++ b/tests/backend/union_test.cpp
@@ -314,7 +314,7 @@ TEST_CASE("[backend] Generate assembly for unions", "backend") {
 
           // Check if user is not null.
           asmb->addCheckStructNull();
-          asmb->addLogicInvInt();
+          asmb->addCheckIntZero(); // Invert.
 
           asmb->addCall("func-test", 1, novasm::CallMode::Normal);
           asmb->addRet();
@@ -333,7 +333,7 @@ TEST_CASE("[backend] Generate assembly for unions", "backend") {
           asmb->addDup();
           asmb->addStackStore(0);
           asmb->addCheckStructNull();
-          asmb->addLogicInvInt();
+          asmb->addCheckIntZero(); // Invert.
           asmb->addJumpIf("user-is-not-null");
 
           // Is null.

--- a/tests/backend/union_test.cpp
+++ b/tests/backend/union_test.cpp
@@ -9,9 +9,9 @@ TEST_CASE("[backend] Generate assembly for unions", "backend") {
     CHECK_PROG(
         "union Val = int, float "
         "fun test(bool b) b "
-        "test(Val(1) == Val(1.0))"
+        "test(intrinsic{usertype_eq_usertype}(Val(1), Val(1.0)))"
         "test(Val(1) is int)"
-        "test(Val(1) as int i ? (i == 0) : false)",
+        "test(Val(1) as int i ? intrinsic{int_eq_int}(i, 0) : false)",
         [](novasm::Assembler* asmb) -> void {
           // --- Union equality function start.
           asmb->label("ValEq");
@@ -180,10 +180,12 @@ TEST_CASE("[backend] Generate assembly for unions", "backend") {
         "struct Null "
         "union NullableUser = User, Null "
         "fun test(bool b) b "
-        "test(NullableUser(User(\"John\", 42)) == Null())"
+        "test(intrinsic{usertype_eq_usertype}(NullableUser(User(\"John\", 42)), Null()))"
         "test(NullableUser(User(\"John\", 42)) is Null)"
         "test(NullableUser(User(\"John\", 42)) is User)"
-        "test(NullableUser(User(\"John\", 42)) as User u ? (u.name == \"J\") : false)",
+        "test(NullableUser(User(\"John\", 42)) as User u "
+        "  ? intrinsic{string_eq_string}(u.name, \"J\") "
+        "  : false)",
         [](novasm::Assembler* asmb) -> void {
           // -- struct 'User' equality function start.
           asmb->label("user-eq");

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
     }
 
     SECTION("Overload operator") {
-      const auto& output = ANALYZE("fun -(bool b) !b "
+      const auto& output = ANALYZE("fun -(bool b) b "
                                    "fun f() -false");
       REQUIRE(output.isSuccess());
 

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -145,7 +145,8 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
   SECTION("Implicit conversions") {
 
     SECTION("Declare implicit conversion") {
-      const auto& output = ANALYZE("fun implicit bool(int i) i == 0");
+      const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                   "fun implicit bool(int i) i == 0");
       REQUIRE(output.isSuccess());
       const auto& funcDecl = GET_FUNC_DECL(output, "bool", GET_TYPE_ID(output, "int"));
       CHECK(funcDecl.getOutput() == GET_TYPE_ID(output, "bool"));

--- a/tests/frontend/define_exec_stmts_test.cpp
+++ b/tests/frontend/define_exec_stmts_test.cpp
@@ -53,7 +53,8 @@ TEST_CASE("[frontend] Analyzing execute statements", "frontend") {
   }
 
   SECTION("Define exec statement with const") {
-    const auto& output = ANALYZE("fun fa(bool b, string s) b "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun fa(bool b, string s) b "
                                  "fa(x = 5; x == 1, \"msg\")");
     REQUIRE(output.isSuccess());
     auto execsBegin        = output.getProg().beginExecStmts();

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -111,6 +111,7 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
           " a2 = 42; b2 = 1337; f(a + a2, b + b2)",
           errPureFuncInfRecursion(NO_SRC));
       CHECK_DIAG(
+          "fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
           "fun f(int a, int b) -> int "
           " if f(a, b) == a -> a "
           " else            -> b",

--- a/tests/frontend/get_index_expr_test.cpp
+++ b/tests/frontend/get_index_expr_test.cpp
@@ -10,7 +10,8 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
 
   SECTION("Get single argument index operator") {
-    const auto& output = ANALYZE("struct Pair = int a, int b "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "struct Pair = int a, int b "
                                  "fun [](Pair p, int i) "
                                  "  if i == 0 -> p.a "
                                  "  else      -> p.b "
@@ -30,7 +31,8 @@ TEST_CASE("[frontend] Analyzing index expressions", "frontend") {
   }
 
   SECTION("Get multi argument index operator") {
-    const auto& output = ANALYZE("struct Pair = string a, string b "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "struct Pair = string a, string b "
                                  "fun [](Pair p, int i, string b) "
                                  "  if i == 0 -> Pair(p.a, b) "
                                  "  else      -> Pair(p.b, b) "

--- a/tests/frontend/opt_args_test.cpp
+++ b/tests/frontend/opt_args_test.cpp
@@ -176,7 +176,7 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Type parameter can be inferred from an initializer") {
-      const auto& output = ANALYZE("fun implicit int(char c) intrinsic{char_to_int}(c) "
+      const auto& output = ANALYZE("fun implicit int(char c) intrinsic{char_as_int}(c) "
                                    "fun string(int i) intrinsic{int_to_string}(i) "
                                    "fun ft{TX, TY}(TX a = \"World\", TY b = 'W') a + string(b) "
                                    "fun f1() ft() "

--- a/tests/frontend/overload_test.cpp
+++ b/tests/frontend/overload_test.cpp
@@ -32,7 +32,8 @@ TEST_CASE("[frontend] Analyzing overloads", "frontend") {
   }
 
   SECTION("Allow conversion in binary operator") {
-    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
+    const auto& output = ANALYZE("fun ==(float x, float y) -> bool intrinsic{float_eq_float}(x, y) "
+                                 "fun implicit float(int i) intrinsic{int_to_float}(i) "
                                  "fun a(bool b) b "
                                  "a(1.0 / 2 == .5)");
     REQUIRE(output.isSuccess());

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -179,7 +179,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Templated call") {
-    const auto& output = ANALYZE("fun ft{T}(T a) a == a "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun ft{T}(T a) a == a "
                                  "fun f(int i) ft{int}(i)");
     REQUIRE(output.isSuccess());
     CHECK(
@@ -212,7 +213,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Forked templated call") {
-    const auto& output = ANALYZE("fun ft{T}(T a) a == a "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun ft{T}(T a) a == a "
                                  "fun f(int i) fork ft{int}(i)");
     REQUIRE(output.isSuccess());
     CHECK(
@@ -229,21 +231,24 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Lazy call") {
-    const auto& output = ANALYZE("fun f1(int i) i * i "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun f1(int i) i == i "
                                  "fun f2() lazy f1(42)");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DECL(output, "f2").getOutput() == GET_TYPE_ID(output, "__lazy_int"));
+    CHECK(GET_FUNC_DECL(output, "f2").getOutput() == GET_TYPE_ID(output, "__lazy_bool"));
   }
 
   SECTION("Lazy action call") {
-    const auto& output = ANALYZE("act a1(int i) i * i "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "act a1(int i) i == i "
                                  "act a2() lazy a1(42)");
     REQUIRE(output.isSuccess());
-    CHECK(GET_FUNC_DECL(output, "a2").getOutput() == GET_TYPE_ID(output, "__lazy_action_int"));
+    CHECK(GET_FUNC_DECL(output, "a2").getOutput() == GET_TYPE_ID(output, "__lazy_action_bool"));
   }
 
   SECTION("Lazy templated call") {
-    const auto& output = ANALYZE("fun ft{T}(T a) a == a "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun ft{T}(T a) a == a "
                                  "fun f(int i) lazy ft{int}(i)");
     REQUIRE(output.isSuccess());
     CHECK(
@@ -252,7 +257,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Lazy templated action call") {
-    const auto& output = ANALYZE("act at{T}(T a) a == a "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "act at{T}(T a) a == a "
                                  "act a(int i) lazy at{int}(i)");
     REQUIRE(output.isSuccess());
     CHECK(
@@ -288,14 +294,16 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Call operator") {
-    const auto& output = ANALYZE("fun ()(int i) i != 0 "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun ()(int i) i == 0 "
                                  "fun f() 42()");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "bool"));
   }
 
   SECTION("Forked call operator") {
-    const auto& output = ANALYZE("fun ()(int i) i != 0 "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun ()(int i) i == 0 "
                                  "fun f() fork 42()");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__future_bool"));
@@ -365,7 +373,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Anonymous function") {
-    const auto& output = ANALYZE("fun f() lambda (int i) i == i");
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun f() lambda (int i) i == i");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__function_int_bool"));
   }
@@ -378,7 +387,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Anonymous function call") {
-    const auto& output = ANALYZE("fun f() (lambda (int i) i == i)(42)");
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun f() (lambda (int i) i == i)(42)");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "bool"));
   }
@@ -416,13 +426,15 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Anonymous action") {
-    const auto& output = ANALYZE("act a() impure lambda (int i) i == i");
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "act a() impure lambda (int i) i == i");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "a").getOutput() == GET_TYPE_ID(output, "__action_int_bool"));
   }
 
   SECTION("Anonymous action call") {
-    const auto& output = ANALYZE("act a() (lambda (int i) i == i)(42)");
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "act a() (lambda (int i) i == i)(42)");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "a").getOutput() == GET_TYPE_ID(output, "bool"));
   }

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -12,7 +12,8 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
 
   SECTION("Recursive templated call") {
-    const auto& output = ANALYZE("fun ft{T}(T a) -> T a != 0 ? ft{T}(a) : a "
+    const auto& output = ANALYZE("fun ==(int x, int y) -> bool intrinsic{int_eq_int}(x, y) "
+                                 "fun ft{T}(T a) -> T a == 0 ? ft{T}(a) : a "
                                  "fun f() -> int ft{int}(1)");
     REQUIRE(output.isSuccess());
 

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -78,8 +78,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_INT(precomputeLiterals, "2 | 1", litIntNode(prog, 3));
     ASSERT_EXPR_INT(precomputeLiterals, "3 ^ 1", litIntNode(prog, 2));
     ASSERT_EXPR_INT(precomputeLiterals, "~1", litIntNode(prog, -2));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1 == 2", litBoolNode(prog, false));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1 != 2", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "intrinsic{int_eq_int}(1, 2)", litBoolNode(prog, false));
     ASSERT_EXPR_BOOL(precomputeLiterals, "1 < 2", litBoolNode(prog, true));
     ASSERT_EXPR_BOOL(precomputeLiterals, "1 <= 2", litBoolNode(prog, true));
     ASSERT_EXPR_BOOL(precomputeLiterals, "1 > 2", litBoolNode(prog, false));
@@ -110,8 +109,8 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_FLOAT(
         precomputeLiterals, "intrinsic{float_atan2}(0.0, 0.0)", litFloatNode(prog, 0.0));
     ASSERT_EXPR_FLOAT(precomputeLiterals, "-1.1", litFloatNode(prog, -1.1));
-    ASSERT_EXPR(precomputeLiterals, "1.1 == 1.2", litBoolNode(prog, false));
-    ASSERT_EXPR(precomputeLiterals, "1.1 != 1.2", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "intrinsic{float_eq_float}(1.1, 1.2)", litBoolNode(prog, false));
     ASSERT_EXPR(precomputeLiterals, "1.1 < 1.2", litBoolNode(prog, true));
     ASSERT_EXPR(precomputeLiterals, "1.1 <= 1.2", litBoolNode(prog, true));
     ASSERT_EXPR(precomputeLiterals, "1.1 > 1.2", litBoolNode(prog, false));
@@ -152,12 +151,12 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR(precomputeLiterals, "2L | 1L", litLongNode(prog, 3));
     ASSERT_EXPR(precomputeLiterals, "3L ^ 1L", litLongNode(prog, 2));
     ASSERT_EXPR(precomputeLiterals, "~1L", litLongNode(prog, -2));
-    ASSERT_EXPR(precomputeLiterals, "1L == 2L", litBoolNode(prog, false));
-    ASSERT_EXPR(precomputeLiterals, "1L != 2L", litBoolNode(prog, true));
-    ASSERT_EXPR(precomputeLiterals, "1L < 2L", litBoolNode(prog, true));
-    ASSERT_EXPR(precomputeLiterals, "1L <= 2L", litBoolNode(prog, true));
-    ASSERT_EXPR(precomputeLiterals, "1L > 2L", litBoolNode(prog, false));
-    ASSERT_EXPR(precomputeLiterals, "1L >= 2L", litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "intrinsic{long_eq_long}(1L, 2L)", litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "1L < 2L", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "1L <= 2L", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "1L > 2L", litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "1L >= 2L", litBoolNode(prog, false));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{long_to_int}(137L)", litIntNode(prog, 137));
     ASSERT_EXPR_STRING(
         precomputeLiterals, "intrinsic{long_to_string}(1337L)", litStringNode(prog, "1337"));
@@ -165,9 +164,11 @@ TEST_CASE("[opt] Precompute literals", "opt") {
   }
 
   SECTION("bool intrinsics") {
-    ASSERT_EXPR(precomputeLiterals, "!false", litBoolNode(prog, true));
-    ASSERT_EXPR(precomputeLiterals, "false == true", litBoolNode(prog, false));
-    ASSERT_EXPR(precomputeLiterals, "false != true", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "!false", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "intrinsic{bool_eq_bool}(false, true)", litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "!intrinsic{bool_eq_bool}(false, true)", litBoolNode(prog, true));
   }
 
   SECTION("char intrinsics") {
@@ -196,9 +197,18 @@ TEST_CASE("[opt] Precompute literals", "opt") {
         precomputeLiterals, "\"hello world\"[0, 11]", litStringNode(prog, "hello world"));
     ASSERT_EXPR_STRING(
         precomputeLiterals, "\"hello\" + ' ' + \"world\"", litStringNode(prog, "hello world"));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "\"hello\" == \"world\"", litBoolNode(prog, false));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "\"hello\" == \"hello\"", litBoolNode(prog, true));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "\"hello\" != \"world\"", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals,
+        "intrinsic{string_eq_string}(\"hello\", \"world\")",
+        litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals,
+        "intrinsic{string_eq_string}(\"hello\", \"hello\")",
+        litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals,
+        "!intrinsic{string_eq_string}(\"hello\", \"world\")",
+        litBoolNode(prog, true));
   }
 
   SECTION("reinterpret conversions") {

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -165,10 +165,6 @@ TEST_CASE("[opt] Precompute literals", "opt") {
 
   SECTION("bool intrinsics") {
     ASSERT_EXPR_BOOL(precomputeLiterals, "!false", litBoolNode(prog, true));
-    ASSERT_EXPR_BOOL(
-        precomputeLiterals, "intrinsic{bool_eq_bool}(false, true)", litBoolNode(prog, false));
-    ASSERT_EXPR_BOOL(
-        precomputeLiterals, "!intrinsic{bool_eq_bool}(false, true)", litBoolNode(prog, true));
   }
 
   SECTION("char intrinsics") {

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -163,10 +163,6 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_CHAR(precomputeLiterals, "intrinsic{long_to_char}(137L)", litCharNode(prog, 137));
   }
 
-  SECTION("bool intrinsics") {
-    ASSERT_EXPR_BOOL(precomputeLiterals, "!false", litBoolNode(prog, true));
-  }
-
   SECTION("char intrinsics") {
     ASSERT_EXPR_STRING(
         precomputeLiterals, "intrinsic{char_to_string}('h')", litStringNode(prog, "h"));
@@ -200,10 +196,6 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_BOOL(
         precomputeLiterals,
         "intrinsic{string_eq_string}(\"hello\", \"hello\")",
-        litBoolNode(prog, true));
-    ASSERT_EXPR_BOOL(
-        precomputeLiterals,
-        "!intrinsic{string_eq_string}(\"hello\", \"world\")",
         litBoolNode(prog, true));
   }
 

--- a/tests/vm/int_op_test.cpp
+++ b/tests/vm/int_op_test.cpp
@@ -156,7 +156,7 @@ TEST_CASE("[vm] Execute integer operations", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitInt(0);
-          asmb->addLogicInvInt();
+          asmb->addCheckIntZero(); // Invert.
           asmb->addConvIntString();
           ADD_PRINT(asmb);
         },
@@ -165,7 +165,7 @@ TEST_CASE("[vm] Execute integer operations", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitInt(1);
-          asmb->addLogicInvInt();
+          asmb->addCheckIntZero(); // Invert.
           asmb->addConvIntString();
           ADD_PRINT(asmb);
         },
@@ -174,7 +174,7 @@ TEST_CASE("[vm] Execute integer operations", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitInt(2);
-          asmb->addLogicInvInt();
+          asmb->addCheckIntZero(); // Invert.
           asmb->addConvIntString();
           ADD_PRINT(asmb);
         },

--- a/tests/vm/io_test.cpp
+++ b/tests/vm/io_test.cpp
@@ -134,7 +134,7 @@ TEST_CASE("[vm] Execute input and output", "vm") {
 
           // Assert that file-stream is not valid.
           asmb->addPCall(novasm::PCallCode::StreamCheckValid);
-          asmb->addLogicInvInt(); // Invert to check if stream is not valid.
+          asmb->addCheckIntZero(); // Invert. // Invert to check if stream is not valid.
           ADD_ASSERT(asmb);
           asmb->addRet();
         },
@@ -183,7 +183,7 @@ TEST_CASE("[vm] Execute input and output", "vm") {
           asmb->addPCall(novasm::PCallCode::StreamWriteString);
 
           // Assert that writing failed.
-          asmb->addLogicInvInt(); // Invert to check if writing failed.
+          asmb->addCheckIntZero(); // Invert. // Invert to check if writing failed.
           ADD_ASSERT(asmb);
           asmb->addRet();
         },

--- a/tests/vm/struct_op_test.cpp
+++ b/tests/vm/struct_op_test.cpp
@@ -15,7 +15,7 @@ TEST_CASE("[vm] Execute struct operations", "vm") {
 
           // Assert its not null.
           asmb->addCheckStructNull();
-          asmb->addLogicInvInt();
+          asmb->addCheckIntZero(); // Invert.
           ADD_ASSERT(asmb);
         },
         "input",


### PR DESCRIPTION
Equality operators are now implemented in the std lib instead of being build-in to compiler. This allows more flexibility, like overriding the equals operator (`==`) for your own type with a custom implementation.