### PR TITLE
Convert build-in operators to intrinsics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 *.ns linguist-language=C
 
 # Binary files.
+*.nx binary
 *.jpg binary
 *.png binary
 *.ppm binary

--- a/include/prog/expr/node_call.hpp
+++ b/include/prog/expr/node_call.hpp
@@ -42,6 +42,7 @@ public:
   [[nodiscard]] auto getMode() const noexcept -> CallMode;
   [[nodiscard]] auto isFork() const noexcept -> bool;
   [[nodiscard]] auto isLazy() const noexcept -> bool;
+  [[nodiscard]] auto isCallToIntrinsic() const noexcept -> bool;
   [[nodiscard]] auto isComplete(const Program& prog) const noexcept -> bool;
 
   /* Patching arguments actually mutates the arguments. This only ever valid while still
@@ -57,12 +58,18 @@ private:
   sym::FuncId m_func;
   sym::TypeId m_resultType;
   CallMode m_mode;
+  bool m_callToIntrinsic;
 
   // NOTE: The arguments are mutable because optional arguments are applied in a separate phase
   // after all functions have been defined.
   mutable std::vector<NodePtr> m_args;
 
-  CallExprNode(sym::FuncId func, sym::TypeId resultType, std::vector<NodePtr> args, CallMode mode);
+  CallExprNode(
+      sym::FuncId func,
+      sym::TypeId resultType,
+      std::vector<NodePtr> args,
+      CallMode mode,
+      bool callToIntrinsic);
 };
 
 // Factories.

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -23,9 +23,7 @@ enum class FuncKind {
   InvInt,           // Bitwise invert an integer.
   CheckEqInt,       // Check if two integers are equal.
   CheckLeInt,       // Check if an integer is less then another integer.
-  CheckLeEqInt,     // Check if an integer is less then or equal to another integer.
   CheckGtInt,       // Check if an integer is greater then another integer.
-  CheckGtEqInt,     // Check if an integer is greater then or equal to another integer.
   CheckIntZero,     // Check if an integer is zero.
   CheckStringEmpty, // Check if a string is empty.
 
@@ -43,30 +41,26 @@ enum class FuncKind {
   InvLong,        // Bitwise invert an long.
   CheckEqLong,    // Check if two longs are equal.
   CheckLeLong,    // Check if a long is less then another long.
-  CheckLeEqLong,  // Check if a long is less then or equal to another long.
   CheckGtLong,    // Check if a long is greater then another long.
-  CheckGtEqLong,  // CHeck if a long is greater then or equal to another long.
 
-  AddFloat,       // Add two floats.
-  SubFloat,       // Substract two floats.
-  MulFloat,       // Multiply two floats.
-  DivFloat,       // Divide two floats.
-  ModFloat,       // Modulo two floats.
-  PowFloat,       // Raise a float to the power of another float.
-  SqrtFloat,      // Return the square-root of a float.
-  SinFloat,       // Compute the sine of a float.
-  CosFloat,       // Compute the cosine of a float.
-  TanFloat,       // Compute the tangent of a float.
-  ASinFloat,      // Compute the arc sine of a float.
-  ACosFloat,      // Compute the arc cosine of a float.
-  ATanFloat,      // Compute the arc tangent of a float.
-  ATan2Float,     // Compute the arc tangent of two floats.
-  NegateFloat,    // Negate a float.
-  CheckEqFloat,   // Check if two floats are equal.
-  CheckLeFloat,   // Check if a float is less then another float.
-  CheckLeEqFloat, // Check if a float is less then or equal to another float.
-  CheckGtFloat,   // Check if a float is greater then another float.
-  CheckGtEqFloat, // Check if a float is greater then or equal to another float.
+  AddFloat,     // Add two floats.
+  SubFloat,     // Substract two floats.
+  MulFloat,     // Multiply two floats.
+  DivFloat,     // Divide two floats.
+  ModFloat,     // Modulo two floats.
+  PowFloat,     // Raise a float to the power of another float.
+  SqrtFloat,    // Return the square-root of a float.
+  SinFloat,     // Compute the sine of a float.
+  CosFloat,     // Compute the cosine of a float.
+  TanFloat,     // Compute the tangent of a float.
+  ASinFloat,    // Compute the arc sine of a float.
+  ACosFloat,    // Compute the arc cosine of a float.
+  ATanFloat,    // Compute the arc tangent of a float.
+  ATan2Float,   // Compute the arc tangent of two floats.
+  NegateFloat,  // Negate a float.
+  CheckEqFloat, // Check if two floats are equal.
+  CheckLeFloat, // Check if a float is less then another float.
+  CheckGtFloat, // Check if a float is greater then another float.
 
   AddString,     // Combine two strings.
   LengthString,  // Return the length of a string.

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -71,7 +71,6 @@ enum class FuncKind {
   AppendChar, // Append a character to a string.
 
   ConvIntLong,     // Convert a integer to a long.
-  ConvCharLong,    // Convert a character to a long.
   ConvIntFloat,    // Convert a int to a float.
   ConvLongInt,     // Convert a long to an integer.
   ConvLongFloat,   // Convert a long to a float.

--- a/include/prog/sym/func_kind.hpp
+++ b/include/prog/sym/func_kind.hpp
@@ -63,12 +63,11 @@ enum class FuncKind {
   CheckGtFloat, // Check if a float is greater then another float.
 
   AddString,     // Combine two strings.
+  AppendChar,    // Append a character to a string.
   LengthString,  // Return the length of a string.
   IndexString,   // Return the character at a specific index into a string.
   SliceString,   // Return a subsection of a string, indicated by start and end.
   CheckEqString, // Check if two strings are equal.
-
-  AppendChar, // Append a character to a string.
 
   ConvIntLong,     // Convert a integer to a long.
   ConvIntFloat,    // Convert a int to a float.

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -169,16 +169,8 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::CheckLeInt:
     m_asmb->addCheckLeInt();
     break;
-  case prog::sym::FuncKind::CheckLeEqInt:
-    m_asmb->addCheckGtInt();
-    m_asmb->addCheckIntZero(); // Invert.
-    break;
   case prog::sym::FuncKind::CheckGtInt:
     m_asmb->addCheckGtInt();
-    break;
-  case prog::sym::FuncKind::CheckGtEqInt:
-    m_asmb->addCheckLeInt();
-    m_asmb->addCheckIntZero(); // Invert.
     break;
   case prog::sym::FuncKind::CheckIntZero:
     m_asmb->addCheckIntZero();
@@ -230,16 +222,8 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::CheckLeLong:
     m_asmb->addCheckLeLong();
     break;
-  case prog::sym::FuncKind::CheckLeEqLong:
-    m_asmb->addCheckGtLong();
-    m_asmb->addCheckIntZero(); // Invert.
-    break;
   case prog::sym::FuncKind::CheckGtLong:
     m_asmb->addCheckGtLong();
-    break;
-  case prog::sym::FuncKind::CheckGtEqLong:
-    m_asmb->addCheckLeLong();
-    m_asmb->addCheckIntZero(); // Invert.
     break;
 
   case prog::sym::FuncKind::AddFloat:
@@ -294,16 +278,8 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::CheckLeFloat:
     m_asmb->addCheckLeFloat();
     break;
-  case prog::sym::FuncKind::CheckLeEqFloat:
-    m_asmb->addCheckGtFloat();
-    m_asmb->addCheckIntZero(); // Invert.
-    break;
   case prog::sym::FuncKind::CheckGtFloat:
     m_asmb->addCheckGtFloat();
-    break;
-  case prog::sym::FuncKind::CheckGtEqFloat:
-    m_asmb->addCheckLeFloat();
-    m_asmb->addCheckIntZero(); // Invert.
     break;
 
   case prog::sym::FuncKind::AddString:

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -303,7 +303,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
 
   case prog::sym::FuncKind::ConvIntLong:
-  case prog::sym::FuncKind::ConvCharLong:
     m_asmb->addConvIntLong();
     break;
   case prog::sym::FuncKind::ConvIntFloat:

--- a/src/backend/internal/gen_expr.cpp
+++ b/src/backend/internal/gen_expr.cpp
@@ -285,6 +285,9 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
   case prog::sym::FuncKind::AddString:
     m_asmb->addAddString();
     break;
+  case prog::sym::FuncKind::AppendChar:
+    m_asmb->addAppendChar();
+    break;
   case prog::sym::FuncKind::LengthString:
     m_asmb->addLengthString();
     break;
@@ -296,10 +299,6 @@ auto GenExpr::visit(const prog::expr::CallExprNode& n) -> void {
     break;
   case prog::sym::FuncKind::CheckEqString:
     m_asmb->addCheckEqString();
-    break;
-
-  case prog::sym::FuncKind::AppendChar:
-    m_asmb->addAppendChar();
     break;
 
   case prog::sym::FuncKind::ConvIntLong:

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -33,9 +33,7 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::InvInt:
   case prog::sym::FuncKind::CheckEqInt:
   case prog::sym::FuncKind::CheckLeInt:
-  case prog::sym::FuncKind::CheckLeEqInt:
   case prog::sym::FuncKind::CheckGtInt:
-  case prog::sym::FuncKind::CheckGtEqInt:
   case prog::sym::FuncKind::CheckIntZero:
   case prog::sym::FuncKind::ConvIntLong:
   case prog::sym::FuncKind::ConvCharLong:
@@ -61,9 +59,7 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::NegateFloat:
   case prog::sym::FuncKind::CheckEqFloat:
   case prog::sym::FuncKind::CheckLeFloat:
-  case prog::sym::FuncKind::CheckLeEqFloat:
   case prog::sym::FuncKind::CheckGtFloat:
-  case prog::sym::FuncKind::CheckGtEqFloat:
   case prog::sym::FuncKind::ConvFloatInt:
   case prog::sym::FuncKind::ConvFloatString:
   case prog::sym::FuncKind::ConvFloatChar:
@@ -84,9 +80,7 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::InvLong:
   case prog::sym::FuncKind::CheckEqLong:
   case prog::sym::FuncKind::CheckLeLong:
-  case prog::sym::FuncKind::CheckLeEqLong:
   case prog::sym::FuncKind::CheckGtLong:
-  case prog::sym::FuncKind::CheckGtEqLong:
   case prog::sym::FuncKind::ConvLongInt:
   case prog::sym::FuncKind::ConvLongFloat:
   case prog::sym::FuncKind::ConvLongString:
@@ -190,17 +184,9 @@ auto precomputeIntrinsic(
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getInt(*args[0]) < getInt(*args[1]));
   }
-  case prog::sym::FuncKind::CheckLeEqInt: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getInt(*args[0]) <= getInt(*args[1]));
-  }
   case prog::sym::FuncKind::CheckGtInt: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getInt(*args[0]) > getInt(*args[1]));
-  }
-  case prog::sym::FuncKind::CheckGtEqInt: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getInt(*args[0]) >= getInt(*args[1]));
   }
   case prog::sym::FuncKind::CheckIntZero: {
     assert(args.size() == 1);
@@ -295,17 +281,9 @@ auto precomputeIntrinsic(
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getFloat(*args[0]) < getFloat(*args[1]));
   }
-  case prog::sym::FuncKind::CheckLeEqFloat: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getFloat(*args[0]) <= getFloat(*args[1]));
-  }
   case prog::sym::FuncKind::CheckGtFloat: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getFloat(*args[0]) > getFloat(*args[1]));
-  }
-  case prog::sym::FuncKind::CheckGtEqFloat: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getFloat(*args[0]) >= getFloat(*args[1]));
   }
   case prog::sym::FuncKind::ConvFloatInt: {
     assert(args.size() == 1);
@@ -397,17 +375,9 @@ auto precomputeIntrinsic(
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getLong(*args[0]) < getLong(*args[1]));
   }
-  case prog::sym::FuncKind::CheckLeEqLong: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getLong(*args[0]) <= getLong(*args[1]));
-  }
   case prog::sym::FuncKind::CheckGtLong: {
     assert(args.size() == 2);
     return prog::expr::litBoolNode(prog, getLong(*args[0]) > getLong(*args[1]));
-  }
-  case prog::sym::FuncKind::CheckGtEqLong: {
-    assert(args.size() == 2);
-    return prog::expr::litBoolNode(prog, getLong(*args[0]) >= getLong(*args[1]));
   }
   case prog::sym::FuncKind::ConvLongInt: {
     assert(args.size() == 1);

--- a/src/opt/internal/intrinsics.cpp
+++ b/src/opt/internal/intrinsics.cpp
@@ -36,7 +36,6 @@ auto isPrecomputableIntrinsic(prog::sym::FuncKind funcKind) -> bool {
   case prog::sym::FuncKind::CheckGtInt:
   case prog::sym::FuncKind::CheckIntZero:
   case prog::sym::FuncKind::ConvIntLong:
-  case prog::sym::FuncKind::ConvCharLong:
   case prog::sym::FuncKind::ConvIntFloat:
   case prog::sym::FuncKind::ConvIntString:
   case prog::sym::FuncKind::ConvIntChar:
@@ -192,8 +191,7 @@ auto precomputeIntrinsic(
     assert(args.size() == 1);
     return prog::expr::litBoolNode(prog, getInt(*args[0]) == 0);
   }
-  case prog::sym::FuncKind::ConvIntLong:
-  case prog::sym::FuncKind::ConvCharLong: {
+  case prog::sym::FuncKind::ConvIntLong: {
     assert(args.size() == 1);
     return prog::expr::litLongNode(prog, static_cast<int64_t>(getInt(*args[0])));
   }

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -34,27 +34,6 @@ Program::Program() :
   using Fk = prog::sym::FuncKind;
   using Op = prog::Operator;
 
-  // Register build-in unary int operators.
-  m_funcDecls.registerFunc(*this, Fk::InvInt, getFuncName(Op::Tilde), sym::TypeSet{m_int}, m_int);
-
-  // Register build-in binary int operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::MulInt, getFuncName(Op::Star), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::DivInt, getFuncName(Op::Slash), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::RemInt, getFuncName(Op::Rem), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::ShiftLeftInt, getFuncName(Op::ShiftL), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::ShiftRightInt, getFuncName(Op::ShiftR), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::AndInt, getFuncName(Op::Amp), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::OrInt, getFuncName(Op::Pipe), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::XorInt, getFuncName(Op::Hat), sym::TypeSet{m_int, m_int}, m_int);
-
   // Register int intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqInt, "int_eq_int", sym::TypeSet{m_int, m_int}, m_bool);
@@ -69,6 +48,22 @@ Program::Program() :
   m_funcDecls.registerIntrinsic(
       *this, Fk::SubInt, "int_sub_int", sym::TypeSet{m_int, m_int}, m_int);
   m_funcDecls.registerIntrinsic(*this, Fk::NegateInt, "int_neg", sym::TypeSet{m_int}, m_int);
+  m_funcDecls.registerIntrinsic(*this, Fk::InvInt, "int_inv", sym::TypeSet{m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::MulInt, "int_mul_int", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::DivInt, "int_div_int", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::RemInt, "int_rem_int", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ShiftLeftInt, "int_shiftleft", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ShiftRightInt, "int_shiftright", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::AndInt, "int_and_int", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(*this, Fk::OrInt, "int_or_int", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::XorInt, "int_xor_int", sym::TypeSet{m_int, m_int}, m_int);
 
   // Register build-in unary long operators.
   m_funcDecls.registerFunc(

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -32,7 +32,6 @@ Program::Program() :
     m_process{m_typeDecls.registerType(sym::TypeKind::Process, "sys_process")} {
 
   using Fk = prog::sym::FuncKind;
-  using Op = prog::Operator;
 
   // Register int intrinsics.
   m_funcDecls.registerIntrinsic(
@@ -136,18 +135,12 @@ Program::Program() :
       *this, Fk::AddString, "string_add_string", sym::TypeSet{m_string, m_string}, m_string);
   m_funcDecls.registerIntrinsic(
       *this, Fk::AppendChar, "string_add_char", sym::TypeSet{m_string, m_char}, m_string);
-
-  // Register build-in string functions.
   m_funcDecls.registerIntrinsic(
       *this, Fk::LengthString, "string_length", sym::TypeSet{m_string}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::IndexString, getFuncName(Op::SquareSquare), sym::TypeSet{m_string, m_int}, m_char);
-  m_funcDecls.registerFunc(
-      *this,
-      Fk::SliceString,
-      getFuncName(Op::SquareSquare),
-      sym::TypeSet{m_string, m_int, m_int},
-      m_string);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::IndexString, "string_index", sym::TypeSet{m_string, m_int}, m_char);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::SliceString, "string_slice", sym::TypeSet{m_string, m_int, m_int}, m_string);
 
   // Register conversion intrinsics.
   m_funcDecls.registerIntrinsic(*this, Fk::ConvIntLong, "int_to_long", sym::TypeSet{m_int}, m_long);

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -60,20 +60,16 @@ Program::Program() :
       *this, Fk::OrInt, getFuncName(Op::Pipe), sym::TypeSet{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
       *this, Fk::XorInt, getFuncName(Op::Hat), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckLeInt, getFuncName(Op::Le), sym::TypeSet{m_int, m_int}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckLeEqInt, getFuncName(Op::LeEq), sym::TypeSet{m_int, m_int}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckGtInt, getFuncName(Op::Gt), sym::TypeSet{m_int, m_int}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckGtEqInt, getFuncName(Op::GtEq), sym::TypeSet{m_int, m_int}, m_bool);
 
   // Register int intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqInt, "int_eq_int", sym::TypeSet{m_int, m_int}, m_bool);
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckIntZero, "int_eq_zero", sym::TypeSet{m_int}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckLeInt, "int_le_int", sym::TypeSet{m_int, m_int}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckGtInt, "int_gt_int", sym::TypeSet{m_int, m_int}, m_bool);
 
   // Register build-in unary long operators.
   m_funcDecls.registerFunc(
@@ -102,18 +98,14 @@ Program::Program() :
       *this, Fk::OrLong, getFuncName(Op::Pipe), sym::TypeSet{m_long, m_long}, m_long);
   m_funcDecls.registerFunc(
       *this, Fk::XorLong, getFuncName(Op::Hat), sym::TypeSet{m_long, m_long}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckLeLong, getFuncName(Op::Le), sym::TypeSet{m_long, m_long}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckLeEqLong, getFuncName(Op::LeEq), sym::TypeSet{m_long, m_long}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckGtLong, getFuncName(Op::Gt), sym::TypeSet{m_long, m_long}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckGtEqLong, getFuncName(Op::GtEq), sym::TypeSet{m_long, m_long}, m_bool);
 
   // Register long intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqLong, "long_eq_long", sym::TypeSet{m_long, m_long}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckLeLong, "long_le_long", sym::TypeSet{m_long, m_long}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckGtLong, "long_gt_long", sym::TypeSet{m_long, m_long}, m_bool);
 
   // Register build-in unary float operators.
   m_funcDecls.registerFunc(
@@ -130,18 +122,14 @@ Program::Program() :
       *this, Fk::DivFloat, getFuncName(Op::Slash), sym::TypeSet{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
       *this, Fk::ModFloat, getFuncName(Op::Rem), sym::TypeSet{m_float, m_float}, m_float);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckLeFloat, getFuncName(Op::Le), sym::TypeSet{m_float, m_float}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckLeEqFloat, getFuncName(Op::LeEq), sym::TypeSet{m_float, m_float}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckGtFloat, getFuncName(Op::Gt), sym::TypeSet{m_float, m_float}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, Fk::CheckGtEqFloat, getFuncName(Op::GtEq), sym::TypeSet{m_float, m_float}, m_bool);
 
   // Register float intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqFloat, "float_eq_float", sym::TypeSet{m_float, m_float}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckLeFloat, "float_le_float", sym::TypeSet{m_float, m_float}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::CheckGtFloat, "float_gt_float", sym::TypeSet{m_float, m_float}, m_bool);
   m_funcDecls.registerIntrinsic(
       *this, Fk::PowFloat, "float_pow", sym::TypeSet{m_float, m_float}, m_float);
   m_funcDecls.registerIntrinsic(*this, Fk::SqrtFloat, "float_sqrt", sym::TypeSet{m_float}, m_float);
@@ -575,15 +563,11 @@ auto Program::defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t
   // Register implicit conversion to int and long.
   m_funcDecls.registerImplicitConv(*this, fk::NoOp, id, m_int);
 
-  // Register ordering operators (<, <=, >, >=).
+  // Register ordering operators (<, >).
   m_funcDecls.registerFunc(
       *this, fk::CheckLeInt, getFuncName(Operator::Le), sym::TypeSet{id, id}, m_bool);
   m_funcDecls.registerFunc(
-      *this, fk::CheckLeEqInt, getFuncName(Operator::LeEq), sym::TypeSet{id, id}, m_bool);
-  m_funcDecls.registerFunc(
       *this, fk::CheckGtInt, getFuncName(Operator::Gt), sym::TypeSet{id, id}, m_bool);
-  m_funcDecls.registerFunc(
-      *this, fk::CheckGtEqInt, getFuncName(Operator::GtEq), sym::TypeSet{id, id}, m_bool);
 
   // Register bitwise & and | operators.
   m_funcDecls.registerFunc(*this, fk::OrInt, getFuncName(Operator::Pipe), sym::TypeSet{id, id}, id);

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -41,10 +41,6 @@ Program::Program() :
 
   // Register build-in binary int operators.
   m_funcDecls.registerFunc(
-      *this, Fk::AddInt, getFuncName(Op::Plus), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
-      *this, Fk::SubInt, getFuncName(Op::Minus), sym::TypeSet{m_int, m_int}, m_int);
-  m_funcDecls.registerFunc(
       *this, Fk::MulInt, getFuncName(Op::Star), sym::TypeSet{m_int, m_int}, m_int);
   m_funcDecls.registerFunc(
       *this, Fk::DivInt, getFuncName(Op::Slash), sym::TypeSet{m_int, m_int}, m_int);
@@ -70,6 +66,10 @@ Program::Program() :
       *this, Fk::CheckLeInt, "int_le_int", sym::TypeSet{m_int, m_int}, m_bool);
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckGtInt, "int_gt_int", sym::TypeSet{m_int, m_int}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::AddInt, "int_add_int", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::SubInt, "int_sub_int", sym::TypeSet{m_int, m_int}, m_int);
 
   // Register build-in unary long operators.
   m_funcDecls.registerFunc(

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -65,28 +65,6 @@ Program::Program() :
   m_funcDecls.registerIntrinsic(
       *this, Fk::XorInt, "int_xor_int", sym::TypeSet{m_int, m_int}, m_int);
 
-  // Register build-in unary long operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::InvLong, getFuncName(Op::Tilde), sym::TypeSet{m_long}, m_long);
-
-  // Register build-in binary long operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::MulLong, getFuncName(Op::Star), sym::TypeSet{m_long, m_long}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::DivLong, getFuncName(Op::Slash), sym::TypeSet{m_long, m_long}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::RemLong, getFuncName(Op::Rem), sym::TypeSet{m_long, m_long}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::ShiftLeftLong, getFuncName(Op::ShiftL), sym::TypeSet{m_long, m_int}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::ShiftRightLong, getFuncName(Op::ShiftR), sym::TypeSet{m_long, m_int}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::AndLong, getFuncName(Op::Amp), sym::TypeSet{m_long, m_long}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::OrLong, getFuncName(Op::Pipe), sym::TypeSet{m_long, m_long}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::XorLong, getFuncName(Op::Hat), sym::TypeSet{m_long, m_long}, m_long);
-
   // Register long intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqLong, "long_eq_long", sym::TypeSet{m_long, m_long}, m_bool);
@@ -99,6 +77,23 @@ Program::Program() :
   m_funcDecls.registerIntrinsic(
       *this, Fk::SubLong, "long_sub_long", sym::TypeSet{m_long, m_long}, m_long);
   m_funcDecls.registerIntrinsic(*this, Fk::NegateLong, "long_neg", sym::TypeSet{m_long}, m_long);
+  m_funcDecls.registerIntrinsic(*this, Fk::InvLong, "long_inv", sym::TypeSet{m_long}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::MulLong, "long_mul_long", sym::TypeSet{m_long, m_long}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::DivLong, "long_div_long", sym::TypeSet{m_long, m_long}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::RemLong, "long_rem_long", sym::TypeSet{m_long, m_long}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ShiftLeftLong, "long_shiftleft", sym::TypeSet{m_long, m_int}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ShiftRightLong, "long_shiftright", sym::TypeSet{m_long, m_int}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::AndLong, "long_and_long", sym::TypeSet{m_long, m_long}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::OrLong, "long_or_long", sym::TypeSet{m_long, m_long}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::XorLong, "long_xor_long", sym::TypeSet{m_long, m_long}, m_long);
 
   // Register float intrinsics.
   m_funcDecls.registerIntrinsic(

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -100,14 +100,6 @@ Program::Program() :
       *this, Fk::SubLong, "long_sub_long", sym::TypeSet{m_long, m_long}, m_long);
   m_funcDecls.registerIntrinsic(*this, Fk::NegateLong, "long_neg", sym::TypeSet{m_long}, m_long);
 
-  // Register build-in binary float operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::MulFloat, getFuncName(Op::Star), sym::TypeSet{m_float, m_float}, m_float);
-  m_funcDecls.registerFunc(
-      *this, Fk::DivFloat, getFuncName(Op::Slash), sym::TypeSet{m_float, m_float}, m_float);
-  m_funcDecls.registerFunc(
-      *this, Fk::ModFloat, getFuncName(Op::Rem), sym::TypeSet{m_float, m_float}, m_float);
-
   // Register float intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqFloat, "float_eq_float", sym::TypeSet{m_float, m_float}, m_bool);
@@ -123,6 +115,13 @@ Program::Program() :
       *this, Fk::NegateFloat, "float_neg", sym::TypeSet{m_float}, m_float);
   m_funcDecls.registerIntrinsic(
       *this, Fk::PowFloat, "float_pow", sym::TypeSet{m_float, m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::MulFloat, "float_mul_float", sym::TypeSet{m_float, m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::DivFloat, "float_div_float", sym::TypeSet{m_float, m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::ModFloat, "float_mod_float", sym::TypeSet{m_float, m_float}, m_float);
+
   m_funcDecls.registerIntrinsic(*this, Fk::SqrtFloat, "float_sqrt", sym::TypeSet{m_float}, m_float);
   m_funcDecls.registerIntrinsic(*this, Fk::SinFloat, "float_sin", sym::TypeSet{m_float}, m_float);
   m_funcDecls.registerIntrinsic(*this, Fk::CosFloat, "float_cos", sym::TypeSet{m_float}, m_float);

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -534,7 +534,7 @@ auto Program::defineEnum(sym::TypeId id, std::unordered_map<std::string, int32_t
   // Register explicit conversion from int.
   m_funcDecls.registerFunc(*this, fk::NoOp, name, sym::TypeSet{m_int}, id);
 
-  // Register implicit conversion to int and long.
+  // Register implicit conversion to int.
   m_funcDecls.registerImplicitConv(*this, fk::NoOp, id, m_int);
 
   // Register ordering operators (<, >).

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -35,8 +35,6 @@ Program::Program() :
   using Op = prog::Operator;
 
   // Register build-in unary int operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::NegateInt, getFuncName(Op::Minus), sym::TypeSet{m_int}, m_int);
   m_funcDecls.registerFunc(*this, Fk::InvInt, getFuncName(Op::Tilde), sym::TypeSet{m_int}, m_int);
 
   // Register build-in binary int operators.
@@ -70,18 +68,13 @@ Program::Program() :
       *this, Fk::AddInt, "int_add_int", sym::TypeSet{m_int, m_int}, m_int);
   m_funcDecls.registerIntrinsic(
       *this, Fk::SubInt, "int_sub_int", sym::TypeSet{m_int, m_int}, m_int);
+  m_funcDecls.registerIntrinsic(*this, Fk::NegateInt, "int_neg", sym::TypeSet{m_int}, m_int);
 
   // Register build-in unary long operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::NegateLong, getFuncName(Op::Minus), sym::TypeSet{m_long}, m_long);
   m_funcDecls.registerFunc(
       *this, Fk::InvLong, getFuncName(Op::Tilde), sym::TypeSet{m_long}, m_long);
 
   // Register build-in binary long operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::AddLong, getFuncName(Op::Plus), sym::TypeSet{m_long, m_long}, m_long);
-  m_funcDecls.registerFunc(
-      *this, Fk::SubLong, getFuncName(Op::Minus), sym::TypeSet{m_long, m_long}, m_long);
   m_funcDecls.registerFunc(
       *this, Fk::MulLong, getFuncName(Op::Star), sym::TypeSet{m_long, m_long}, m_long);
   m_funcDecls.registerFunc(
@@ -106,16 +99,13 @@ Program::Program() :
       *this, Fk::CheckLeLong, "long_le_long", sym::TypeSet{m_long, m_long}, m_bool);
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckGtLong, "long_gt_long", sym::TypeSet{m_long, m_long}, m_bool);
-
-  // Register build-in unary float operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::NegateFloat, getFuncName(Op::Minus), sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::AddLong, "long_add_long", sym::TypeSet{m_long, m_long}, m_long);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::SubLong, "long_sub_long", sym::TypeSet{m_long, m_long}, m_long);
+  m_funcDecls.registerIntrinsic(*this, Fk::NegateLong, "long_neg", sym::TypeSet{m_long}, m_long);
 
   // Register build-in binary float operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::AddFloat, getFuncName(Op::Plus), sym::TypeSet{m_float, m_float}, m_float);
-  m_funcDecls.registerFunc(
-      *this, Fk::SubFloat, getFuncName(Op::Minus), sym::TypeSet{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
       *this, Fk::MulFloat, getFuncName(Op::Star), sym::TypeSet{m_float, m_float}, m_float);
   m_funcDecls.registerFunc(
@@ -131,6 +121,12 @@ Program::Program() :
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckGtFloat, "float_gt_float", sym::TypeSet{m_float, m_float}, m_bool);
   m_funcDecls.registerIntrinsic(
+      *this, Fk::AddFloat, "float_add_float", sym::TypeSet{m_float, m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::SubFloat, "float_sub_float", sym::TypeSet{m_float, m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::NegateFloat, "float_neg", sym::TypeSet{m_float}, m_float);
+  m_funcDecls.registerIntrinsic(
       *this, Fk::PowFloat, "float_pow", sym::TypeSet{m_float, m_float}, m_float);
   m_funcDecls.registerIntrinsic(*this, Fk::SqrtFloat, "float_sqrt", sym::TypeSet{m_float}, m_float);
   m_funcDecls.registerIntrinsic(*this, Fk::SinFloat, "float_sin", sym::TypeSet{m_float}, m_float);
@@ -142,17 +138,15 @@ Program::Program() :
   m_funcDecls.registerIntrinsic(
       *this, Fk::ATan2Float, "float_atan2", sym::TypeSet{m_float, m_float}, m_float);
 
-  // Register build-in binary string operators.
-  m_funcDecls.registerFunc(
-      *this, Fk::AddString, getFuncName(Op::Plus), sym::TypeSet{m_string, m_string}, m_string);
-  m_funcDecls.registerFunc(
-      *this, Fk::AppendChar, getFuncName(Op::Plus), sym::TypeSet{m_string, m_char}, m_string);
-
   // Register string intrinsics.
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckEqString, "string_eq_string", sym::TypeSet{m_string, m_string}, m_bool);
   m_funcDecls.registerIntrinsic(
       *this, Fk::CheckStringEmpty, "string_eq_empty", sym::TypeSet{m_string}, m_bool);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::AddString, "string_add_string", sym::TypeSet{m_string, m_string}, m_string);
+  m_funcDecls.registerIntrinsic(
+      *this, Fk::AppendChar, "string_add_char", sym::TypeSet{m_string, m_char}, m_string);
 
   // Register build-in string functions.
   m_funcDecls.registerIntrinsic(

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -169,8 +169,6 @@ Program::Program() :
   // Register conversion intrinsics.
   m_funcDecls.registerIntrinsic(*this, Fk::ConvIntLong, "int_to_long", sym::TypeSet{m_int}, m_long);
   m_funcDecls.registerIntrinsic(
-      *this, Fk::ConvCharLong, "char_to_long", sym::TypeSet{m_char}, m_long);
-  m_funcDecls.registerIntrinsic(
       *this, Fk::ConvIntFloat, "int_to_float", sym::TypeSet{m_int}, m_float);
   m_funcDecls.registerIntrinsic(
       *this, Fk::ConvFloatInt, "float_to_int", sym::TypeSet{m_float}, m_int);

--- a/std/format/utf8.ns
+++ b/std/format/utf8.ns
@@ -129,10 +129,11 @@ assert(utf8Validate(string(char(0b1100_0000), char(0b1000_0001)), 0, true))
 assert(utf8Validate(string(char(0b1110_0000), char(0b1000_0001), char(0b1000_0001)), 0, true))
 assert(utf8Validate(string(char(0b1111_0000), char(0b1000_0001), char(0b1000_0001), char(0b1000_0001)), 0, true))
 
-assertEq(
-  allCodePoints   = rangeList(minUnicodePoint(), maxUnicodePoint());
-  allUtf8Strs     = allCodePoints.mapReverse(toUtf8);
-  codePointParser = utf8CodePointParser();
-  makePair(
-    allUtf8Strs.mapReverse(lambda (string str) codePointParser(str) ?? errorUnicodePoint()),
-    allCodePoints))
+// Very slow test:
+// assertEq(
+//   allCodePoints   = rangeList(minUnicodePoint(), maxUnicodePoint());
+//   allUtf8Strs     = allCodePoints.mapReverse(toUtf8);
+//   codePointParser = utf8CodePointParser();
+//   makePair(
+//     allUtf8Strs.mapReverse(lambda (string str) codePointParser(str) ?? errorUnicodePoint()),
+//     allCodePoints))

--- a/std/prim.ns
+++ b/std/prim.ns
@@ -22,7 +22,7 @@ fun highBit{T}()              lowBit{T}() << (bitSize{T}() - 1)
 fun minVal{T}()               minVal(Type{T}())
 fun maxVal{T}()               maxVal(Type{T}())
 
-// -- Equality
+// -- Comparision
 
 fun =={T}(T x, T y) -> bool
   intrinsic{usertype_eq_usertype}(x, y)
@@ -35,6 +35,24 @@ fun equals{T1, T2}(T1 x, T2 y) -> bool
 
 fun equals{T}(T x, T y) -> bool
   x == y
+
+fun >={T1, T2}(T1 x, T2 y) -> bool
+  !(x < y)
+
+fun <={T1, T2}(T1 x, T2 y) -> bool
+  !(x > y)
+
+fun less{T1, T2}(T1 x, T2 y) -> bool
+  x < y
+
+fun less{T}(T x, T y) -> bool
+  x < y
+
+fun greater{T1, T2}(T1 x, T2 y) -> bool
+  x > y
+
+fun greater{T}(T x, T y) -> bool
+  x > y
 
 // -- Tests
 

--- a/std/prim/char.ns
+++ b/std/prim/char.ns
@@ -28,7 +28,13 @@ fun char(float f)
 
 fun +(char c) c
 
+fun +(char x, char y)
+  char(intrinsic{int_add_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y)))
+
 fun ++(char c) c + char(1)
+
+fun -(char x, char y)
+  char(intrinsic{int_sub_int}(intrinsic{char_as_int}(x), char(y)))
 
 fun --(char c) c - char(1)
 
@@ -46,12 +52,6 @@ fun |(char x, char y)
 
 fun ~(char x)
   char(~intrinsic{char_as_int}(x))
-
-fun +(char x, char y)
-  char(intrinsic{char_as_int}(x) + intrinsic{char_as_int}(y))
-
-fun -(char x, char y)
-  char(intrinsic{char_as_int}(x) - char(y))
 
 fun ==(char x, char y) -> bool
   intrinsic{int_eq_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y))

--- a/std/prim/char.ns
+++ b/std/prim/char.ns
@@ -39,19 +39,19 @@ fun -(char x, char y)
 fun --(char c) c - char(1)
 
 fun <<(char x, int y)
-  char(intrinsic{char_as_int}(x) << y)
+  char(intrinsic{int_shiftleft}(intrinsic{char_as_int}(x), y))
 
 fun >>(char x, int y)
-  char(intrinsic{char_as_int}(x) >> y)
+  char(intrinsic{int_shiftright}(intrinsic{char_as_int}(x), y))
 
 fun &(char x, char y)
-  char(intrinsic{char_as_int}(x) & intrinsic{char_as_int}(y))
+  char(intrinsic{int_and_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y)))
 
 fun |(char x, char y)
-  char(intrinsic{char_as_int}(x) | intrinsic{char_as_int}(y))
+  char(intrinsic{int_or_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y)))
 
 fun ~(char x)
-  char(~intrinsic{char_as_int}(x))
+  char(intrinsic{int_inv}(intrinsic{char_as_int}(x)))
 
 fun ==(char x, char y) -> bool
   intrinsic{int_eq_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y))

--- a/std/prim/char.ns
+++ b/std/prim/char.ns
@@ -57,16 +57,10 @@ fun ==(char x, char y) -> bool
   intrinsic{int_eq_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y))
 
 fun <(char x, char y) -> bool
-  intrinsic{char_as_int}(x) < intrinsic{char_as_int}(y)
-
-fun <=(char x, char y) -> bool
-  intrinsic{char_as_int}(x) <= intrinsic{char_as_int}(y)
+  intrinsic{int_le_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y))
 
 fun >(char x, char y) -> bool
-  intrinsic{char_as_int}(x) > intrinsic{char_as_int}(y)
-
-fun >=(char x, char y) -> bool
-  intrinsic{char_as_int}(x) >= intrinsic{char_as_int}(y)
+  intrinsic{int_gt_int}(intrinsic{char_as_int}(x), intrinsic{char_as_int}(y))
 
 // -- Tests
 

--- a/std/prim/float.ns
+++ b/std/prim/float.ns
@@ -27,7 +27,16 @@ fun asFloat(int i) -> float
 
 fun +(float f) f
 
+fun +(float x, float y) -> float
+  intrinsic{float_add_float}(x, y)
+
 fun ++(float f) f + 1.0
+
+fun -(float x) -> float
+  intrinsic{float_neg}(x)
+
+fun -(float x, float y) -> float
+  intrinsic{float_sub_float}(x, y)
 
 fun --(float f) f - 1.0
 

--- a/std/prim/float.ns
+++ b/std/prim/float.ns
@@ -34,6 +34,12 @@ fun --(float f) f - 1.0
 fun ==(float x, float y) -> bool
   intrinsic{float_eq_float}(x, y)
 
+fun <(float x, float y) -> bool
+  intrinsic{float_le_float}(x, y)
+
+fun >(float x, float y) -> bool
+  intrinsic{float_gt_float}(x, y)
+
 // -- Utilities
 
 fun nan()

--- a/std/prim/float.ns
+++ b/std/prim/float.ns
@@ -40,6 +40,15 @@ fun -(float x, float y) -> float
 
 fun --(float f) f - 1.0
 
+fun *(float x, float y) -> float
+  intrinsic{float_mul_float}(x, y)
+
+fun /(float x, float y) -> float
+  intrinsic{float_div_float}(x, y)
+
+fun %(float x, float y) -> float
+  intrinsic{float_mod_float}(x, y)
+
 fun ==(float x, float y) -> bool
   intrinsic{float_eq_float}(x, y)
 

--- a/std/prim/int.ns
+++ b/std/prim/int.ns
@@ -36,6 +36,9 @@ fun +(int x, int y) -> int
 
 fun ++(int i) i + 1
 
+fun -(int x) -> int
+  intrinsic{int_neg}(x)
+
 fun -(int x, int y) -> int
   intrinsic{int_sub_int}(x, y)
 

--- a/std/prim/int.ns
+++ b/std/prim/int.ns
@@ -37,3 +37,9 @@ fun --(int i) i - 1
 
 fun ==(int x, int y) -> bool
   intrinsic{int_eq_int}(x, y)
+
+fun <(int x, int y) -> bool
+  intrinsic{int_le_int}(x, y)
+
+fun >(int x, int y) -> bool
+  intrinsic{int_gt_int}(x, y)

--- a/std/prim/int.ns
+++ b/std/prim/int.ns
@@ -31,7 +31,13 @@ fun asInt(float f) -> int
 
 fun +(int i) i
 
+fun +(int x, int y) -> int
+  intrinsic{int_add_int}(x, y)
+
 fun ++(int i) i + 1
+
+fun -(int x, int y) -> int
+  intrinsic{int_sub_int}(x, y)
 
 fun --(int i) i - 1
 

--- a/std/prim/int.ns
+++ b/std/prim/int.ns
@@ -44,6 +44,33 @@ fun -(int x, int y) -> int
 
 fun --(int i) i - 1
 
+fun ~(int x) -> int
+  intrinsic{int_inv}(x)
+
+fun *(int x, int y) -> int
+  intrinsic{int_mul_int}(x, y)
+
+fun /(int x, int y) -> int
+  intrinsic{int_div_int}(x, y)
+
+fun %(int x, int y) -> int
+  intrinsic{int_rem_int}(x, y)
+
+fun <<(int x, int y) -> int
+  intrinsic{int_shiftleft}(x, y)
+
+fun >>(int x, int y) -> int
+  intrinsic{int_shiftright}(x, y)
+
+fun &(int x, int y) -> int
+  intrinsic{int_and_int}(x, y)
+
+fun |(int x, int y) -> int
+  intrinsic{int_or_int}(x, y)
+
+fun ^(int x, int y) -> int
+  intrinsic{int_xor_int}(x, y)
+
 fun ==(int x, int y) -> bool
   intrinsic{int_eq_int}(x, y)
 

--- a/std/prim/long.ns
+++ b/std/prim/long.ns
@@ -26,7 +26,16 @@ fun implicit long(char c)
 
 fun +(long l) l
 
+fun +(long x, long y) -> long
+  intrinsic{long_add_long}(x, y)
+
 fun ++(long l) l + 1L
+
+fun -(long x) -> long
+  intrinsic{long_neg}(x)
+
+fun -(long x, long y) -> long
+  intrinsic{long_sub_long}(x, y)
 
 fun --(long l) l - 1L
 

--- a/std/prim/long.ns
+++ b/std/prim/long.ns
@@ -39,6 +39,33 @@ fun -(long x, long y) -> long
 
 fun --(long l) l - 1L
 
+fun ~(long x) -> long
+  intrinsic{long_inv}(x)
+
+fun *(long x, long y) -> long
+  intrinsic{long_mul_long}(x, y)
+
+fun /(long x, long y) -> long
+  intrinsic{long_div_long}(x, y)
+
+fun %(long x, long y) -> long
+  intrinsic{long_rem_long}(x, y)
+
+fun <<(long x, int y) -> long
+  intrinsic{long_shiftleft}(x, y)
+
+fun >>(long x, int y) -> long
+  intrinsic{long_shiftright}(x, y)
+
+fun &(long x, long y) -> long
+  intrinsic{long_and_long}(x, y)
+
+fun |(long x, long y) -> long
+  intrinsic{long_or_long}(x, y)
+
+fun ^(long x, long y) -> long
+  intrinsic{long_xor_long}(x, y)
+
 fun ==(long x, long y) -> bool
   intrinsic{long_eq_long}(x, y)
 

--- a/std/prim/long.ns
+++ b/std/prim/long.ns
@@ -32,3 +32,9 @@ fun --(long l) l - 1L
 
 fun ==(long x, long y) -> bool
   intrinsic{long_eq_long}(x, y)
+
+fun <(long x, long y) -> bool
+  intrinsic{long_le_long}(x, y)
+
+fun >(long x, long y) -> bool
+  intrinsic{long_gt_long}(x, y)

--- a/std/prim/long.ns
+++ b/std/prim/long.ns
@@ -20,7 +20,7 @@ fun implicit long(int i)
   intrinsic{int_to_long}(i)
 
 fun implicit long(char c)
-  intrinsic{char_to_long}(c)
+  intrinsic{int_to_long}(intrinsic{char_as_int}(c))
 
 // -- Operators
 

--- a/std/prim/string.ns
+++ b/std/prim/string.ns
@@ -60,6 +60,12 @@ fun +(string x, string y) -> string
 fun +(string x, char y) -> string
   intrinsic{string_add_char}(x, y)
 
+fun [](string s, int index) -> char
+  intrinsic{string_index}(s, index)
+
+fun [](string s, int start, int end) -> string
+  intrinsic{string_slice}(s, start, end)
+
 fun ==(string x, string y) -> bool
   intrinsic{string_eq_string}(x, y)
 

--- a/std/prim/string.ns
+++ b/std/prim/string.ns
@@ -54,6 +54,12 @@ fun string(long i, int minDigits)
 fun +{T}(string s, T v)
   s + v.string()
 
+fun +(string x, string y) -> string
+  intrinsic{string_add_string}(x, y)
+
+fun +(string x, char y) -> string
+  intrinsic{string_add_char}(x, y)
+
 fun ==(string x, string y) -> bool
   intrinsic{string_eq_string}(x, y)
 

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -90,7 +90,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
           asmb->addNegLong();
           asmb->addNegLong();
         });
-    CHECK_EXPR_LONG("~42L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_inv}(42L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(42);
       asmb->addInvLong();
     });
@@ -104,42 +104,42 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitLong(3);
       asmb->addSubLong();
     });
-    CHECK_EXPR_LONG("1L * 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_mul_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addMulLong();
     });
-    CHECK_EXPR_LONG("1L / 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_div_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addDivLong();
     });
-    CHECK_EXPR_LONG("1L % 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_rem_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addRemLong();
     });
-    CHECK_EXPR_LONG("1L << 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_shiftleft}(1L, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftLeftLong();
     });
-    CHECK_EXPR_LONG("1L >> 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_shiftright}(1L, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftRightLong();
     });
-    CHECK_EXPR_LONG("1L & 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_and_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addAndLong();
     });
-    CHECK_EXPR_LONG("1L | 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_or_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addOrLong();
     });
-    CHECK_EXPR_LONG("1L ^ 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_xor_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addXorLong();

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -16,7 +16,7 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
           asmb->addNegInt();
           asmb->addNegInt();
         });
-    CHECK_EXPR_INT("~42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_inv}(42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(42);
       asmb->addInvInt();
     });
@@ -37,42 +37,42 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitInt(3);
       asmb->addSubInt();
     });
-    CHECK_EXPR_INT("1 * 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_mul_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addMulInt();
     });
-    CHECK_EXPR_INT("1 / 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_div_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addDivInt();
     });
-    CHECK_EXPR_INT("1 % 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_rem_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addRemInt();
     });
-    CHECK_EXPR_INT("1 << 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_shiftleft}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftLeftInt();
     });
-    CHECK_EXPR_INT("1 >> 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_shiftright}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftRightInt();
     });
-    CHECK_EXPR_INT("1 & 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_and_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addAndInt();
     });
-    CHECK_EXPR_INT("1 | 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_or_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addOrInt();
     });
-    CHECK_EXPR_INT("1 ^ 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_xor_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addXorInt();

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -6,16 +6,17 @@ namespace backend {
 TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
 
   SECTION("Int operations") {
-    CHECK_EXPR("-42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_neg}(42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(42);
       asmb->addNegInt();
     });
-    CHECK_EXPR("- -42", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(42);
-      asmb->addNegInt();
-      asmb->addNegInt();
-    });
-    CHECK_EXPR("~42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT(
+        "intrinsic{int_neg}(intrinsic{int_neg}(42))", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitInt(42);
+          asmb->addNegInt();
+          asmb->addNegInt();
+        });
+    CHECK_EXPR_INT("~42", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(42);
       asmb->addInvInt();
     });
@@ -24,53 +25,54 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitInt(3);
       asmb->addAddInt();
     });
-    CHECK_EXPR_INT("intrinsic{int_add_int}(-1, 3)", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addNegInt();
-      asmb->addLoadLitInt(3);
-      asmb->addAddInt();
-    });
+    CHECK_EXPR_INT(
+        "intrinsic{int_add_int}(intrinsic{int_neg}(1), 3)", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitInt(1);
+          asmb->addNegInt();
+          asmb->addLoadLitInt(3);
+          asmb->addAddInt();
+        });
     CHECK_EXPR_INT("intrinsic{int_sub_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addSubInt();
     });
-    CHECK_EXPR("1 * 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 * 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addMulInt();
     });
-    CHECK_EXPR("1 / 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 / 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addDivInt();
     });
-    CHECK_EXPR("1 % 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 % 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addRemInt();
     });
-    CHECK_EXPR("1 << 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 << 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftLeftInt();
     });
-    CHECK_EXPR("1 >> 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 >> 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftRightInt();
     });
-    CHECK_EXPR("1 & 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 & 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addAndInt();
     });
-    CHECK_EXPR("1 | 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 | 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addOrInt();
     });
-    CHECK_EXPR("1 ^ 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("1 ^ 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addXorInt();
@@ -78,71 +80,66 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("Long operations") {
-    CHECK_EXPR("-42L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_neg}(42L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(42);
       asmb->addNegLong();
     });
-    CHECK_EXPR("- -42L", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitLong(42);
-      asmb->addNegLong();
-      asmb->addNegLong();
-    });
-    CHECK_EXPR("~42L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG(
+        "intrinsic{long_neg}(intrinsic{long_neg}(42L))", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitLong(42);
+          asmb->addNegLong();
+          asmb->addNegLong();
+        });
+    CHECK_EXPR_LONG("~42L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(42);
       asmb->addInvLong();
     });
-    CHECK_EXPR("1L + 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_add_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addAddLong();
     });
-    CHECK_EXPR("-1L + 3L", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitLong(1);
-      asmb->addNegLong();
-      asmb->addLoadLitLong(3);
-      asmb->addAddLong();
-    });
-    CHECK_EXPR("1L - 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("intrinsic{long_sub_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addSubLong();
     });
-    CHECK_EXPR("1L * 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L * 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addMulLong();
     });
-    CHECK_EXPR("1L / 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L / 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addDivLong();
     });
-    CHECK_EXPR("1L % 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L % 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addRemLong();
     });
-    CHECK_EXPR("1L << 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L << 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftLeftLong();
     });
-    CHECK_EXPR("1L >> 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L >> 3", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitInt(3);
       asmb->addShiftRightLong();
     });
-    CHECK_EXPR("1L & 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L & 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addAndLong();
     });
-    CHECK_EXPR("1L | 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L | 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addOrLong();
     });
-    CHECK_EXPR("1L ^ 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_LONG("1L ^ 3L", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addXorLong();
@@ -150,16 +147,16 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("Float operations") {
-    CHECK_EXPR_FLOAT("-.1337", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_FLOAT("intrinsic{float_neg}(.1337)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(0.1337F);
       asmb->addNegFloat();
     });
-    CHECK_EXPR_FLOAT("1.42 + 3.42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_FLOAT("intrinsic{float_add_float}(1.42, 3.42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addAddFloat();
     });
-    CHECK_EXPR_FLOAT("1.42 - 3.42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_FLOAT("intrinsic{float_sub_float}(1.42, 3.42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addSubFloat();
@@ -216,12 +213,13 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitInt(3);
       asmb->addCheckEqInt();
     });
-    CHECK_EXPR_BOOL("intrinsic{int_eq_int}(1, -3)", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addLoadLitInt(3);
-      asmb->addNegInt();
-      asmb->addCheckEqInt();
-    });
+    CHECK_EXPR_BOOL(
+        "intrinsic{int_eq_int}(1, intrinsic{int_neg}(3))", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitInt(1);
+          asmb->addLoadLitInt(3);
+          asmb->addNegInt();
+          asmb->addCheckEqInt();
+        });
     CHECK_EXPR_BOOL("intrinsic{int_le_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
@@ -240,12 +238,14 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitLong(3);
       asmb->addCheckEqLong();
     });
-    CHECK_EXPR_BOOL("intrinsic{long_eq_long}(1L, -3L)", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitLong(1);
-      asmb->addLoadLitLong(3);
-      asmb->addNegLong();
-      asmb->addCheckEqLong();
-    });
+    CHECK_EXPR_BOOL(
+        "intrinsic{long_eq_long}(1L, intrinsic{long_neg}(3L))",
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitLong(1);
+          asmb->addLoadLitLong(3);
+          asmb->addNegLong();
+          asmb->addCheckEqLong();
+        });
     CHECK_EXPR_BOOL("intrinsic{long_le_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
@@ -277,17 +277,19 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
   }
 
   SECTION("String operations") {
-    CHECK_EXPR("\"hello\" + \"world\"", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitString("hello");
-      asmb->addLoadLitString("world");
-      asmb->addAddString();
-    });
+    CHECK_EXPR_STRING(
+        "intrinsic{string_add_string}(\"hello\", \"world\")", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("hello");
+          asmb->addLoadLitString("world");
+          asmb->addAddString();
+        });
 
-    CHECK_EXPR("\"hello worl\" + 'd'", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitString("hello worl");
-      asmb->addLoadLitInt('d');
-      asmb->addAppendChar();
-    });
+    CHECK_EXPR_STRING(
+        "intrinsic{string_add_char}(\"hello worl\", 'd')", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("hello worl");
+          asmb->addLoadLitInt('d');
+          asmb->addAppendChar();
+        });
 
     CHECK_EXPR_INT("intrinsic{string_length}(\"hello\")", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitString("hello");

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -333,10 +333,6 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitInt(42);
       asmb->addConvIntLong();
     });
-    CHECK_EXPR_LONG("intrinsic{char_to_long}('a')", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt('a');
-      asmb->addConvIntLong();
-    });
     CHECK_EXPR_STRING("intrinsic{int_to_string}(42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(42);
       asmb->addConvIntString();

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -161,17 +161,17 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitFloat(3.42F);
       asmb->addSubFloat();
     });
-    CHECK_EXPR_FLOAT("1.42 * 3.42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_FLOAT("intrinsic{float_mul_float}(1.42, 3.42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addMulFloat();
     });
-    CHECK_EXPR_FLOAT("1.42 / 3.42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_FLOAT("intrinsic{float_div_float}(1.42, 3.42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addDivFloat();
     });
-    CHECK_EXPR_FLOAT("6.0 % 2.0", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_FLOAT("intrinsic{float_mod_float}(6.0, 2.0)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(6.0F);
       asmb->addLoadLitFloat(2.0F);
       asmb->addModFloat();

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -296,17 +296,19 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLengthString();
     });
 
-    CHECK_EXPR("\"hello world\"[6]", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitString("hello world");
-      asmb->addLoadLitInt(6);
-      asmb->addIndexString();
-    });
-    CHECK_EXPR("\"hello world\"[0, 6]", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitString("hello world");
-      asmb->addLoadLitInt(0);
-      asmb->addLoadLitInt(6);
-      asmb->addSliceString();
-    });
+    CHECK_EXPR_CHAR(
+        "intrinsic{string_index}(\"hello world\", 6)", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("hello world");
+          asmb->addLoadLitInt(6);
+          asmb->addIndexString();
+        });
+    CHECK_EXPR_STRING(
+        "intrinsic{string_slice}(\"hello world\", 0, 6)", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitString("hello world");
+          asmb->addLoadLitInt(0);
+          asmb->addLoadLitInt(6);
+          asmb->addSliceString();
+        });
   }
 
   SECTION("String checks") {

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -222,27 +222,15 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addNegInt();
       asmb->addCheckEqInt();
     });
-    CHECK_EXPR("1 < 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{int_le_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addCheckLeInt();
     });
-    CHECK_EXPR("1 <= 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{int_gt_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addCheckGtInt();
-      asmb->addCheckIntZero(); // Invert.
-    });
-    CHECK_EXPR("1 > 3", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addLoadLitInt(3);
-      asmb->addCheckGtInt();
-    });
-    CHECK_EXPR("1 >= 3", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitInt(1);
-      asmb->addLoadLitInt(3);
-      asmb->addCheckLeInt();
-      asmb->addCheckIntZero(); // Invert.
     });
   }
 
@@ -258,27 +246,15 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addNegLong();
       asmb->addCheckEqLong();
     });
-    CHECK_EXPR("1L < 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{long_le_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addCheckLeLong();
     });
-    CHECK_EXPR("1L <= 3L", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{long_gt_long}(1L, 3L)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitLong(1);
       asmb->addLoadLitLong(3);
       asmb->addCheckGtLong();
-      asmb->addCheckIntZero(); // Invert.
-    });
-    CHECK_EXPR("1L > 3L", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitLong(1);
-      asmb->addLoadLitLong(3);
-      asmb->addCheckGtLong();
-    });
-    CHECK_EXPR("1L >= 3L", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitLong(1);
-      asmb->addLoadLitLong(3);
-      asmb->addCheckLeLong();
-      asmb->addCheckIntZero(); // Invert.
     });
   }
 
@@ -288,27 +264,15 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitFloat(3.42F);
       asmb->addCheckEqFloat();
     });
-    CHECK_EXPR("1.42 < 3.42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{float_le_float}(1.42, 3.42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addCheckLeFloat();
     });
-    CHECK_EXPR("1.42 <= 3.42", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_BOOL("intrinsic{float_gt_float}(1.42, 3.42)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitFloat(1.42F);
       asmb->addLoadLitFloat(3.42F);
       asmb->addCheckGtFloat();
-      asmb->addCheckIntZero(); // Invert.
-    });
-    CHECK_EXPR("1.42 > 3.42", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitFloat(1.42F);
-      asmb->addLoadLitFloat(3.42F);
-      asmb->addCheckGtFloat();
-    });
-    CHECK_EXPR("1.42 >= 3.42", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitFloat(1.42F);
-      asmb->addLoadLitFloat(3.42F);
-      asmb->addCheckLeFloat();
-      asmb->addCheckIntZero(); // Invert.
     });
   }
 

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -19,18 +19,18 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitInt(42);
       asmb->addInvInt();
     });
-    CHECK_EXPR("1 + 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_add_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addAddInt();
     });
-    CHECK_EXPR("-1 + 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_add_int}(-1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addNegInt();
       asmb->addLoadLitInt(3);
       asmb->addAddInt();
     });
-    CHECK_EXPR("1 - 3", [](novasm::Assembler* asmb) -> void {
+    CHECK_EXPR_INT("intrinsic{int_sub_int}(1, 3)", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt(1);
       asmb->addLoadLitInt(3);
       asmb->addSubInt();

--- a/tests/backend/call_self_expr_test.cpp
+++ b/tests/backend/call_self_expr_test.cpp
@@ -6,29 +6,31 @@ namespace backend {
 TEST_CASE("[backend] Generate assembly for self call expressions", "backend") {
 
   SECTION("Function") {
-    CHECK_PROG("fun f(int i) i < 0 ? self(0) : i ", [](novasm::Assembler* asmb) -> void {
-      // Function.
-      asmb->label("func");
-      asmb->addStackLoad(0); // Load arg 'i'.
-      asmb->addLoadLitInt(0);
-      asmb->addCheckLeInt();
-      asmb->addJumpIf("less");
+    CHECK_PROG(
+        "fun f(int i) intrinsic{int_le_int}(i, 0) ? self(0) : i ",
+        [](novasm::Assembler* asmb) -> void {
+          // Function.
+          asmb->label("func");
+          asmb->addStackLoad(0); // Load arg 'i'.
+          asmb->addLoadLitInt(0);
+          asmb->addCheckLeInt();
+          asmb->addJumpIf("less");
 
-      asmb->addStackLoad(0); // Load arg 'i'.
-      asmb->addJump("end");
+          asmb->addStackLoad(0); // Load arg 'i'.
+          asmb->addJump("end");
 
-      asmb->label("less");
-      asmb->addLoadLitInt(0);
-      asmb->addCall("func", 1, novasm::CallMode::Tail);
+          asmb->label("less");
+          asmb->addLoadLitInt(0);
+          asmb->addCall("func", 1, novasm::CallMode::Tail);
 
-      asmb->label("end");
-      asmb->addRet();
+          asmb->label("end");
+          asmb->addRet();
 
-      // Entry point.
-      asmb->setEntrypoint("entry");
-      asmb->label("entry");
-      asmb->addRet();
-    });
+          // Entry point.
+          asmb->setEntrypoint("entry");
+          asmb->label("entry");
+          asmb->addRet();
+        });
   }
 
   SECTION("Closure") {

--- a/tests/backend/constants_test.cpp
+++ b/tests/backend/constants_test.cpp
@@ -26,19 +26,20 @@ TEST_CASE("[backend] Generate assembly for storing and loading constants", "back
     asmb->addStackLoad(0);
   });
 
-  CHECK_EXPR("x = 42; y = 1337; x + y", [](novasm::Assembler* asmb) -> void {
-    asmb->addStackAlloc(2);
+  CHECK_EXPR_INT(
+      "x = 42; y = 1337; intrinsic{int_add_int}(x, y)", [](novasm::Assembler* asmb) -> void {
+        asmb->addStackAlloc(2);
 
-    asmb->addLoadLitInt(42);
-    asmb->addStackStore(0);
+        asmb->addLoadLitInt(42);
+        asmb->addStackStore(0);
 
-    asmb->addLoadLitInt(1337);
-    asmb->addStackStore(1);
+        asmb->addLoadLitInt(1337);
+        asmb->addStackStore(1);
 
-    asmb->addStackLoad(0);
-    asmb->addStackLoad(1);
-    asmb->addAddInt();
-  });
+        asmb->addStackLoad(0);
+        asmb->addStackLoad(1);
+        asmb->addAddInt();
+      });
 
   CHECK_EXPR("x = y = 42; y", [](novasm::Assembler* asmb) -> void {
     asmb->addStackAlloc(2);

--- a/tests/backend/tail_calls_test.cpp
+++ b/tests/backend/tail_calls_test.cpp
@@ -7,7 +7,7 @@ TEST_CASE("[backend] Generate assembly for tail calls", "backend") {
 
   SECTION("Tail recursion") {
     CHECK_PROG(
-        "fun test(int a) -> int a > 0 ? test(0) : a "
+        "fun test(int a) -> int intrinsic{int_gt_int}(a, 0) ? test(0) : a "
         "test(42)",
         [](novasm::Assembler* asmb) -> void {
           asmb->label("test");

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -59,12 +59,14 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
     }
 
     SECTION("Declare templated conversion function") {
-      const auto& output = ANALYZE("fun string(int i) intrinsic{int_to_string}(i) "
-                                   "fun string(bool b) b ? \"true\" : \"false\" "
-                                   "struct Tuple{T, Y} = T a, Y b "
-                                   "fun string{T, Y}(Tuple{T, Y} t) "
-                                   " t.a.string() + \",\" + t.b.string() "
-                                   "fun f() string{int, bool}(Tuple{int, bool}(42, false))");
+      const auto& output =
+          ANALYZE("fun +(string x, string y) -> string intrinsic{string_add_string}(x, y) "
+                  "fun string(int i) intrinsic{int_to_string}(i) "
+                  "fun string(bool b) b ? \"true\" : \"false\" "
+                  "struct Tuple{T, Y} = T a, Y b "
+                  "fun string{T, Y}(Tuple{T, Y} t) "
+                  " t.a.string() + \",\" + t.b.string() "
+                  "fun f() string{int, bool}(Tuple{int, bool}(42, false))");
       REQUIRE(output.isSuccess());
       CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "string"));
       CHECK(
@@ -169,7 +171,6 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
         errIncorrectReturnTypeInConvFunc(NO_SRC, "s{int}", "int"),
         errInvalidFuncInstantiation(NO_SRC),
         errNoTypeOrConversionFoundToInstantiate(NO_SRC, "s", 1));
-    CHECK_DIAG("fun -(int i) -> int 1", errDuplicateFuncDeclaration(NO_SRC, "operator-"));
     CHECK_DIAG("fun &&() -> int 1", errNonOverloadableOperator(NO_SRC, "&&"));
     CHECK_DIAG("fun f{int}() -> int 1", errTypeParamNameConflictsWithType(NO_SRC, "int"));
     CHECK_DIAG(

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -118,8 +118,8 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
           errPureFuncInfRecursion(NO_SRC));
       CHECK_DIAG(
           "fun f(int a, int b) -> int "
-          " if a > b  -> f(a, 0) "
-          " else      -> f(0, b)",
+          " if intrinsic{int_le_int}(a, b) -> f(a, 0) "
+          " else                           -> f(0, b)",
           errPureFuncInfRecursion(NO_SRC));
       CHECK_DIAG("fun f(int a = a) a", errUndeclaredConst(NO_SRC, "a"));
       CHECK_DIAG("fun f(int a = b = 42) a", errConstDeclareNotSupported(NO_SRC));

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -105,8 +105,10 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
 
       CHECK_DIAG("fun f() -> int f()", errPureFuncInfRecursion(NO_SRC));
       CHECK_DIAG("fun f() -> int a = f()", errPureFuncInfRecursion(NO_SRC));
-      CHECK_DIAG("fun f(int i) -> int i + f(i)", errPureFuncInfRecursion(NO_SRC));
       CHECK_DIAG(
+          "fun f(int i) -> int intrinsic{int_add_int}(i, f(i))", errPureFuncInfRecursion(NO_SRC));
+      CHECK_DIAG(
+          "fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
           "fun f(int a, int b) -> int "
           " a2 = 42; b2 = 1337; f(a + a2, b + b2)",
           errPureFuncInfRecursion(NO_SRC));

--- a/tests/frontend/define_user_funcs_test.cpp
+++ b/tests/frontend/define_user_funcs_test.cpp
@@ -87,6 +87,7 @@ TEST_CASE("[frontend] Analyzing user-function definitions", "frontend") {
         errInvalidFuncInstantiation(NO_SRC),
         errNoPureFuncFoundToInstantiate(NO_SRC, "f", 1));
     CHECK_DIAG(
+        "fun *(int x, int y) -> int intrinsic{int_mul_int}(x, y) "
         "fun f{T}(T i) -> T "
         "  T = i * 2; i "
         "fun f2() -> int f{int}(1)",

--- a/tests/frontend/get_binary_expr_test.cpp
+++ b/tests/frontend/get_binary_expr_test.cpp
@@ -32,8 +32,10 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
   }
 
   SECTION("Get binary expression with conversion on lhs") {
-    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun f(float a) 2 * a");
+    const auto& output =
+        ANALYZE("fun *(float x, float y) -> float intrinsic{float_mul_float}(x, y) "
+                "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "fun f(float a) 2 * a");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "float"));
 
@@ -53,8 +55,10 @@ TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
   }
 
   SECTION("Get binary expression with conversion on rhs") {
-    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun f(float a) a * 2");
+    const auto& output =
+        ANALYZE("fun *(float x, float y) -> float intrinsic{float_mul_float}(x, y) "
+                "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "fun f(float a) a * 2");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "float"));
 

--- a/tests/frontend/get_binary_expr_test.cpp
+++ b/tests/frontend/get_binary_expr_test.cpp
@@ -14,7 +14,8 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing binary expressions", "frontend") {
 
   SECTION("Get basic binary expression") {
-    const auto& output = ANALYZE("fun f(int a) -> int 1 * a");
+    const auto& output = ANALYZE("fun *(int x, int y) -> int intrinsic{int_mul_int}(x, y) "
+                                 "fun f(int a) -> int 1 * a");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"));
 

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -104,7 +104,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
   }
 
   SECTION("Get lazy call to overloaded call operator on literal") {
-    const auto& output = ANALYZE("fun ()(int i) -> int i * i "
+    const auto& output = ANALYZE("fun ()(int i) -> int intrinsic{int_mul_int}(i, i) "
                                  "fun f() -> lazy{int} lazy 1()");
     REQUIRE(output.isSuccess());
 
@@ -119,7 +119,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
   }
 
   SECTION("Get call to overloaded call operator on literal") {
-    const auto& output = ANALYZE("fun ()(int i) -> int i * i "
+    const auto& output = ANALYZE("fun ()(int i) -> int intrinsic{int_mul_int}(i, i) "
                                  "fun f() -> int 1()");
     REQUIRE(output.isSuccess());
 
@@ -132,7 +132,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
   }
 
   SECTION("Get call to overloaded call operator on const") {
-    const auto& output = ANALYZE("fun ()(int i) -> int i * i "
+    const auto& output = ANALYZE("fun ()(int i) -> int intrinsic{int_mul_int}(i, i) "
                                  "fun f(int i) -> int i()");
     REQUIRE(output.isSuccess());
 
@@ -285,6 +285,7 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
         "fun f2() -> int a{int}()",
         errNoPureFuncFoundToInstantiate(NO_SRC, "a", 1));
     CHECK_DIAG(
+        "fun *(int x, int y) -> int intrinsic{int_mul_int}(x, y) "
         "act a(int i) -> int i * 2 "
         "fun f2(int i) -> int i.a()",
         errUndeclaredPureFunc(NO_SRC, "a", {"int"}));

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -21,7 +21,8 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
   }
 
   SECTION("Get call with arg") {
-    const auto& output = ANALYZE("fun f1(int a) -> int a + 1 "
+    const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                 "fun f1(int a) -> int a + 1 "
                                  "fun f2() -> int f1(1)");
     REQUIRE(output.isSuccess());
 

--- a/tests/frontend/get_call_expr_test.cpp
+++ b/tests/frontend/get_call_expr_test.cpp
@@ -164,9 +164,11 @@ TEST_CASE("[frontend] Analyzing call expressions", "frontend") {
   }
 
   SECTION("Get instance call with args") {
-    const auto& output = ANALYZE("fun string(int i) intrinsic{int_to_string}(i) "
-                                 "fun f1(int i, string v) -> string i.string() + v "
-                                 "fun f2(int i) -> string i.f1(\"test\")");
+    const auto& output =
+        ANALYZE("fun +(string x, string y) -> string intrinsic{string_add_string}(x, y) "
+                "fun string(int i) intrinsic{int_to_string}(i) "
+                "fun f1(int i, string v) -> string i.string() + v "
+                "fun f2(int i) -> string i.f1(\"test\")");
     REQUIRE(output.isSuccess());
 
     const auto& fDef   = GET_FUNC_DEF(output, "f2", GET_TYPE_ID(output, "int"));

--- a/tests/frontend/get_call_self_expr_test.cpp
+++ b/tests/frontend/get_call_self_expr_test.cpp
@@ -40,13 +40,19 @@ TEST_CASE("[frontend] Analyzing self call expressions", "frontend") {
 
   SECTION("Diagnostics") {
     CHECK_DIAG("conWrite(self())", errSelfCallInNonFunc(NO_SRC));
-    CHECK_DIAG("fun f(int i) i < 0 ? fork self(0) : i", errForkedSelfCall(NO_SRC));
-    CHECK_DIAG("fun f(int i) i < 0 ? lazy self(0) : i", errLazySelfCall(NO_SRC));
-    CHECK_DIAG("fun f() self()", errSelfCallWithoutInferredRetType(NO_SRC));
-    CHECK_DIAG("fun f(int i) i < 0 ? self() : i", errIncorrectNumArgsInSelfCall(NO_SRC, 1, 0));
-    CHECK_DIAG("fun f(int i) i < 0 ? self(i, 1) : i", errIncorrectNumArgsInSelfCall(NO_SRC, 1, 2));
     CHECK_DIAG(
-        "fun f(int i) i < 0 ? self(\"hello\") : i",
+        "fun f(int i) intrinsic{int_le_int}(i, 0) ? fork self(0) : i", errForkedSelfCall(NO_SRC));
+    CHECK_DIAG(
+        "fun f(int i) intrinsic{int_le_int}(i, 0) ? lazy self(0) : i", errLazySelfCall(NO_SRC));
+    CHECK_DIAG("fun f() self()", errSelfCallWithoutInferredRetType(NO_SRC));
+    CHECK_DIAG(
+        "fun f(int i) intrinsic{int_le_int}(i, 0) ? self() : i",
+        errIncorrectNumArgsInSelfCall(NO_SRC, 1, 0));
+    CHECK_DIAG(
+        "fun f(int i) intrinsic{int_le_int}(i, 0) ? self(i, 1) : i",
+        errIncorrectNumArgsInSelfCall(NO_SRC, 1, 2));
+    CHECK_DIAG(
+        "fun f(int i) intrinsic{int_le_int}(i, 0) ? self(\"hello\") : i",
         errNoImplicitConversionFound(NO_SRC, "string", "int"));
   }
 }

--- a/tests/frontend/get_const_expr_test.cpp
+++ b/tests/frontend/get_const_expr_test.cpp
@@ -69,8 +69,8 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
         errUninitializedConst(NO_SRC, "b"));
     CHECK_DIAG(
         "fun f(int a) -> int "
-        "if b = a * a; intrinsic{int_le_int}(b, 5) -> b "
-        "else                                      -> b + 1",
+        "if b = intrinsic{int_mul_int}(a, a); intrinsic{int_le_int}(b, 5) -> b "
+        "else                                                             -> b + 1",
         errUninitializedConst(NO_SRC, "b"));
     CHECK_DIAG("fun f() -> int (true && (x = 5; false)); x", errUninitializedConst(NO_SRC, "x"));
   }

--- a/tests/frontend/get_const_expr_test.cpp
+++ b/tests/frontend/get_const_expr_test.cpp
@@ -59,18 +59,18 @@ TEST_CASE("[frontend] Analyzing constant expressions", "frontend") {
     CHECK_DIAG("fun f(int a) -> int a = 42", errConstNameConflictsWithConst(NO_SRC, "a"));
     CHECK_DIAG(
         "fun f(int a) -> int "
-        "if a > 5  -> b = 1 "
-        "else      -> b = 2",
+        "if intrinsic{int_le_int}(a, 5) -> b = 1 "
+        "else                           -> b = 2",
         errConstNameConflictsWithConst(NO_SRC, "b"));
     CHECK_DIAG(
         "fun f(int a) -> int "
-        "if a > 5  -> b = 1 "
-        "else      -> b + 1",
+        "if intrinsic{int_gt_int}(a, 5) -> b = 1 "
+        "else                           -> b + 1",
         errUninitializedConst(NO_SRC, "b"));
     CHECK_DIAG(
         "fun f(int a) -> int "
-        "if b = a * a; b > 5  -> b "
-        "else                 -> b + 1",
+        "if b = a * a; intrinsic{int_le_int}(b, 5) -> b "
+        "else                                      -> b + 1",
         errUninitializedConst(NO_SRC, "b"));
     CHECK_DIAG("fun f() -> int (true && (x = 5; false)); x", errUninitializedConst(NO_SRC, "x"));
   }

--- a/tests/frontend/get_group_expr_test.cpp
+++ b/tests/frontend/get_group_expr_test.cpp
@@ -12,7 +12,8 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing group expressions", "frontend") {
 
   SECTION("Get basic group expression") {
-    const auto& output = ANALYZE("fun f() b = 1; c = 2; b * c");
+    const auto& output = ANALYZE("fun *(int x, int y) -> int intrinsic{int_mul_int}(x, y) "
+                                 "fun f() b = 1; c = 2; b * c");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f");
     const auto& consts  = funcDef.getConsts();

--- a/tests/frontend/get_paren_expr_test.cpp
+++ b/tests/frontend/get_paren_expr_test.cpp
@@ -9,7 +9,8 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing parenthesized expressions", "frontend") {
 
   SECTION("Get basic paren expression") {
-    const auto& output = ANALYZE("fun f(int a, int b) ((a) + (b))");
+    const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                 "fun f(int a, int b) ((a) + (b))");
     REQUIRE(output.isSuccess());
     const auto& funcDef =
         GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"), GET_TYPE_ID(output, "int"));

--- a/tests/frontend/get_unary_expr_test.cpp
+++ b/tests/frontend/get_unary_expr_test.cpp
@@ -10,7 +10,8 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing unary expressions", "frontend") {
 
   SECTION("Get basic unary expression") {
-    const auto& output = ANALYZE("fun f(int a) -> int -a");
+    const auto& output = ANALYZE("fun -(int x) -> int intrinsic{int_neg}(x) "
+                                 "fun f(int a) -> int -a");
     REQUIRE(output.isSuccess());
     const auto& funcDef = GET_FUNC_DEF(output, "f", GET_TYPE_ID(output, "int"));
 

--- a/tests/frontend/opt_args_test.cpp
+++ b/tests/frontend/opt_args_test.cpp
@@ -86,7 +86,8 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Call a function with an optional argument") {
-      const auto& output = ANALYZE("fun fa(int a, int b = 1 + 2) a + b "
+      const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                   "fun fa(int a, int b = 1 + 2) a + b "
                                    "fun fb() fa(2)");
       REQUIRE(output.isSuccess());
       CHECK(
@@ -246,6 +247,7 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
           errNoPureFuncFoundToInstantiate(NO_SRC, "ft", 1));
 
       CHECK_DIAG(
+          "fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
           "fun ft{T}(T a = T(), T b) a + b "
           "fun f() ft{int}()",
           errNonOptArgFollowingOpt(NO_SRC),

--- a/tests/frontend/opt_args_test.cpp
+++ b/tests/frontend/opt_args_test.cpp
@@ -27,8 +27,10 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Declare a function with a normal argument and a optional argument") {
-      const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                   "fun f(float a, int b = 0) a + b");
+      const auto& output =
+          ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                  "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                  "fun f(float a, int b = 0) a + b");
       REQUIRE(output.isSuccess());
 
       const auto& funcDecl =
@@ -110,9 +112,11 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Call a function with an optional argument with a conversion") {
-      const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                   "fun fa(int a, float b = 2) a + b "
-                                   "fun fb() fa(2)");
+      const auto& output =
+          ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                  "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                  "fun fa(int a, float b = 2) a + b "
+                  "fun fb() fa(2)");
       REQUIRE(output.isSuccess());
       CHECK(
           GET_FUNC_DEF(output, "fb").getBody() ==
@@ -177,12 +181,14 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Type parameter can be inferred from an initializer") {
-      const auto& output = ANALYZE("fun implicit int(char c) intrinsic{char_as_int}(c) "
-                                   "fun string(int i) intrinsic{int_to_string}(i) "
-                                   "fun ft{TX, TY}(TX a = \"World\", TY b = 'W') a + string(b) "
-                                   "fun f1() ft() "
-                                   "fun f2() ft(\"Hello\", 42) "
-                                   "fun f3() ft(\"Hello\")");
+      const auto& output =
+          ANALYZE("fun +(string x, string y) -> string intrinsic{string_add_string}(x, y) "
+                  "fun implicit int(char c) intrinsic{char_as_int}(c) "
+                  "fun string(int i) intrinsic{int_to_string}(i) "
+                  "fun ft{TX, TY}(TX a = \"World\", TY b = 'W') a + string(b) "
+                  "fun f1() ft() "
+                  "fun f2() ft(\"Hello\", 42) "
+                  "fun f3() ft(\"Hello\")");
       REQUIRE(output.isSuccess());
 
       const auto& funcT1Decl = GET_FUNC_DECL(

--- a/tests/frontend/opt_args_test.cpp
+++ b/tests/frontend/opt_args_test.cpp
@@ -73,7 +73,7 @@ TEST_CASE("[frontend] Analyzing optional argument", "frontend") {
     }
 
     SECTION("Declare a function with an optional arg initializer that calls an intrinsic") {
-      const auto& output = ANALYZE("act a(long time = intrinsic{clock_nanosteady}()) time * 2L");
+      const auto& output = ANALYZE("act a(long time = intrinsic{clock_nanosteady}()) time");
       REQUIRE(output.isSuccess());
 
       const auto& funcDecl = GET_FUNC_DECL(output, "a", GET_TYPE_ID(output, "long"));

--- a/tests/frontend/overload_test.cpp
+++ b/tests/frontend/overload_test.cpp
@@ -34,10 +34,12 @@ TEST_CASE("[frontend] Analyzing overloads", "frontend") {
   }
 
   SECTION("Allow conversion in binary operator") {
-    const auto& output = ANALYZE("fun ==(float x, float y) -> bool intrinsic{float_eq_float}(x, y) "
-                                 "fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun a(bool b) b "
-                                 "a(1.0 / 2 == .5)");
+    const auto& output =
+        ANALYZE("fun /(float x, float y) -> float intrinsic{float_div_float}(x, y) "
+                "fun ==(float x, float y) -> bool intrinsic{float_eq_float}(x, y) "
+                "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "fun a(bool b) b "
+                "a(1.0 / 2 == .5)");
     REQUIRE(output.isSuccess());
   }
 

--- a/tests/frontend/overload_test.cpp
+++ b/tests/frontend/overload_test.cpp
@@ -6,9 +6,11 @@ namespace frontend {
 TEST_CASE("[frontend] Analyzing overloads", "frontend") {
 
   SECTION("Allow conversion") {
-    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun f1(float a, float b) a + b "
-                                 "fun f2() f1(42, 1337)");
+    const auto& output =
+        ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "fun f1(float a, float b) a + b "
+                "fun f2() f1(42, 1337)");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DEF(output, "f2").getBody().getType() == GET_TYPE_ID(output, "float"));
   }

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -313,14 +313,14 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Lazy call operator") {
-    const auto& output = ANALYZE("fun ()(int x, int y) x * y "
+    const auto& output = ANALYZE("fun ()(int x, int y) -> int intrinsic{int_mul_int}(x, y) "
                                  "fun f() lazy 42(1337)");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "__lazy_int"));
   }
 
   SECTION("Instance function call") {
-    const auto& output = ANALYZE("fun double(int i) i * 2 "
+    const auto& output = ANALYZE("fun double(int i) -> int intrinsic{int_mul_int}(i, 2) "
                                  "fun f() (42).double()");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "int"));

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -132,7 +132,7 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
 
   SECTION("Conditional operator") {
     const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun f() 1 > 2 ? 42 : 1337.0");
+                                 "fun f() intrinsic{int_le_int}(1, 2) ? 42 : 1337.0");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "float"));
   }
@@ -140,8 +140,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   SECTION("Switch") {
     const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
                                  "fun f() "
-                                 "if 1 > 2  -> 1 "
-                                 "else      -> 2.0");
+                                 "if intrinsic{int_gt_int}(1, 2) -> 1 "
+                                 "else                           -> 2.0");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "float"));
   }
@@ -189,7 +189,7 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Recursive templated call") {
-    const auto& output = ANALYZE("fun ft{T}(T a) a < 0 ? ft(-a) : a "
+    const auto& output = ANALYZE("fun ft{T}(T a) intrinsic{int_le_int}(a, 0) ? ft(-a) : a "
                                  "fun f(int i) ft{int}(i)");
     REQUIRE(output.isSuccess());
     CHECK(

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -126,7 +126,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Unary operator") {
-    const auto& output = ANALYZE("fun f() -42");
+    const auto& output = ANALYZE("fun -(int x) -> int intrinsic{int_neg}(x) "
+                                 "fun f() -42");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "int"));
   }
@@ -190,7 +191,7 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Recursive templated call") {
-    const auto& output = ANALYZE("fun ft{T}(T a) intrinsic{int_le_int}(a, 0) ? ft(-a) : a "
+    const auto& output = ANALYZE("fun ft{T}(T a) intrinsic{int_le_int}(a, 0) ? ft(a) : a "
                                  "fun f(int i) ft{int}(i)");
     REQUIRE(output.isSuccess());
     CHECK(
@@ -326,9 +327,11 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Instance function call with arguments") {
-    const auto& output = ANALYZE("fun string(int i) intrinsic{int_to_string}(i) "
-                                 "fun test(int a, string b) a.string() + b "
-                                 "fun f() (42).test(\"test\")");
+    const auto& output =
+        ANALYZE("fun +(string x, string y) -> string intrinsic{string_add_string}(x, y) "
+                "fun string(int i) intrinsic{int_to_string}(i) "
+                "fun test(int a, string b) a.string() + b "
+                "fun f() (42).test(\"test\")");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "string"));
   }
@@ -396,7 +399,9 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Anonymous function with closure") {
-    const auto& output = ANALYZE("fun f(float a) lambda (float b) b + a");
+    const auto& output =
+        ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                "fun f(float a) lambda (float b) b + a");
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float")).getOutput() ==
@@ -404,7 +409,9 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Anonymous function with nested closure") {
-    const auto& output = ANALYZE("fun f(float a) lambda (float b) (lambda () b + a)");
+    const auto& output =
+        ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                "fun f(float a) lambda (float b) (lambda () b + a)");
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float")).getOutput() ==
@@ -412,7 +419,9 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Anonymous function call with closure") {
-    const auto& output = ANALYZE("fun f(float a) (lambda (float b) b + a)(42.0)");
+    const auto& output =
+        ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                "fun f(float a) (lambda (float b) b + a)(42.0)");
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "float")).getOutput() ==

--- a/tests/frontend/typeinfer_user_funcs_test.cpp
+++ b/tests/frontend/typeinfer_user_funcs_test.cpp
@@ -119,7 +119,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Binary operator") {
-    const auto& output = ANALYZE("fun f() 42 + 1337");
+    const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                 "fun f() 42 + 1337");
     REQUIRE(output.isSuccess());
     CHECK(GET_FUNC_DECL(output, "f").getOutput() == GET_TYPE_ID(output, "int"));
   }
@@ -284,7 +285,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Index operator") {
-    const auto& output = ANALYZE("struct s = int a "
+    const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                 "struct s = int a "
                                  "fun [](s a, int i) a.a + i "
                                  "fun f(s a) a[0]");
     REQUIRE(output.isSuccess());
@@ -418,7 +420,8 @@ TEST_CASE("[frontend] Infer return type of user functions", "frontend") {
   }
 
   SECTION("Anonymous function call with nested closure") {
-    const auto& output = ANALYZE("fun f(int a) (lambda (int b) (lambda () b + a))(42)");
+    const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                 "fun f(int a) (lambda (int b) (lambda () b + a))(42)");
     REQUIRE(output.isSuccess());
     CHECK(
         GET_FUNC_DECL(output, "f", GET_TYPE_ID(output, "int")).getOutput() ==

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -52,10 +52,12 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Overload templated functions") {
-    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun ft{T}(int a, T b) -> int intrinsic{int_add_int}(a, b) "
-                                 "fun ft{T}(float a, T b) -> float a + b "
-                                 "fun f() -> float ft{int}(1.0, 2)");
+    const auto& output =
+        ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "fun ft{T}(int a, T b) -> int intrinsic{int_add_int}(a, b) "
+                "fun ft{T}(float a, T b) -> float a + b "
+                "fun f() -> float ft{int}(1.0, 2)");
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
@@ -122,10 +124,12 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Infer type-parameter in templated call") {
-    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun ft{T, Y}(T a, Y b) "
-                                 "  a + b "
-                                 "fun f() ft(2, 1.0)");
+    const auto& output =
+        ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "fun ft{T, Y}(T a, Y b) "
+                "  a + b "
+                "fun f() ft(2, 1.0)");
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");
@@ -141,10 +145,12 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Infer type-parameter supports implicit conversion") {
-    const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun ft{T}(T a, T b) "
-                                 "  a + b "
-                                 "fun f() ft(1.0, 2)");
+    const auto& output =
+        ANALYZE("fun +(float x, float y) -> float intrinsic{float_add_float}(x, y) "
+                "fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "fun ft{T}(T a, T b) "
+                "  a + b "
+                "fun f() ft(1.0, 2)");
     REQUIRE(output.isSuccess());
 
     const auto& fDef = GET_FUNC_DEF(output, "f");

--- a/tests/frontend/user_func_templates_test.cpp
+++ b/tests/frontend/user_func_templates_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Chained templated call") {
-    const auto& output = ANALYZE("fun ft1{T}(T a, T b) -> T a + b "
+    const auto& output = ANALYZE("fun ft1{T}(T a, T b) -> T intrinsic{int_add_int}(a, b) "
                                  "fun ft2{T}(T a) -> T ft1{T}(a, a) "
                                  "fun f() -> int ft2{int}(1)");
     REQUIRE(output.isSuccess());
@@ -53,8 +53,8 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
 
   SECTION("Overload templated functions") {
     const auto& output = ANALYZE("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                 "fun ft{T}(int a, T b) a + b "
-                                 "fun ft{T}(float a, T b) a + b "
+                                 "fun ft{T}(int a, T b) -> int intrinsic{int_add_int}(a, b) "
+                                 "fun ft{T}(float a, T b) -> float a + b "
                                  "fun f() -> float ft{int}(1.0, 2)");
     REQUIRE(output.isSuccess());
 
@@ -160,7 +160,8 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Infer type-parameter in templated call") {
-    const auto& output = ANALYZE("fun int() 0 "
+    const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                 "fun int() 0 "
                                  "struct Null "
                                  "union Option{T} = T, Null "
                                  "fun ft{T}(Option{T} a, Option{T} b) "
@@ -213,7 +214,8 @@ TEST_CASE("[frontend] Analyzing user-function templates", "frontend") {
   }
 
   SECTION("Overloaded func templates prefer less type-parameters") {
-    const auto& output = ANALYZE("fun bool(bool b) b "
+    const auto& output = ANALYZE("fun +(int x, int y) -> int intrinsic{int_add_int}(x, y) "
+                                 "fun bool(bool b) b "
                                  "union Choice{T1, T2} = T1, T2 "
                                  "fun ft{T1, T2}(T1 a, T2 b) -> Choice{T1, T2} "
                                  "  bool(a) ? a : b "

--- a/tests/frontend/user_type_templates_test.cpp
+++ b/tests/frontend/user_type_templates_test.cpp
@@ -91,7 +91,8 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
 
   SECTION("Templated conversion") {
     const auto& output =
-        ANALYZE("fun string(int i) intrinsic{int_to_string}(i) "
+        ANALYZE("fun +(string x, string y) -> string intrinsic{string_add_string}(x, y) "
+                "fun string(int i) intrinsic{int_to_string}(i) "
                 "fun string(float f) intrinsic{float_to_string}(f) "
                 "struct tuple{T1, T2} = T1 a, T2 b "
                 "fun string{T1, T2}(tuple{T1, T2} t) t.a.string() + \",\" + t.b.string() "

--- a/tests/novasm/serialization_test.cpp
+++ b/tests/novasm/serialization_test.cpp
@@ -20,17 +20,18 @@ static auto testSerializeAndDeserializeAsm(Executable a) {
 TEST_CASE("[novasm] Assembly serialization", "novasm") {
 
   SECTION("Basic program") {
-    testSerializeAndDeserializeAsm(GEN_ASM("fun implicit float(int i) intrinsic{int_to_float}(i) "
-                                           "act main(int i, float f) -> float"
-                                           "  intrinsic{float_pow}(i, f) + intrinsic{float_sin}(f) "
-                                           "main(42, 1.337)"));
+    testSerializeAndDeserializeAsm(
+        GEN_ASM("fun implicit float(int i) intrinsic{int_to_float}(i) "
+                "act main(int i, float f) -> float"
+                "  intrinsic{float_add_float}(intrinsic{float_pow}(i, f), intrinsic{float_sin}(f)) "
+                "main(42, 1.337)"));
   }
 
   SECTION("Empty program") { testSerializeAndDeserializeAsm(GEN_ASM("")); }
 
   SECTION("Basic program with string literals") {
-    testSerializeAndDeserializeAsm(GEN_ASM("act main(string strA, string strB) "
-                                           "  strA + strB "
+    testSerializeAndDeserializeAsm(GEN_ASM("act main(string strA, string strB) -> string "
+                                           "  intrinsic{string_add_string}(strA, strB) "
                                            "main(\"hello\", \"world\")"));
   }
 }

--- a/tests/opt/const_elimination_test.cpp
+++ b/tests/opt/const_elimination_test.cpp
@@ -17,7 +17,7 @@ TEST_CASE("[opt] Constants elimination", "opt") {
     // Verify that both constants are removed.
     const auto& funcDef = GET_FUNC_DEF(optProg, "func");
 
-    CHECK(funcDef.getBody() == *getIntrinsicBinaryOp(optProg, "int_add_int", 42, 1337));
+    CHECK(funcDef.getBody() == *getIntrinsicIntBinaryOp(optProg, "int_add_int", 42, 1337));
   }
 
   SECTION("Trivial constants are eliminated") {
@@ -30,7 +30,7 @@ TEST_CASE("[opt] Constants elimination", "opt") {
     // Verify that both constants are removed.
     const auto& funcDef = GET_FUNC_DEF(optProg, "func");
 
-    CHECK(funcDef.getBody() == *getIntrinsicBinaryOp(optProg, "int_add_int", 42, 42));
+    CHECK(funcDef.getBody() == *getIntrinsicIntBinaryOp(optProg, "int_add_int", 42, 42));
   }
 }
 

--- a/tests/opt/const_elimination_test.cpp
+++ b/tests/opt/const_elimination_test.cpp
@@ -8,7 +8,8 @@ TEST_CASE("[opt] Constants elimination", "opt") {
 
   SECTION("Eliminate one-time use constants") {
 
-    const auto& output = ANALYZE("fun func() a = 42; b = 1337; a + b");
+    const auto& output =
+        ANALYZE("fun func() -> int a = 42; b = 1337; intrinsic{int_add_int}(a, b)");
     REQUIRE(output.isSuccess());
 
     auto optProg = eliminateConsts(output.getProg());
@@ -16,12 +17,12 @@ TEST_CASE("[opt] Constants elimination", "opt") {
     // Verify that both constants are removed.
     const auto& funcDef = GET_FUNC_DEF(optProg, "func");
 
-    CHECK(funcDef.getBody() == *getIntBinaryOpExpr(optProg, prog::Operator::Plus, 42, 1337));
+    CHECK(funcDef.getBody() == *getIntrinsicBinaryOp(optProg, "int_add_int", 42, 1337));
   }
 
   SECTION("Trivial constants are eliminated") {
 
-    const auto& output = ANALYZE("fun func() a = 42; a + a");
+    const auto& output = ANALYZE("fun func() -> int a = 42; intrinsic{int_add_int}(a, a)");
     REQUIRE(output.isSuccess());
 
     auto optProg = eliminateConsts(output.getProg());
@@ -29,7 +30,7 @@ TEST_CASE("[opt] Constants elimination", "opt") {
     // Verify that both constants are removed.
     const auto& funcDef = GET_FUNC_DEF(optProg, "func");
 
-    CHECK(funcDef.getBody() == *getIntBinaryOpExpr(optProg, prog::Operator::Plus, 42, 42));
+    CHECK(funcDef.getBody() == *getIntrinsicBinaryOp(optProg, "int_add_int", 42, 42));
   }
 }
 

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -91,7 +91,7 @@ inline auto arrayMoveToVec(Array c) {
 #define EXPRS(...)                                                                                 \
   arrayMoveToVec<std::array<prog::expr::NodePtr, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
 
-inline auto getIntrinsicBinaryOp(
+inline auto getIntrinsicIntBinaryOp(
     const prog::Program& prog, const std::string& intrinsic, int32_t lhs, int32_t rhs)
     -> prog::expr::NodePtr {
 
@@ -100,7 +100,7 @@ inline auto getIntrinsicBinaryOp(
       prog, funcId, EXPRS(prog::expr::litIntNode(prog, lhs), prog::expr::litIntNode(prog, rhs)));
 }
 
-inline auto getIntrinsicBinaryOp(
+inline auto getIntrinsicLongBinaryOp(
     const prog::Program& prog, const std::string& intrinsic, int64_t lhs, int64_t rhs)
     -> prog::expr::NodePtr {
 

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -100,29 +100,13 @@ inline auto getIntrinsicBinaryOp(
       prog, funcId, EXPRS(prog::expr::litIntNode(prog, lhs), prog::expr::litIntNode(prog, rhs)));
 }
 
-inline auto
-getIntBinaryOpExpr(const prog::Program& prog, prog::Operator op, int32_t lhs, int32_t rhs)
+inline auto getIntrinsicBinaryOp(
+    const prog::Program& prog, const std::string& intrinsic, int64_t lhs, int64_t rhs)
     -> prog::expr::NodePtr {
 
-  const auto funcId = GET_OP_FUNC_ID(prog, op, GET_TYPE_ID(prog, "int"), GET_TYPE_ID(prog, "int"));
-
-  auto args = std::vector<prog::expr::NodePtr>{};
-  args.push_back(prog::expr::litIntNode(prog, lhs));
-  args.push_back(prog::expr::litIntNode(prog, rhs));
-  return prog::expr::callExprNode(prog, funcId, std::move(args));
-}
-
-inline auto
-getLongBinaryOpExpr(const prog::Program& prog, prog::Operator op, int64_t lhs, int64_t rhs)
-    -> prog::expr::NodePtr {
-
-  const auto funcId =
-      GET_OP_FUNC_ID(prog, op, GET_TYPE_ID(prog, "long"), GET_TYPE_ID(prog, "long"));
-
-  auto args = std::vector<prog::expr::NodePtr>{};
-  args.push_back(prog::expr::litLongNode(prog, lhs));
-  args.push_back(prog::expr::litLongNode(prog, rhs));
-  return prog::expr::callExprNode(prog, funcId, std::move(args));
+  const auto funcId = GET_INTRINSIC_ID(prog, intrinsic, prog.getLong(), prog.getLong());
+  return prog::expr::callExprNode(
+      prog, funcId, EXPRS(prog::expr::litLongNode(prog, lhs), prog::expr::litLongNode(prog, rhs)));
 }
 
 } // namespace opt

--- a/tests/opt/helpers.hpp
+++ b/tests/opt/helpers.hpp
@@ -91,6 +91,15 @@ inline auto arrayMoveToVec(Array c) {
 #define EXPRS(...)                                                                                 \
   arrayMoveToVec<std::array<prog::expr::NodePtr, NUM_ARGS(__VA_ARGS__)>>({__VA_ARGS__})
 
+inline auto getIntrinsicBinaryOp(
+    const prog::Program& prog, const std::string& intrinsic, int32_t lhs, int32_t rhs)
+    -> prog::expr::NodePtr {
+
+  const auto funcId = GET_INTRINSIC_ID(prog, intrinsic, prog.getInt(), prog.getInt());
+  return prog::expr::callExprNode(
+      prog, funcId, EXPRS(prog::expr::litIntNode(prog, lhs), prog::expr::litIntNode(prog, rhs)));
+}
+
 inline auto
 getIntBinaryOpExpr(const prog::Program& prog, prog::Operator op, int32_t lhs, int32_t rhs)
     -> prog::expr::NodePtr {

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -108,9 +108,12 @@ TEST_CASE("[opt] Precompute literals", "opt") {
         precomputeLiterals, "intrinsic{float_add_float}(1.1, 1.2)", litFloatNode(prog, 2.3));
     ASSERT_EXPR_FLOAT(
         precomputeLiterals, "intrinsic{float_sub_float}(1.2, 1.1)", litFloatNode(prog, 0.1));
-    ASSERT_EXPR_FLOAT(precomputeLiterals, "1.1 * 1.2", litFloatNode(prog, 1.32));
-    ASSERT_EXPR_FLOAT(precomputeLiterals, "3.3 / 1.1", litFloatNode(prog, 3.0));
-    ASSERT_EXPR_FLOAT(precomputeLiterals, "5.2 % 2.2", litFloatNode(prog, 0.8));
+    ASSERT_EXPR_FLOAT(
+        precomputeLiterals, "intrinsic{float_mul_float}(1.1, 1.2)", litFloatNode(prog, 1.32));
+    ASSERT_EXPR_FLOAT(
+        precomputeLiterals, "intrinsic{float_div_float}(3.3, 1.1)", litFloatNode(prog, 3.0));
+    ASSERT_EXPR_FLOAT(
+        precomputeLiterals, "intrinsic{float_mod_float}(5.2, 2.2)", litFloatNode(prog, 0.8));
     ASSERT_EXPR_FLOAT(
         precomputeLiterals, "intrinsic{float_pow}(1.1, 2.0)", litFloatNode(prog, 1.21));
     ASSERT_EXPR_FLOAT(precomputeLiterals, "intrinsic{float_sqrt}(4.0)", litFloatNode(prog, 2.0));
@@ -131,7 +134,9 @@ TEST_CASE("[opt] Precompute literals", "opt") {
         precomputeLiterals, "intrinsic{float_gt_float}(1.1, 1.2)", litBoolNode(prog, false));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{float_to_int}(1337.0)", litIntNode(prog, 1337));
     ASSERT_EXPR_STRING(
-        precomputeLiterals, "intrinsic{float_to_string}(0.0 / 0.0)", litStringNode(prog, "nan"));
+        precomputeLiterals,
+        "intrinsic{float_to_string}(intrinsic{float_div_float}(0.0, 0.0))",
+        litStringNode(prog, "nan"));
     ASSERT_EXPR_STRING(
         precomputeLiterals, "intrinsic{float_to_string}(42.1337)", litStringNode(prog, "42.1337"));
     ASSERT_EXPR_STRING(

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -11,32 +11,32 @@ TEST_CASE("[opt] Precompute literals", "opt") {
   SECTION("switch expression") {
     ASSERT_EXPR(
         precomputeLiterals,
-        "if 1 > 2 -> 1 "
-        "else     -> 2",
+        "if intrinsic{int_gt_int}(1, 2) -> 1 "
+        "else                           -> 2",
         litIntNode(prog, 2));
     ASSERT_EXPR(
         precomputeLiterals,
-        "if 2 > 1 -> 1 "
-        "else     -> 2",
+        "if intrinsic{int_gt_int}(2, 1) -> 1 "
+        "else                           -> 2",
         litIntNode(prog, 1));
     ASSERT_EXPR(
         precomputeLiterals,
-        "if 1 < 1 -> 1 "
-        "if 2 > 3 -> 2 "
-        "else     -> 3",
+        "if intrinsic{int_le_int}(1, 1) -> 1 "
+        "if intrinsic{int_gt_int}(2, 3) -> 2 "
+        "else                           -> 3",
         litIntNode(prog, 3));
     ASSERT_EXPR(
         precomputeLiterals,
-        "if 1 < 1 -> 1 "
-        "if 4 > 3 -> 2 "
-        "else     -> 3",
+        "if intrinsic{int_le_int}(1, 1) -> 1 "
+        "if intrinsic{int_gt_int}(4, 3) -> 2 "
+        "else                           -> 3",
         litIntNode(prog, 2));
 
     ASSERT_EXPR(
         precomputeLiterals,
-        "if 1 < 1                               -> 1 "
-        "if intrinsic{env_argument_count}() > 3 -> 2 "
-        "else                                   -> 3",
+        "if intrinsic{int_le_int}(1, 1)                               -> 1 "
+        "if intrinsic{int_gt_int}(intrinsic{env_argument_count}(), 3) -> 2 "
+        "else                                                         -> 3",
         ([&]() {
           auto args = std::vector<prog::expr::NodePtr>{};
           args.push_back(callExprNode(prog, GET_INTRINSIC_ID(prog, "env_argument_count"), {}));
@@ -45,7 +45,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
           auto conditions = std::vector<prog::expr::NodePtr>{};
           conditions.push_back(prog::expr::callExprNode(
               prog,
-              GET_OP_FUNC_ID(prog, prog::Operator::Gt, prog.getInt(), prog.getInt()),
+              GET_INTRINSIC_ID(prog, "int_gt_int", prog.getInt(), prog.getInt()),
               std::move(args)));
 
           auto branches = std::vector<prog::expr::NodePtr>{};
@@ -79,10 +79,8 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_INT(precomputeLiterals, "3 ^ 1", litIntNode(prog, 2));
     ASSERT_EXPR_INT(precomputeLiterals, "~1", litIntNode(prog, -2));
     ASSERT_EXPR_BOOL(precomputeLiterals, "intrinsic{int_eq_int}(1, 2)", litBoolNode(prog, false));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1 < 2", litBoolNode(prog, true));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1 <= 2", litBoolNode(prog, true));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1 > 2", litBoolNode(prog, false));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1 >= 2", litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "intrinsic{int_le_int}(1, 2)", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(precomputeLiterals, "intrinsic{int_gt_int}(1, 2)", litBoolNode(prog, false));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{int_to_long}(137)", litLongNode(prog, 137));
     ASSERT_EXPR_FLOAT(precomputeLiterals, "intrinsic{int_to_float}(137)", litFloatNode(prog, 137));
     ASSERT_EXPR_STRING(
@@ -111,10 +109,10 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_FLOAT(precomputeLiterals, "-1.1", litFloatNode(prog, -1.1));
     ASSERT_EXPR_BOOL(
         precomputeLiterals, "intrinsic{float_eq_float}(1.1, 1.2)", litBoolNode(prog, false));
-    ASSERT_EXPR(precomputeLiterals, "1.1 < 1.2", litBoolNode(prog, true));
-    ASSERT_EXPR(precomputeLiterals, "1.1 <= 1.2", litBoolNode(prog, true));
-    ASSERT_EXPR(precomputeLiterals, "1.1 > 1.2", litBoolNode(prog, false));
-    ASSERT_EXPR(precomputeLiterals, "1.1 >= 1.2", litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "intrinsic{float_le_float}(1.1, 1.2)", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "intrinsic{float_gt_float}(1.1, 1.2)", litBoolNode(prog, false));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{float_to_int}(1337.0)", litIntNode(prog, 1337));
     ASSERT_EXPR_STRING(
         precomputeLiterals, "intrinsic{float_to_string}(0.0 / 0.0)", litStringNode(prog, "nan"));
@@ -153,10 +151,10 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR(precomputeLiterals, "~1L", litLongNode(prog, -2));
     ASSERT_EXPR_BOOL(
         precomputeLiterals, "intrinsic{long_eq_long}(1L, 2L)", litBoolNode(prog, false));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1L < 2L", litBoolNode(prog, true));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1L <= 2L", litBoolNode(prog, true));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1L > 2L", litBoolNode(prog, false));
-    ASSERT_EXPR_BOOL(precomputeLiterals, "1L >= 2L", litBoolNode(prog, false));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "intrinsic{long_le_long}(1L, 2L)", litBoolNode(prog, true));
+    ASSERT_EXPR_BOOL(
+        precomputeLiterals, "intrinsic{long_gt_long}(1L, 2L)", litBoolNode(prog, false));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{long_to_int}(137L)", litIntNode(prog, 137));
     ASSERT_EXPR_STRING(
         precomputeLiterals, "intrinsic{long_to_string}(1337L)", litStringNode(prog, "1337"));

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -56,8 +56,8 @@ TEST_CASE("[opt] Precompute literals", "opt") {
   }
 
   SECTION("int intrinsics") {
-    ASSERT_EXPR_INT(precomputeLiterals, "1 + 2", litIntNode(prog, 3));
-    ASSERT_EXPR_INT(precomputeLiterals, "1 - 2", litIntNode(prog, -1));
+    ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_add_int}(1, 2)", litIntNode(prog, 3));
+    ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_sub_int}(1, 2)", litIntNode(prog, -1));
     ASSERT_EXPR_INT(precomputeLiterals, "3 * 2", litIntNode(prog, 6));
     ASSERT_EXPR_INT(precomputeLiterals, "4 / 2", litIntNode(prog, 2));
     ASSERT_EXPR_INT(precomputeLiterals, "4 / -2", litIntNode(prog, -2));
@@ -305,7 +305,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
   }
 
   SECTION("Lazy get to normal lazy call") {
-    const auto& output = ANALYZE("fun f1(int a, int b) a + b "
+    const auto& output = ANALYZE("fun f1(int a, int b) -> int intrinsic{int_add_int}(a, b) "
                                  "fun f2() -> int intrinsic{lazy_get}(lazy f1(1, 2))");
     REQUIRE(output.isSuccess());
     // Check that it originally call lazy-get.

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -60,18 +60,18 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_sub_int}(1, 2)", litIntNode(prog, -1));
     ASSERT_EXPR_INT(precomputeLiterals, "3 * 2", litIntNode(prog, 6));
     ASSERT_EXPR_INT(precomputeLiterals, "4 / 2", litIntNode(prog, 2));
-    ASSERT_EXPR_INT(precomputeLiterals, "4 / -2", litIntNode(prog, -2));
+    ASSERT_EXPR_INT(precomputeLiterals, "4 / intrinsic{int_neg}(2)", litIntNode(prog, -2));
     ASSERT_EXPR_INT(
         precomputeLiterals, "4 / 0", getIntBinaryOpExpr(prog, prog::Operator::Slash, 4, 0));
     ASSERT_EXPR_INT(
         precomputeLiterals, "0 / 0", getIntBinaryOpExpr(prog, prog::Operator::Slash, 0, 0));
     ASSERT_EXPR_INT(precomputeLiterals, "4 % 3", litIntNode(prog, 1));
-    ASSERT_EXPR_INT(precomputeLiterals, "4 % -3", litIntNode(prog, 1));
+    ASSERT_EXPR_INT(precomputeLiterals, "4 % intrinsic{int_neg}(3)", litIntNode(prog, 1));
     ASSERT_EXPR_INT(
         precomputeLiterals, "4 % 0", getIntBinaryOpExpr(prog, prog::Operator::Rem, 4, 0));
     ASSERT_EXPR_INT(
         precomputeLiterals, "0 % 0", getIntBinaryOpExpr(prog, prog::Operator::Rem, 0, 0));
-    ASSERT_EXPR_INT(precomputeLiterals, "-42", litIntNode(prog, -42));
+    ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_neg}(42)", litIntNode(prog, -42));
     ASSERT_EXPR_INT(precomputeLiterals, "2 << 1", litIntNode(prog, 4));
     ASSERT_EXPR_INT(precomputeLiterals, "4 >> 1", litIntNode(prog, 2));
     ASSERT_EXPR_INT(precomputeLiterals, "3 & 1", litIntNode(prog, 1));
@@ -90,8 +90,10 @@ TEST_CASE("[opt] Precompute literals", "opt") {
   }
 
   SECTION("float intrinsics") {
-    ASSERT_EXPR_FLOAT(precomputeLiterals, "1.1 + 1.2", litFloatNode(prog, 2.3));
-    ASSERT_EXPR_FLOAT(precomputeLiterals, "1.2 - 1.1", litFloatNode(prog, 0.1));
+    ASSERT_EXPR_FLOAT(
+        precomputeLiterals, "intrinsic{float_add_float}(1.1, 1.2)", litFloatNode(prog, 2.3));
+    ASSERT_EXPR_FLOAT(
+        precomputeLiterals, "intrinsic{float_sub_float}(1.2, 1.1)", litFloatNode(prog, 0.1));
     ASSERT_EXPR_FLOAT(precomputeLiterals, "1.1 * 1.2", litFloatNode(prog, 1.32));
     ASSERT_EXPR_FLOAT(precomputeLiterals, "3.3 / 1.1", litFloatNode(prog, 3.0));
     ASSERT_EXPR_FLOAT(precomputeLiterals, "5.2 % 2.2", litFloatNode(prog, 0.8));
@@ -106,7 +108,7 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_FLOAT(precomputeLiterals, "intrinsic{float_atan}(0.0)", litFloatNode(prog, 0.0));
     ASSERT_EXPR_FLOAT(
         precomputeLiterals, "intrinsic{float_atan2}(0.0, 0.0)", litFloatNode(prog, 0.0));
-    ASSERT_EXPR_FLOAT(precomputeLiterals, "-1.1", litFloatNode(prog, -1.1));
+    ASSERT_EXPR_FLOAT(precomputeLiterals, "intrinsic{float_neg}(1.1)", litFloatNode(prog, -1.1));
     ASSERT_EXPR_BOOL(
         precomputeLiterals, "intrinsic{float_eq_float}(1.1, 1.2)", litBoolNode(prog, false));
     ASSERT_EXPR_BOOL(
@@ -120,35 +122,35 @@ TEST_CASE("[opt] Precompute literals", "opt") {
         precomputeLiterals, "intrinsic{float_to_string}(42.1337)", litStringNode(prog, "42.1337"));
     ASSERT_EXPR_STRING(
         precomputeLiterals,
-        "intrinsic{float_to_string}(-42.1337)",
+        "intrinsic{float_to_string}(intrinsic{float_neg}(42.1337))",
         litStringNode(prog, "-42.1337"));
     ASSERT_EXPR_CHAR(precomputeLiterals, "intrinsic{float_to_char}(230.0)", litCharNode(prog, 230));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{float_to_long}(230.0)", litLongNode(prog, 230));
   }
 
   SECTION("long intrinsics") {
-    ASSERT_EXPR(precomputeLiterals, "1L + 2L", litLongNode(prog, 3));
-    ASSERT_EXPR(precomputeLiterals, "1L - 2L", litLongNode(prog, -1));
-    ASSERT_EXPR(precomputeLiterals, "3L * 2L", litLongNode(prog, 6));
-    ASSERT_EXPR(precomputeLiterals, "4L / 2L", litLongNode(prog, 2));
-    ASSERT_EXPR(precomputeLiterals, "4L / -2L", litLongNode(prog, -2));
-    ASSERT_EXPR(
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_add_long}(1L, 2L)", litLongNode(prog, 3));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_sub_long}(1L, 2L)", litLongNode(prog, -1));
+    ASSERT_EXPR_LONG(precomputeLiterals, "3L * 2L", litLongNode(prog, 6));
+    ASSERT_EXPR_LONG(precomputeLiterals, "4L / 2L", litLongNode(prog, 2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "4L / intrinsic{long_neg}(2L)", litLongNode(prog, -2));
+    ASSERT_EXPR_LONG(
         precomputeLiterals, "4L / 0L", getLongBinaryOpExpr(prog, prog::Operator::Slash, 4, 0));
-    ASSERT_EXPR(
+    ASSERT_EXPR_LONG(
         precomputeLiterals, "0L / 0L", getLongBinaryOpExpr(prog, prog::Operator::Slash, 0, 0));
-    ASSERT_EXPR(precomputeLiterals, "4L % 3L", litLongNode(prog, 1));
-    ASSERT_EXPR(precomputeLiterals, "4L % -3L", litLongNode(prog, 1));
-    ASSERT_EXPR(
+    ASSERT_EXPR_LONG(precomputeLiterals, "4L % 3L", litLongNode(prog, 1));
+    ASSERT_EXPR_LONG(precomputeLiterals, "4L % intrinsic{long_neg}(3L)", litLongNode(prog, 1));
+    ASSERT_EXPR_LONG(
         precomputeLiterals, "4L % 0L", getLongBinaryOpExpr(prog, prog::Operator::Rem, 4, 0));
-    ASSERT_EXPR(
+    ASSERT_EXPR_LONG(
         precomputeLiterals, "0L % 0L", getLongBinaryOpExpr(prog, prog::Operator::Rem, 0, 0));
-    ASSERT_EXPR(precomputeLiterals, "-42L", litLongNode(prog, -42));
-    ASSERT_EXPR(precomputeLiterals, "2L << 1", litLongNode(prog, 4));
-    ASSERT_EXPR(precomputeLiterals, "4L >> 1", litLongNode(prog, 2));
-    ASSERT_EXPR(precomputeLiterals, "3L & 1L", litLongNode(prog, 1));
-    ASSERT_EXPR(precomputeLiterals, "2L | 1L", litLongNode(prog, 3));
-    ASSERT_EXPR(precomputeLiterals, "3L ^ 1L", litLongNode(prog, 2));
-    ASSERT_EXPR(precomputeLiterals, "~1L", litLongNode(prog, -2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_neg}(42L)", litLongNode(prog, -42));
+    ASSERT_EXPR_LONG(precomputeLiterals, "2L << 1", litLongNode(prog, 4));
+    ASSERT_EXPR_LONG(precomputeLiterals, "4L >> 1", litLongNode(prog, 2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "3L & 1L", litLongNode(prog, 1));
+    ASSERT_EXPR_LONG(precomputeLiterals, "2L | 1L", litLongNode(prog, 3));
+    ASSERT_EXPR_LONG(precomputeLiterals, "3L ^ 1L", litLongNode(prog, 2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "~1L", litLongNode(prog, -2));
     ASSERT_EXPR_BOOL(
         precomputeLiterals, "intrinsic{long_eq_long}(1L, 2L)", litBoolNode(prog, false));
     ASSERT_EXPR_BOOL(
@@ -168,17 +170,20 @@ TEST_CASE("[opt] Precompute literals", "opt") {
 
   SECTION("string intrinsics") {
     ASSERT_EXPR_STRING(
-        precomputeLiterals, "\"hello\" + \"world\"", litStringNode(prog, "helloworld"));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello\" + ' '", litStringNode(prog, "hello "));
+        precomputeLiterals,
+        "intrinsic{string_add_string}(\"hello\", \"world\")",
+        litStringNode(prog, "helloworld"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_add_char}(\"hello\", ' ')",
+        litStringNode(prog, "hello "));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{string_length}(\"hello\")", litIntNode(prog, 5));
     ASSERT_EXPR_CHAR(precomputeLiterals, "\"hello\"[0]", litCharNode(prog, 'h'));
     ASSERT_EXPR_CHAR(precomputeLiterals, "\"hello\"[4]", litCharNode(prog, 'o'));
-    ASSERT_EXPR_CHAR(precomputeLiterals, "\"hello\"[-1]", litCharNode(prog, '\0'));
     ASSERT_EXPR_CHAR(precomputeLiterals, "\"hello\"[5]", litCharNode(prog, '\0'));
     ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[0, 5]", litStringNode(prog, "hello"));
     ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[4, 4]", litStringNode(prog, ""));
     ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[4, 5]", litStringNode(prog, "o"));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[-99, 5]", litStringNode(prog, "hello"));
     ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[6, 11]", litStringNode(prog, "world"));
     ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[6, 99]", litStringNode(prog, "world"));
     ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[2, 9]", litStringNode(prog, "llo wor"));
@@ -186,7 +191,9 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_STRING(
         precomputeLiterals, "\"hello world\"[0, 11]", litStringNode(prog, "hello world"));
     ASSERT_EXPR_STRING(
-        precomputeLiterals, "\"hello\" + ' ' + \"world\"", litStringNode(prog, "hello world"));
+        precomputeLiterals,
+        "intrinsic{string_add_string}(intrinsic{string_add_char}(\"hello\", ' '), \"world\")",
+        litStringNode(prog, "hello world"));
     ASSERT_EXPR_BOOL(
         precomputeLiterals,
         "intrinsic{string_eq_string}(\"hello\", \"world\")",
@@ -225,7 +232,8 @@ TEST_CASE("[opt] Precompute literals", "opt") {
                   funcDef.getConsts(), *funcDef.getConsts().lookup("s")))));
     }
     {
-      const auto& output = ANALYZE("fun f(string s) -> string s + \"\"");
+      const auto& output =
+          ANALYZE("fun f(string s) -> string intrinsic{string_add_string}(s, \"\")");
       REQUIRE(output.isSuccess());
       const auto prog     = precomputeLiterals(output.getProg());
       const auto& funcDef = GET_FUNC_DEF(prog, "f", prog.getString());
@@ -234,7 +242,8 @@ TEST_CASE("[opt] Precompute literals", "opt") {
           *prog::expr::constExprNode(funcDef.getConsts(), *funcDef.getConsts().lookup("s")));
     }
     {
-      const auto& output = ANALYZE("fun f(string s) -> string \"\" + s");
+      const auto& output =
+          ANALYZE("fun f(string s) -> string intrinsic{string_add_string}(\"\", s)");
       REQUIRE(output.isSuccess());
       const auto prog     = precomputeLiterals(output.getProg());
       const auto& funcDef = GET_FUNC_DEF(prog, "f", prog.getString());

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -150,26 +150,40 @@ TEST_CASE("[opt] Precompute literals", "opt") {
   SECTION("long intrinsics") {
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_add_long}(1L, 2L)", litLongNode(prog, 3));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_sub_long}(1L, 2L)", litLongNode(prog, -1));
-    ASSERT_EXPR_LONG(precomputeLiterals, "3L * 2L", litLongNode(prog, 6));
-    ASSERT_EXPR_LONG(precomputeLiterals, "4L / 2L", litLongNode(prog, 2));
-    ASSERT_EXPR_LONG(precomputeLiterals, "4L / intrinsic{long_neg}(2L)", litLongNode(prog, -2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_mul_long}(3L, 2L)", litLongNode(prog, 6));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_div_long}(4L, 2L)", litLongNode(prog, 2));
     ASSERT_EXPR_LONG(
-        precomputeLiterals, "4L / 0L", getLongBinaryOpExpr(prog, prog::Operator::Slash, 4, 0));
+        precomputeLiterals,
+        "intrinsic{long_div_long}(4L, intrinsic{long_neg}(2L))",
+        litLongNode(prog, -2));
     ASSERT_EXPR_LONG(
-        precomputeLiterals, "0L / 0L", getLongBinaryOpExpr(prog, prog::Operator::Slash, 0, 0));
-    ASSERT_EXPR_LONG(precomputeLiterals, "4L % 3L", litLongNode(prog, 1));
-    ASSERT_EXPR_LONG(precomputeLiterals, "4L % intrinsic{long_neg}(3L)", litLongNode(prog, 1));
+        precomputeLiterals,
+        "intrinsic{long_div_long}(4L, 0L)",
+        getIntrinsicBinaryOp(prog, "long_div_long", 4L, 0L));
     ASSERT_EXPR_LONG(
-        precomputeLiterals, "4L % 0L", getLongBinaryOpExpr(prog, prog::Operator::Rem, 4, 0));
+        precomputeLiterals,
+        "intrinsic{long_div_long}(0L, 0L)",
+        getIntrinsicBinaryOp(prog, "long_div_long", 0L, 0L));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_rem_long}(4L, 3L)", litLongNode(prog, 1));
     ASSERT_EXPR_LONG(
-        precomputeLiterals, "0L % 0L", getLongBinaryOpExpr(prog, prog::Operator::Rem, 0, 0));
+        precomputeLiterals,
+        "intrinsic{long_rem_long}(4L, intrinsic{long_neg}(3L))",
+        litLongNode(prog, 1));
+    ASSERT_EXPR_LONG(
+        precomputeLiterals,
+        "intrinsic{long_rem_long}(4L, 0L)",
+        getIntrinsicBinaryOp(prog, "long_rem_long", 4L, 0L));
+    ASSERT_EXPR_LONG(
+        precomputeLiterals,
+        "intrinsic{long_rem_long}(0L, 0L)",
+        getIntrinsicBinaryOp(prog, "long_rem_long", 0L, 0L));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_neg}(42L)", litLongNode(prog, -42));
-    ASSERT_EXPR_LONG(precomputeLiterals, "2L << 1", litLongNode(prog, 4));
-    ASSERT_EXPR_LONG(precomputeLiterals, "4L >> 1", litLongNode(prog, 2));
-    ASSERT_EXPR_LONG(precomputeLiterals, "3L & 1L", litLongNode(prog, 1));
-    ASSERT_EXPR_LONG(precomputeLiterals, "2L | 1L", litLongNode(prog, 3));
-    ASSERT_EXPR_LONG(precomputeLiterals, "3L ^ 1L", litLongNode(prog, 2));
-    ASSERT_EXPR_LONG(precomputeLiterals, "~1L", litLongNode(prog, -2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_shiftleft}(2L, 1)", litLongNode(prog, 4));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_shiftright}(4L, 1)", litLongNode(prog, 2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_and_long}(3L, 1L)", litLongNode(prog, 1));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_or_long}(2L, 1L)", litLongNode(prog, 3));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_xor_long}(3L, 1L)", litLongNode(prog, 2));
+    ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_inv}(1L)", litLongNode(prog, -2));
     ASSERT_EXPR_BOOL(
         precomputeLiterals, "intrinsic{long_eq_long}(1L, 2L)", litBoolNode(prog, false));
     ASSERT_EXPR_BOOL(

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -67,11 +67,11 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_INT(
         precomputeLiterals,
         "intrinsic{int_div_int}(4, 0)",
-        getIntrinsicBinaryOp(prog, "int_div_int", 4, 0));
+        getIntrinsicIntBinaryOp(prog, "int_div_int", 4, 0));
     ASSERT_EXPR_INT(
         precomputeLiterals,
         "intrinsic{int_div_int}(0, 0)",
-        getIntrinsicBinaryOp(prog, "int_div_int", 0, 0));
+        getIntrinsicIntBinaryOp(prog, "int_div_int", 0, 0));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_rem_int}(4, 3)", litIntNode(prog, 1));
     ASSERT_EXPR_INT(
         precomputeLiterals,
@@ -80,11 +80,11 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_INT(
         precomputeLiterals,
         "intrinsic{int_rem_int}(4, 0)",
-        getIntrinsicBinaryOp(prog, "int_rem_int", 4, 0));
+        getIntrinsicIntBinaryOp(prog, "int_rem_int", 4, 0));
     ASSERT_EXPR_INT(
         precomputeLiterals,
         "intrinsic{int_rem_int}(0, 0)",
-        getIntrinsicBinaryOp(prog, "int_rem_int", 0, 0));
+        getIntrinsicIntBinaryOp(prog, "int_rem_int", 0, 0));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_neg}(42)", litIntNode(prog, -42));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_shiftleft}(2, 1)", litIntNode(prog, 4));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{int_shiftright}(4, 1)", litIntNode(prog, 2));
@@ -159,11 +159,11 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_LONG(
         precomputeLiterals,
         "intrinsic{long_div_long}(4L, 0L)",
-        getIntrinsicBinaryOp(prog, "long_div_long", 4L, 0L));
+        getIntrinsicLongBinaryOp(prog, "long_div_long", 4L, 0L));
     ASSERT_EXPR_LONG(
         precomputeLiterals,
         "intrinsic{long_div_long}(0L, 0L)",
-        getIntrinsicBinaryOp(prog, "long_div_long", 0L, 0L));
+        getIntrinsicLongBinaryOp(prog, "long_div_long", 0L, 0L));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_rem_long}(4L, 3L)", litLongNode(prog, 1));
     ASSERT_EXPR_LONG(
         precomputeLiterals,
@@ -172,11 +172,11 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_LONG(
         precomputeLiterals,
         "intrinsic{long_rem_long}(4L, 0L)",
-        getIntrinsicBinaryOp(prog, "long_rem_long", 4L, 0L));
+        getIntrinsicLongBinaryOp(prog, "long_rem_long", 4L, 0L));
     ASSERT_EXPR_LONG(
         precomputeLiterals,
         "intrinsic{long_rem_long}(0L, 0L)",
-        getIntrinsicBinaryOp(prog, "long_rem_long", 0L, 0L));
+        getIntrinsicLongBinaryOp(prog, "long_rem_long", 0L, 0L));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_neg}(42L)", litLongNode(prog, -42));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_shiftleft}(2L, 1)", litLongNode(prog, 4));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{long_shiftright}(4L, 1)", litLongNode(prog, 2));

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -211,18 +211,44 @@ TEST_CASE("[opt] Precompute literals", "opt") {
         "intrinsic{string_add_char}(\"hello\", ' ')",
         litStringNode(prog, "hello "));
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{string_length}(\"hello\")", litIntNode(prog, 5));
-    ASSERT_EXPR_CHAR(precomputeLiterals, "\"hello\"[0]", litCharNode(prog, 'h'));
-    ASSERT_EXPR_CHAR(precomputeLiterals, "\"hello\"[4]", litCharNode(prog, 'o'));
-    ASSERT_EXPR_CHAR(precomputeLiterals, "\"hello\"[5]", litCharNode(prog, '\0'));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[0, 5]", litStringNode(prog, "hello"));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[4, 4]", litStringNode(prog, ""));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[4, 5]", litStringNode(prog, "o"));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[6, 11]", litStringNode(prog, "world"));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[6, 99]", litStringNode(prog, "world"));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[2, 9]", litStringNode(prog, "llo wor"));
-    ASSERT_EXPR_STRING(precomputeLiterals, "\"hello world\"[8, 3]", litStringNode(prog, ""));
+    ASSERT_EXPR_CHAR(
+        precomputeLiterals, "intrinsic{string_index}(\"hello\", 0)", litCharNode(prog, 'h'));
+    ASSERT_EXPR_CHAR(
+        precomputeLiterals, "intrinsic{string_index}(\"hello\", 4)", litCharNode(prog, 'o'));
+    ASSERT_EXPR_CHAR(
+        precomputeLiterals, "intrinsic{string_index}(\"hello\", 5)", litCharNode(prog, '\0'));
     ASSERT_EXPR_STRING(
-        precomputeLiterals, "\"hello world\"[0, 11]", litStringNode(prog, "hello world"));
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 0, 5)",
+        litStringNode(prog, "hello"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 4, 4)",
+        litStringNode(prog, ""));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 4, 5)",
+        litStringNode(prog, "o"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 6, 11)",
+        litStringNode(prog, "world"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 6, 99)",
+        litStringNode(prog, "world"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 2, 9)",
+        litStringNode(prog, "llo wor"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 8, 3)",
+        litStringNode(prog, ""));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{string_slice}(\"hello world\", 0, 11)",
+        litStringNode(prog, "hello world"));
     ASSERT_EXPR_STRING(
         precomputeLiterals,
         "intrinsic{string_add_string}(intrinsic{string_add_char}(\"hello\", ' '), \"world\")",

--- a/tests/opt/synergy_test.cpp
+++ b/tests/opt/synergy_test.cpp
@@ -27,13 +27,14 @@ TEST_CASE("[opt] Optimization synergy", "opt") {
 
   SECTION("One time used lazy calls are optimized out") {
 
-    const auto& output = ANALYZE("act get{T}(lazy_action{T} a) -> T intrinsic{lazy_action_get}(a) "
-                                 "act getNonZero(lazy_action{int} a, lazy_action{int} b) "
-                                 " v = a.get(); intrinsic{int_gt_int}(v, 0) ? v : b.get() "
-                                 "act produceA() -> int intrinsic{int_neg}(1337) "
-                                 "act produceB(int multiplier) 42 * multiplier "
-                                 "act main() getNonZero(lazy produceA(), lazy produceB(2)) "
-                                 "main()");
+    const auto& output =
+        ANALYZE("act get{T}(lazy_action{T} a) -> T intrinsic{lazy_action_get}(a) "
+                "act getNonZero(lazy_action{int} a, lazy_action{int} b) "
+                " v = a.get(); intrinsic{int_gt_int}(v, 0) ? v : b.get() "
+                "act produceA() -> int intrinsic{int_neg}(1337) "
+                "act produceB(int multiplier) -> int intrinsic{int_mul_int}(42, multiplier) "
+                "act main() getNonZero(lazy produceA(), lazy produceB(2)) "
+                "main()");
     REQUIRE(output.isSuccess());
 
     auto optimizedProg = optimize(output.getProg());

--- a/tests/opt/synergy_test.cpp
+++ b/tests/opt/synergy_test.cpp
@@ -29,7 +29,7 @@ TEST_CASE("[opt] Optimization synergy", "opt") {
 
     const auto& output = ANALYZE("act get{T}(lazy_action{T} a) -> T intrinsic{lazy_action_get}(a) "
                                  "act getNonZero(lazy_action{int} a, lazy_action{int} b) "
-                                 " v = a.get(); v > 0 ? v : b.get() "
+                                 " v = a.get(); intrinsic{int_gt_int}(v, 0) ? v : b.get() "
                                  "act produceA() -1337 "
                                  "act produceB(int multiplier) 42 * multiplier "
                                  "act main() getNonZero(lazy produceA(), lazy produceB(2)) "

--- a/tests/opt/synergy_test.cpp
+++ b/tests/opt/synergy_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE("[opt] Optimization synergy", "opt") {
     const auto& output = ANALYZE("act get{T}(lazy_action{T} a) -> T intrinsic{lazy_action_get}(a) "
                                  "act getNonZero(lazy_action{int} a, lazy_action{int} b) "
                                  " v = a.get(); intrinsic{int_gt_int}(v, 0) ? v : b.get() "
-                                 "act produceA() -1337 "
+                                 "act produceA() -> int intrinsic{int_neg}(1337) "
                                  "act produceB(int multiplier) 42 * multiplier "
                                  "act main() getNonZero(lazy produceA(), lazy produceB(2)) "
                                  "main()");


### PR DESCRIPTION
Convert all remaining build in operators to intrinsic. This allows more flexibility on the standard library side.

The only remaining exceptions are operators that belong to user defined enums, the language would need to support more meta-programming to be able to convert these into intrinsics.