### PR TITLE
Optimizer: Various new simpliciations

### DIFF
--- a/include/novasm/assembler.hpp
+++ b/include/novasm/assembler.hpp
@@ -99,6 +99,7 @@ public:
   auto addCheckLeFloat() -> void;
   auto addCheckStructNull() -> void;
   auto addCheckIntZero() -> void;
+  auto addCheckStringEmtpy() -> void;
 
   auto addConvIntLong() -> void;
   auto addConvIntFloat() -> void;

--- a/include/novasm/op_code.hpp
+++ b/include/novasm/op_code.hpp
@@ -87,6 +87,7 @@ enum class OpCode : uint8_t {
   CheckLeFloat      = 101, // [] (float, float)           -> (int) Check float is less.
   CheckStructNull   = 102, // [] (struct)                 -> (int) Check if struct is null.
   CheckIntZero      = 103, // [] (int)                    -> (int) Check if integer is zero.
+  CheckStringEmpty  = 104, // [] (string)                 -> (int) Check if string is empty.
 
   ConvIntLong     = 111, // [] (int)   -> (long)     Convert int to long.
   ConvIntFloat    = 112, // [] (int)   -> (float)    Convert int to float.

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -7,7 +7,7 @@ namespace novasm {
 // Version number for the binary representation of the novus assembly format.
 // Increase this when performing breaking changes to the format.
 // TODO(bastian): Add system for defining migrations.
-const uint16_t executableFormatVersion = 10U;
+const uint16_t executableFormatVersion = 11U;
 
 // Write a binary representation of the executable file to the output iterator.
 template <typename OutputItr>

--- a/include/prog/program.hpp
+++ b/include/prog/program.hpp
@@ -102,11 +102,12 @@ public:
   [[nodiscard]] auto lookupFunc(const std::string& name, OvOptions options) const
       -> std::vector<sym::FuncId>;
 
-  [[nodiscard]] auto
-  lookupIntrinsic(const std::string& name, const sym::TypeSet& input, OvOptions options) const
+  [[nodiscard]] auto lookupIntrinsic(
+      const std::string& name, const sym::TypeSet& input, OvOptions options = OvOptions{0}) const
       -> std::optional<sym::FuncId>;
 
-  [[nodiscard]] auto lookupIntrinsic(const std::string& name, OvOptions options) const
+  [[nodiscard]] auto
+  lookupIntrinsic(const std::string& name, OvOptions options = OvOptions{0}) const
       -> std::vector<sym::FuncId>;
 
   [[nodiscard]] auto lookupImplicitConv(sym::TypeId from, sym::TypeId to) const

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -9,24 +9,25 @@ enum class FuncKind {
   NoOp, // Backend will generate no assembly, usefull for aliasing conversions.
   User, // User-defined function, contains a definition in the 'FuncDefTable'.
 
-  AddInt,        // Add two integers.
-  SubInt,        // Substact two integers.
-  MulInt,        // Multiply two integers.
-  DivInt,        // Divide two integers.
-  RemInt,        // Return division remainder of two integers.
-  NegateInt,     // Negate an integer.
-  ShiftLeftInt,  // Shift bits of an integer to the left.
-  ShiftRightInt, // Shift bits of an integer to the right.
-  AndInt,        // Bitwise and two integers.
-  OrInt,         // Bitwise or two integers.
-  XorInt,        // Bitwise xor two integers.
-  InvInt,        // Bitwise invert an integer.
-  CheckEqInt,    // Check if two integers are equal.
-  CheckLeInt,    // Check if an integer is less then another integer.
-  CheckLeEqInt,  // Check if an integer is less then or equal to another integer.
-  CheckGtInt,    // Check if an integer is greater then another integer.
-  CheckGtEqInt,  // Check if an integer is greater then or equal to another integer.
-  CheckIntZero,  // Check if an integer is zero.
+  AddInt,           // Add two integers.
+  SubInt,           // Substact two integers.
+  MulInt,           // Multiply two integers.
+  DivInt,           // Divide two integers.
+  RemInt,           // Return division remainder of two integers.
+  NegateInt,        // Negate an integer.
+  ShiftLeftInt,     // Shift bits of an integer to the left.
+  ShiftRightInt,    // Shift bits of an integer to the right.
+  AndInt,           // Bitwise and two integers.
+  OrInt,            // Bitwise or two integers.
+  XorInt,           // Bitwise xor two integers.
+  InvInt,           // Bitwise invert an integer.
+  CheckEqInt,       // Check if two integers are equal.
+  CheckLeInt,       // Check if an integer is less then another integer.
+  CheckLeEqInt,     // Check if an integer is less then or equal to another integer.
+  CheckGtInt,       // Check if an integer is greater then another integer.
+  CheckGtEqInt,     // Check if an integer is greater then or equal to another integer.
+  CheckIntZero,     // Check if an integer is zero.
+  CheckStringEmpty, // Check if a string is empty.
 
   AddLong,        // Add two longs.
   SubLong,        // Substract two longs.

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -183,6 +183,9 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::CheckIntZero:
     m_asmb->addCheckIntZero();
     break;
+  case prog::sym::FuncKind::CheckStringEmpty:
+    m_asmb->addCheckStringEmtpy();
+    break;
 
   case prog::sym::FuncKind::AddLong:
     m_asmb->addAddLong();

--- a/src/novasm/assembler.cpp
+++ b/src/novasm/assembler.cpp
@@ -202,6 +202,8 @@ auto Assembler::addCheckStructNull() -> void { writeOpCode(OpCode::CheckStructNu
 
 auto Assembler::addCheckIntZero() -> void { writeOpCode(OpCode::CheckIntZero); }
 
+auto Assembler::addCheckStringEmtpy() -> void { writeOpCode(OpCode::CheckStringEmpty); }
+
 auto Assembler::addConvIntLong() -> void { writeOpCode(OpCode::ConvIntLong); }
 
 auto Assembler::addConvIntFloat() -> void { writeOpCode(OpCode::ConvIntFloat); }

--- a/src/novasm/disassembler.cpp
+++ b/src/novasm/disassembler.cpp
@@ -191,6 +191,7 @@ auto disassembleInstructions(
     case OpCode::CheckLeFloat:
     case OpCode::CheckStructNull:
     case OpCode::CheckIntZero:
+    case OpCode::CheckStringEmpty:
     case OpCode::ConvIntLong:
     case OpCode::ConvIntFloat:
     case OpCode::ConvLongInt:

--- a/src/novasm/op_code.cpp
+++ b/src/novasm/op_code.cpp
@@ -223,6 +223,9 @@ auto operator<<(std::ostream& out, const OpCode& rhs) noexcept -> std::ostream& 
   case OpCode::CheckIntZero:
     out << "check-int-zero";
     break;
+  case OpCode::CheckStringEmpty:
+    out << "check-string-empty";
+    break;
 
   case OpCode::ConvIntLong:
     out << "conv-int-long";

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -508,8 +508,13 @@ auto maybeSimplifyIntrinsic(
     assert(args.size() == 2);
     if (isLiteral(*args[1]) && getInt(*args[1]) == 0) {
       return prog::expr::callExprNode(
-          prog, *prog.lookupIntrinsic("int_eq_zero", {prog.getInt()}), cloneAll(args, 1));
+          prog, *prog.lookupIntrinsic("int_eq_zero", {prog.getInt()}), cloneToVec(args[0]));
     }
+    if (isLiteral(*args[0]) && getInt(*args[0]) == 0) {
+      return prog::expr::callExprNode(
+          prog, *prog.lookupIntrinsic("int_eq_zero", {prog.getInt()}), cloneToVec(args[1]));
+    }
+    return nullptr;
   case prog::sym::FuncKind::AddString:
     assert(args.size() == 2);
     if (isLiteral(*args[1]) && getString(*args[1]) == "") {

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -510,6 +510,14 @@ auto maybeSimplifyIntrinsic(
       return prog::expr::callExprNode(
           prog, *prog.lookupIntrinsic("int_eq_zero", {prog.getInt()}), cloneAll(args, 1));
     }
+  case prog::sym::FuncKind::AddString:
+    assert(args.size() == 2);
+    if (isLiteral(*args[1]) && getString(*args[1]) == "") {
+      return args[0]->clone(nullptr);
+    }
+    if (isLiteral(*args[0]) && getString(*args[0]) == "") {
+      return args[1]->clone(nullptr);
+    }
     return nullptr;
   default:
     return nullptr;

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -515,6 +515,17 @@ auto maybeSimplifyIntrinsic(
           prog, *prog.lookupIntrinsic("int_eq_zero", {prog.getInt()}), cloneToVec(args[1]));
     }
     return nullptr;
+  case prog::sym::FuncKind::CheckEqString:
+    assert(args.size() == 2);
+    if (isLiteral(*args[1]) && getString(*args[1]) == "") {
+      return prog::expr::callExprNode(
+          prog, *prog.lookupIntrinsic("string_eq_empty", {prog.getString()}), cloneToVec(args[0]));
+    }
+    if (isLiteral(*args[0]) && getString(*args[0]) == "") {
+      return prog::expr::callExprNode(
+          prog, *prog.lookupIntrinsic("string_eq_empty", {prog.getString()}), cloneToVec(args[1]));
+    }
+    return nullptr;
   case prog::sym::FuncKind::AddString:
     assert(args.size() == 2);
     if (isLiteral(*args[1]) && getString(*args[1]) == "") {

--- a/src/opt/internal/intrinsics.hpp
+++ b/src/opt/internal/intrinsics.hpp
@@ -11,6 +11,11 @@ namespace opt::internal {
     prog::sym::FuncKind funcKind,
     const std::vector<prog::expr::NodePtr>& args) -> prog::expr::NodePtr;
 
+[[nodiscard]] auto maybeSimplifyIntrinsic(
+    const prog::Program& prog,
+    prog::sym::FuncKind funcKind,
+    const std::vector<prog::expr::NodePtr>& args) -> prog::expr::NodePtr;
+
 // NOTE: Returns nullptr if it was not possible to precompute the reinterpret conversion.
 [[nodiscard]] auto maybePrecomputeReinterpretConv(
     const prog::Program& prog, const prog::expr::Node& arg, prog::sym::TypeId dstType)

--- a/src/opt/internal/utilities.cpp
+++ b/src/opt/internal/utilities.cpp
@@ -52,16 +52,10 @@ auto rewriteAll(const std::vector<prog::expr::NodePtr>& nodes, prog::expr::Rewri
   return newNodes;
 }
 
-auto cloneAll(const std::vector<prog::expr::NodePtr>& nodes, size_t count)
-    -> std::vector<prog::expr::NodePtr> {
-
-  assert(nodes.size() >= count);
-
+auto cloneToVec(const prog::expr::NodePtr& node) -> std::vector<prog::expr::NodePtr> {
   auto newNodes = std::vector<prog::expr::NodePtr>{};
-  newNodes.reserve(count);
-  for (auto i = 0u; i != count; ++i) {
-    newNodes.push_back(nodes[i]->clone(nullptr));
-  }
+  newNodes.reserve(1);
+  newNodes.push_back(node->clone(nullptr));
   return newNodes;
 }
 

--- a/src/opt/internal/utilities.cpp
+++ b/src/opt/internal/utilities.cpp
@@ -6,6 +6,7 @@
 #include "prog/expr/node_lit_long.hpp"
 #include "prog/expr/node_lit_string.hpp"
 #include "prog/expr/rewriter.hpp"
+#include <cassert>
 
 namespace opt::internal {
 
@@ -45,11 +46,22 @@ auto rewriteAll(const std::vector<prog::expr::NodePtr>& nodes, prog::expr::Rewri
 
   auto newNodes = std::vector<prog::expr::NodePtr>{};
   newNodes.reserve(nodes.size());
-
   for (const auto& node : nodes) {
     newNodes.push_back(rewriter->rewrite(*node));
   }
+  return newNodes;
+}
 
+auto cloneAll(const std::vector<prog::expr::NodePtr>& nodes, size_t count)
+    -> std::vector<prog::expr::NodePtr> {
+
+  assert(nodes.size() >= count);
+
+  auto newNodes = std::vector<prog::expr::NodePtr>{};
+  newNodes.reserve(count);
+  for (auto i = 0u; i != count; ++i) {
+    newNodes.push_back(nodes[i]->clone(nullptr));
+  }
   return newNodes;
 }
 

--- a/src/opt/internal/utilities.hpp
+++ b/src/opt/internal/utilities.hpp
@@ -25,6 +25,9 @@ namespace opt::internal {
 rewriteAll(const std::vector<prog::expr::NodePtr>& nodes, prog::expr::Rewriter* rewriter)
     -> std::vector<prog::expr::NodePtr>;
 
+[[nodiscard]] auto cloneAll(const std::vector<prog::expr::NodePtr>& nodes, size_t count)
+    -> std::vector<prog::expr::NodePtr>;
+
 inline auto copySourceAttr(prog::expr::Node& to, const prog::expr::Node& from) -> void {
   to.setSourceId(from.getSourceId());
 }

--- a/src/opt/internal/utilities.hpp
+++ b/src/opt/internal/utilities.hpp
@@ -25,8 +25,7 @@ namespace opt::internal {
 rewriteAll(const std::vector<prog::expr::NodePtr>& nodes, prog::expr::Rewriter* rewriter)
     -> std::vector<prog::expr::NodePtr>;
 
-[[nodiscard]] auto cloneAll(const std::vector<prog::expr::NodePtr>& nodes, size_t count)
-    -> std::vector<prog::expr::NodePtr>;
+[[nodiscard]] auto cloneToVec(const prog::expr::NodePtr& node) -> std::vector<prog::expr::NodePtr>;
 
 inline auto copySourceAttr(prog::expr::Node& to, const prog::expr::Node& from) -> void {
   to.setSourceId(from.getSourceId());

--- a/src/opt/precompute_literals.cpp
+++ b/src/opt/precompute_literals.cpp
@@ -186,6 +186,12 @@ auto PrecomputeRewriter::precomputeIntrinsicCall(
       }
     }
   }
+
+  // Attempt to simplify the intrinsic.
+  if (auto simplified = internal::maybeSimplifyIntrinsic(m_prog, funcKind, newArgs)) {
+    return simplified;
+  }
+
   // if we cannot precompute then construct a copy of the call.
   return prog::expr::callExprNode(m_prog, callExpr.getFunc(), std::move(newArgs));
 }

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -163,6 +163,8 @@ Program::Program() :
   // Register string intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqString, "string_eq_string", sym::TypeSet{m_string, m_string}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckStringEmpty, "string_eq_empty", sym::TypeSet{m_string}, m_bool);
 
   // Register build-in string functions.
   m_funcDecls.registerIntrinsic(

--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -382,7 +382,13 @@ auto execute(
       // to the end). Support for building up strings backwards is possible but not implemented atm.
 
       auto* a = getStringOrLinkRef(POP());
-      PUSH_REF(refAlloc->allocStrLink(a, refValue(b)));
+      if (b->getSize() == 0) {
+        // When adding an empty string, its just a no-op.
+        // This way we also maintain our invariant that a StringLink is never empty.
+        PUSH_REF(a);
+      } else {
+        PUSH_REF(refAlloc->allocStrLink(a, refValue(b)));
+      }
     } break;
     case OpCode::AppendChar: {
       auto b  = POP_INT();
@@ -654,6 +660,9 @@ auto execute(
     } break;
     case OpCode::CheckIntZero: {
       PUSH_BOOL(POP_INT() == 0);
+    } break;
+    case OpCode::CheckStringEmpty: {
+      PUSH_BOOL(isStringEmpty(POP()));
     } break;
 
     case OpCode::ConvIntLong: {

--- a/src/vm/internal/ref_string_link.hpp
+++ b/src/vm/internal/ref_string_link.hpp
@@ -68,6 +68,9 @@ private:
   inline explicit StringLinkRef(Ref* prev, Value val) noexcept :
       Ref(getKind()), m_prev{prev}, m_val{val}, m_collapsed{nullptr} {
 
+    // Check the invariant that StringLink's are never empty.
+    assert(!val.isRef() || downcastRef<StringRef>(val.getRef())->getSize() != 0);
+
     assert(m_prev != nullptr);
     assert(m_prev->getKind() == RefKind::String || m_prev->getKind() == RefKind::StringLink);
   }

--- a/src/vm/internal/string_utilities.hpp
+++ b/src/vm/internal/string_utilities.hpp
@@ -10,6 +10,16 @@
 
 namespace vm::internal {
 
+inline auto isStringEmpty(const Value& val) noexcept {
+  auto* ref = getStringOrLinkRef(val);
+  if (ref->getKind() == RefKind::String) {
+    return downcastRef<StringRef>(ref)->getSize() == 0;
+  }
+
+  // String-links are never empty.
+  return false;
+}
+
 // Get a StringRef* from a value. Supports direct StringRef's or StringLinkRefs.
 // Requires a allocator as in-case of a StringLinkRef we might need to allocate a new string.
 inline auto getStringRef(RefAllocator* refAlloc, const Value& val) noexcept {

--- a/std/prim/bool.ns
+++ b/std/prim/bool.ns
@@ -9,7 +9,7 @@ fun bool(bool b) b
 // -- Operators
 
 fun !(bool b) -> bool
-  intrinsic{int_eq_zero}(intrinsic{bool_as_int}(b))
+  intrinsic{bool_as_int}(b) == 0
 
 fun ==(bool x, bool y) -> bool
   intrinsic{int_eq_int}(intrinsic{bool_as_int}(x), intrinsic{bool_as_int}(y))

--- a/std/prim/string.ns
+++ b/std/prim/string.ns
@@ -60,7 +60,7 @@ fun ==(string x, string y) -> bool
 // -- Utilities
 
 fun isEmpty(string str)
-  str.length() == 0
+  str == ""
 
 fun last(string str)
   str[str.length() - 1]

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -10,6 +10,8 @@
 
 namespace opt {
 
+#define NUM_ARGS(...) std::tuple_size<decltype(std::make_tuple(__VA_ARGS__))>::value
+
 inline auto buildSource(std::string input) {
   return frontend::buildSource("test", std::nullopt, input.begin(), input.end());
 }
@@ -74,6 +76,18 @@ inline auto buildSource(std::string input) {
 
 #define ASSERT_EXPR_STRING(OPT, INPUT, EXPECTED_EXPR)                                              \
   ASSERT_EXPR_TYPED(OPT, "string", INPUT, EXPECTED_EXPR)
+
+template <typename Array>
+inline auto arrayMoveToVec(Array c) {
+  auto result = std::vector<typename Array::value_type>{};
+  for (auto& elem : c) {
+    result.push_back(std::move(elem));
+  }
+  return result;
+}
+
+#define EXPRS(...)                                                                                 \
+  arrayMoveToVec<std::array<prog::expr::NodePtr, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
 
 inline auto
 getIntBinaryOpExpr(const prog::Program& prog, prog::Operator op, int32_t lhs, int32_t rhs)

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -7,6 +7,8 @@
 #include "prog/expr/node_lit_long.hpp"
 #include "prog/operator.hpp"
 #include "prog/program.hpp"
+#include <array>
+#include <vector>
 
 namespace opt {
 

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -214,17 +214,17 @@ TEST_CASE("[opt] Precompute literals", "opt") {
                   funcDef.getConsts(), *funcDef.getConsts().lookup("i")))));
     }
     {
-      const auto& output = ANALYZE("fun f(int i) -> bool intrinsic{int_eq_int}(0, i)");
+      const auto& output = ANALYZE("fun f(string s) -> bool intrinsic{string_eq_string}(s, \"\")");
       REQUIRE(output.isSuccess());
       const auto prog     = precomputeLiterals(output.getProg());
-      const auto& funcDef = GET_FUNC_DEF(prog, "f", prog.getInt());
+      const auto& funcDef = GET_FUNC_DEF(prog, "f", prog.getString());
       CHECK(
           funcDef.getBody() ==
           *prog::expr::callExprNode(
               prog,
-              GET_INTRINSIC_ID(prog, "int_eq_zero", prog.getInt()),
+              GET_INTRINSIC_ID(prog, "string_eq_empty", prog.getString()),
               EXPRS(prog::expr::constExprNode(
-                  funcDef.getConsts(), *funcDef.getConsts().lookup("i")))));
+                  funcDef.getConsts(), *funcDef.getConsts().lookup("s")))));
     }
     {
       const auto& output = ANALYZE("fun f(string s) -> string s + \"\"");

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -214,6 +214,19 @@ TEST_CASE("[opt] Precompute literals", "opt") {
                   funcDef.getConsts(), *funcDef.getConsts().lookup("i")))));
     }
     {
+      const auto& output = ANALYZE("fun f(int i) -> bool intrinsic{int_eq_int}(0, i)");
+      REQUIRE(output.isSuccess());
+      const auto prog     = precomputeLiterals(output.getProg());
+      const auto& funcDef = GET_FUNC_DEF(prog, "f", prog.getInt());
+      CHECK(
+          funcDef.getBody() ==
+          *prog::expr::callExprNode(
+              prog,
+              GET_INTRINSIC_ID(prog, "int_eq_zero", prog.getInt()),
+              EXPRS(prog::expr::constExprNode(
+                  funcDef.getConsts(), *funcDef.getConsts().lookup("i")))));
+    }
+    {
       const auto& output = ANALYZE("fun f(string s) -> string s + \"\"");
       REQUIRE(output.isSuccess());
       const auto prog     = precomputeLiterals(output.getProg());

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -213,6 +213,24 @@ TEST_CASE("[opt] Precompute literals", "opt") {
               EXPRS(prog::expr::constExprNode(
                   funcDef.getConsts(), *funcDef.getConsts().lookup("i")))));
     }
+    {
+      const auto& output = ANALYZE("fun f(string s) -> string s + \"\"");
+      REQUIRE(output.isSuccess());
+      const auto prog     = precomputeLiterals(output.getProg());
+      const auto& funcDef = GET_FUNC_DEF(prog, "f", prog.getString());
+      CHECK(
+          funcDef.getBody() ==
+          *prog::expr::constExprNode(funcDef.getConsts(), *funcDef.getConsts().lookup("s")));
+    }
+    {
+      const auto& output = ANALYZE("fun f(string s) -> string \"\" + s");
+      REQUIRE(output.isSuccess());
+      const auto prog     = precomputeLiterals(output.getProg());
+      const auto& funcDef = GET_FUNC_DEF(prog, "f", prog.getString());
+      CHECK(
+          funcDef.getBody() ==
+          *prog::expr::constExprNode(funcDef.getConsts(), *funcDef.getConsts().lookup("s")));
+    }
   }
 
   SECTION("reinterpret conversions") {

--- a/tests/prog/copy_test.cpp
+++ b/tests/prog/copy_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE("[prog] Copy", "prog") {
   SECTION("Fail to copy intrinsic") {
     auto progA     = Program{};
     auto progB     = Program{};
-    auto intrinsic = progA.lookupIntrinsic("clock_nanosteady", sym::TypeSet{}, OvOptions{});
+    auto intrinsic = progA.lookupIntrinsic("clock_nanosteady", sym::TypeSet{});
     REQUIRE(intrinsic);
     REQUIRE(!copyFunc(progA, &progB, *intrinsic));
   }

--- a/tests/vm/string_check_test.cpp
+++ b/tests/vm/string_check_test.cpp
@@ -38,6 +38,68 @@ TEST_CASE("[vm] Execute string checks", "vm") {
         },
         "input",
         "true");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("");
+          asmb->addCheckStringEmtpy();
+          ADD_BOOL_TO_STRING(asmb);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "true");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("Hello");
+          asmb->addCheckStringEmtpy();
+          ADD_BOOL_TO_STRING(asmb);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "false");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("");
+          asmb->addLoadLitString("");
+          asmb->addAddString();
+          asmb->addCheckStringEmtpy();
+          ADD_BOOL_TO_STRING(asmb);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "true");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("Hello");
+          asmb->addLoadLitString("");
+          asmb->addAddString();
+          asmb->addCheckStringEmtpy();
+          ADD_BOOL_TO_STRING(asmb);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "false");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("");
+          asmb->addLoadLitInt('H');
+          asmb->addAppendChar();
+          asmb->addCheckStringEmtpy();
+          ADD_BOOL_TO_STRING(asmb);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "false");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("");
+          asmb->addLoadLitInt('\0');
+          asmb->addAppendChar();
+          asmb->addCheckStringEmtpy();
+          ADD_BOOL_TO_STRING(asmb);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "false");
   }
 }
 


### PR DESCRIPTION
This pr adds various new simplifications to the optimizer,

Checking if an integer is zero is converted into the `CheckIntZero` instruction:
![image](https://user-images.githubusercontent.com/14230060/111039373-71f64f00-8436-11eb-89cc-bb5abf7957b7.png)
![image](https://user-images.githubusercontent.com/14230060/111039383-7fabd480-8436-11eb-87f4-bd7a4cf24cf0.png)

Adding an empty string:
![image](https://user-images.githubusercontent.com/14230060/111039724-32c8fd80-8438-11eb-9b38-c687e30a882b.png)
![image](https://user-images.githubusercontent.com/14230060/111039732-3f4d5600-8438-11eb-90e7-c9076324bbbf.png)

Checking if a string is equal to the empty string:
![image](https://user-images.githubusercontent.com/14230060/111068392-39578380-84d1-11eb-85ca-b1b163132cfc.png)
![image](https://user-images.githubusercontent.com/14230060/111068403-46747280-84d1-11eb-84d5-adc6ec89de78.png)
