### PR TITLE
frontend: Fix crash on duplicate type-param name

### DIFF
--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -80,6 +80,9 @@ errDuplicateEntryNameInEnum(prog::sym::SourceId src, const std::string& entryNam
 [[nodiscard]] auto
 errTypeParamNameConflictsWithType(prog::sym::SourceId src, const std::string& name) -> Diag;
 
+[[nodiscard]] auto errDuplicateTypeParamName(prog::sym::SourceId src, const std::string& name)
+    -> Diag;
+
 [[nodiscard]] auto errDuplicateFuncDeclaration(prog::sym::SourceId src, const std::string& name)
     -> Diag;
 

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -185,6 +185,12 @@ auto errTypeParamNameConflictsWithType(prog::sym::SourceId src, const std::strin
   return error(oss.str(), src);
 }
 
+auto errDuplicateTypeParamName(prog::sym::SourceId src, const std::string& name) -> Diag {
+  std::ostringstream oss;
+  oss << "Duplicate type parameter name '" << name << "'";
+  return error(oss.str(), src);
+}
+
 auto errDuplicateFuncDeclaration(prog::sym::SourceId src, const std::string& name) -> Diag {
   std::ostringstream oss;
   oss << "Declaration of function '" << name

--- a/src/frontend/internal/utilities.cpp
+++ b/src/frontend/internal/utilities.cpp
@@ -499,6 +499,8 @@ auto getSubstitutionParams(Context* ctx, const parse::TypeSubstitutionList& subL
 
   auto typeParams = std::vector<std::string>{};
   auto isValid    = true;
+
+  // Find all substitution params.
   for (const auto& typeSubToken : subList) {
     const auto typeParamName = getName(typeSubToken);
     if (isType(ctx, nullptr, typeParamName)) {
@@ -508,6 +510,17 @@ auto getSubstitutionParams(Context* ctx, const parse::TypeSubstitutionList& subL
       typeParams.push_back(typeParamName);
     }
   }
+
+  // Check for duplicates.
+  for (auto i = 0u; i < typeParams.size(); ++i) {
+    for (auto j = i + 1; j < typeParams.size(); ++j) {
+      if (typeParams[i] == typeParams[j]) {
+        ctx->reportDiag(errDuplicateTypeParamName, subList.getSpan(), typeParams[i]);
+        isValid = false;
+      }
+    }
+  }
+
   return isValid ? std::optional(typeParams) : std::nullopt;
 }
 

--- a/tests/frontend/declare_user_funcs_test.cpp
+++ b/tests/frontend/declare_user_funcs_test.cpp
@@ -173,6 +173,7 @@ TEST_CASE("[frontend] Analyzing user-function declarations", "frontend") {
         errNoTypeOrConversionFoundToInstantiate(NO_SRC, "s", 1));
     CHECK_DIAG("fun &&() -> int 1", errNonOverloadableOperator(NO_SRC, "&&"));
     CHECK_DIAG("fun f{int}() -> int 1", errTypeParamNameConflictsWithType(NO_SRC, "int"));
+    CHECK_DIAG("fun f{T, T}() -> int 1", errDuplicateTypeParamName(NO_SRC, "T"));
     CHECK_DIAG(
         "fun f{T}(T{int} a) -> int i "
         "fun f() f{int}(1)",


### PR DESCRIPTION
A program like this used to crash to compiler:
![image](https://user-images.githubusercontent.com/14230060/111078803-fb258880-84ff-11eb-9628-62175a5cfaec.png)
Now it reports a diag like this:
`test.ns:2:9-2:10: error: Duplicate type parameter name 'T'`