### PR TITLE
Fix diagnostics for misplaced commas

### DIFF
--- a/include/parse/argument_list_decl.hpp
+++ b/include/parse/argument_list_decl.hpp
@@ -59,7 +59,11 @@ public:
 
   ArgumentListDecl() = delete;
   ArgumentListDecl(
-      lex::Token open, std::vector<ArgSpec> args, std::vector<lex::Token> commas, lex::Token close);
+      lex::Token open,
+      std::vector<ArgSpec> args,
+      std::vector<lex::Token> commas,
+      lex::Token close,
+      bool missingComma = false);
 
   auto operator==(const ArgumentListDecl& rhs) const noexcept -> bool;
   auto operator!=(const ArgumentListDecl& rhs) const noexcept -> bool;
@@ -78,12 +82,14 @@ public:
   [[nodiscard]] auto getClose() const -> const lex::Token&;
 
   [[nodiscard]] auto validate() const -> bool;
+  [[nodiscard]] auto hasMissingComma() const -> bool;
 
 private:
   lex::Token m_open;
   std::vector<ArgSpec> m_args;
   std::vector<lex::Token> m_commas;
   lex::Token m_close;
+  bool m_missingComma;
 
   auto print(std::ostream& out) const -> std::ostream&;
 };

--- a/include/parse/error.hpp
+++ b/include/parse/error.hpp
@@ -82,7 +82,8 @@ errInvalidIsExpr(NodePtr lhs, lex::Token kw, const Type& type, std::optional<lex
     lex::Token open,
     std::vector<NodePtr> args,
     std::vector<lex::Token> commas,
-    lex::Token close) -> NodePtr;
+    lex::Token close,
+    bool missingComma) -> NodePtr;
 
 [[nodiscard]] auto errInvalidIndexExpr(
     NodePtr lhs,

--- a/include/parse/type_param_list.hpp
+++ b/include/parse/type_param_list.hpp
@@ -15,7 +15,11 @@ public:
 
   TypeParamList() = delete;
   TypeParamList(
-      lex::Token open, std::vector<Type> params, std::vector<lex::Token> commas, lex::Token close);
+      lex::Token open,
+      std::vector<Type> params,
+      std::vector<lex::Token> commas,
+      lex::Token close,
+      bool missingComma = false);
 
   auto operator==(const TypeParamList& rhs) const noexcept -> bool;
   auto operator!=(const TypeParamList& rhs) const noexcept -> bool;
@@ -34,12 +38,14 @@ public:
   [[nodiscard]] auto getClose() const -> const lex::Token&;
 
   [[nodiscard]] auto validate() const -> bool;
+  [[nodiscard]] auto hasMissingComma() const -> bool;
 
 private:
   lex::Token m_open;
   std::vector<Type> m_params;
   std::vector<lex::Token> m_commas;
   lex::Token m_close;
+  bool m_missingComma;
 
   auto print(std::ostream& out) const -> std::ostream&;
 };

--- a/include/parse/type_substitution_list.hpp
+++ b/include/parse/type_substitution_list.hpp
@@ -19,7 +19,8 @@ public:
       lex::Token open,
       std::vector<lex::Token> subs,
       std::vector<lex::Token> commas,
-      lex::Token close);
+      lex::Token close,
+      bool missingComma = false);
 
   auto operator==(const TypeSubstitutionList& rhs) const noexcept -> bool;
   auto operator!=(const TypeSubstitutionList& rhs) const noexcept -> bool;
@@ -34,12 +35,14 @@ public:
   [[nodiscard]] auto getClose() const -> const lex::Token&;
 
   [[nodiscard]] auto validate() const -> bool;
+  [[nodiscard]] auto hasMissingComma() const -> bool;
 
 private:
   lex::Token m_open;
   std::vector<lex::Token> m_subs;
   std::vector<lex::Token> m_commas;
   lex::Token m_close;
+  bool m_missingComma;
 
   auto print(std::ostream& out) const -> std::ostream&;
 };

--- a/src/parse/argument_list_decl.cpp
+++ b/src/parse/argument_list_decl.cpp
@@ -78,11 +78,16 @@ auto ArgumentListDecl::ArgSpec::validate() const -> bool {
 }
 
 ArgumentListDecl::ArgumentListDecl(
-    lex::Token open, std::vector<ArgSpec> args, std::vector<lex::Token> commas, lex::Token close) :
+    lex::Token open,
+    std::vector<ArgSpec> args,
+    std::vector<lex::Token> commas,
+    lex::Token close,
+    bool missingComma) :
     m_open{std::move(open)},
     m_args{std::move(args)},
     m_commas{std::move(commas)},
-    m_close{std::move(close)} {}
+    m_close{std::move(close)},
+    m_missingComma{missingComma} {}
 
 auto ArgumentListDecl::operator==(const ArgumentListDecl& rhs) const noexcept -> bool {
   return m_args == rhs.m_args;
@@ -144,11 +149,13 @@ auto ArgumentListDecl::validate() const -> bool {
   if (!std::all_of(m_args.begin(), m_args.end(), [](const auto& a) { return a.validate(); })) {
     return false;
   }
-  if (m_commas.size() != (m_args.empty() ? 0 : m_args.size() - 1)) {
+  if (m_missingComma || m_commas.size() != (m_args.empty() ? 0 : m_args.size() - 1)) {
     return false;
   }
   return true;
 }
+
+auto ArgumentListDecl::hasMissingComma() const -> bool { return m_missingComma; }
 
 auto operator<<(std::ostream& out, const ArgumentListDecl& rhs) -> std::ostream& {
   out << '(';

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -485,10 +485,13 @@ auto errInvalidCallExpr(
     lex::Token open,
     std::vector<NodePtr> args,
     std::vector<lex::Token> commas,
-    lex::Token close) -> NodePtr {
+    lex::Token close,
+    bool missingComma) -> NodePtr {
 
   std::ostringstream oss;
-  if (commas.size() != (args.empty() ? 0 : args.size() - 1)) {
+  if (missingComma) {
+    oss << "Missing comma ',' in call expression";
+  } else if (commas.size() != (args.empty() ? 0 : args.size() - 1)) {
     oss << "Incorrect number of comma's ',' in call expression";
   } else if (
       open.getKind() != lex::TokenKind::SepOpenParen &&

--- a/src/parse/error.cpp
+++ b/src/parse/error.cpp
@@ -81,8 +81,13 @@ static auto getError(std::ostream& out, const ArgumentListDecl& argList) -> void
     return;
   }
 
+  if (argList.hasMissingComma()) {
+    out << "Missing comma ',' in argument list";
+    return;
+  }
+
   if (argList.getCommas().size() != (argList.getCount() == 0 ? 0 : argList.getCount() - 1)) {
-    out << "Incorrect number of comma's ',' in function declaration";
+    out << "Incorrect number of comma's ',' in argument list";
     return;
   }
 

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -608,10 +608,11 @@ auto ParserImpl::nextTypeSubstitutionList() -> TypeSubstitutionList {
 }
 
 auto ParserImpl::nextArgDeclList() -> ArgumentListDecl {
-  auto open   = consumeToken();
-  auto empty  = open.getKind() == lex::TokenKind::OpParenParen;
-  auto args   = std::vector<ArgumentListDecl::ArgSpec>{};
-  auto commas = std::vector<lex::Token>{};
+  auto open         = consumeToken();
+  auto empty        = open.getKind() == lex::TokenKind::OpParenParen;
+  auto args         = std::vector<ArgumentListDecl::ArgSpec>{};
+  auto commas       = std::vector<lex::Token>{};
+  auto missingComma = false;
   if (!empty) {
 
     while (peekToken(0).getKind() == lex::TokenKind::Identifier ||
@@ -635,12 +636,16 @@ auto ParserImpl::nextArgDeclList() -> ArgumentListDecl {
 
       if (peekToken(0).getKind() == lex::TokenKind::SepComma) {
         commas.push_back(consumeToken());
+      } else if (
+          peekToken(0).getKind() == lex::TokenKind::Identifier ||
+          peekToken(0).getKind() == lex::TokenKind::Keyword) {
+        missingComma = true;
       }
     }
   }
 
   auto close = empty ? open : consumeToken();
-  return ArgumentListDecl(open, std::move(args), std::move(commas), close);
+  return ArgumentListDecl(open, std::move(args), std::move(commas), close, missingComma);
 }
 
 auto ParserImpl::nextRetTypeSpec() -> RetTypeSpec {

--- a/src/parse/type_param_list.cpp
+++ b/src/parse/type_param_list.cpp
@@ -4,11 +4,16 @@
 namespace parse {
 
 TypeParamList::TypeParamList(
-    lex::Token open, std::vector<Type> params, std::vector<lex::Token> commas, lex::Token close) :
+    lex::Token open,
+    std::vector<Type> params,
+    std::vector<lex::Token> commas,
+    lex::Token close,
+    bool missingComma) :
     m_open{std::move(open)},
     m_params{std::move(params)},
     m_commas{std::move(commas)},
-    m_close{std::move(close)} {}
+    m_close{std::move(close)},
+    m_missingComma{missingComma} {}
 
 auto TypeParamList::operator==(const TypeParamList& rhs) const noexcept -> bool {
   return m_params == rhs.m_params;
@@ -53,7 +58,7 @@ auto TypeParamList::validate() const -> bool {
   if (!std::all_of(m_params.begin(), m_params.end(), [](const auto& t) { return t.validate(); })) {
     return false;
   }
-  if (m_commas.size() != m_params.size() - 1) {
+  if (m_missingComma || m_commas.size() != m_params.size() - 1) {
     return false;
   }
   if (m_close.getKind() != lex::TokenKind::SepCloseCurly) {
@@ -61,6 +66,8 @@ auto TypeParamList::validate() const -> bool {
   }
   return true;
 }
+
+auto TypeParamList::hasMissingComma() const -> bool { return m_missingComma; }
 
 auto operator<<(std::ostream& out, const TypeParamList& rhs) -> std::ostream& {
   out << '{';

--- a/src/parse/type_substitution_list.cpp
+++ b/src/parse/type_substitution_list.cpp
@@ -11,11 +11,13 @@ TypeSubstitutionList::TypeSubstitutionList(
     lex::Token open,
     std::vector<lex::Token> subs,
     std::vector<lex::Token> commas,
-    lex::Token close) :
+    lex::Token close,
+    bool missingComma) :
     m_open{std::move(open)},
     m_subs{std::move(subs)},
     m_commas{std::move(commas)},
-    m_close{std::move(close)} {}
+    m_close{std::move(close)},
+    m_missingComma{missingComma} {}
 
 auto TypeSubstitutionList::operator==(const TypeSubstitutionList& rhs) const noexcept -> bool {
   return m_subs == rhs.m_subs;
@@ -53,7 +55,7 @@ auto TypeSubstitutionList::validate() const -> bool {
       })) {
     return false;
   }
-  if (m_commas.size() != m_subs.size() - 1) {
+  if (m_missingComma || m_commas.size() != m_subs.size() - 1) {
     return false;
   }
   if (m_close.getKind() != lex::TokenKind::SepCloseCurly) {
@@ -61,6 +63,8 @@ auto TypeSubstitutionList::validate() const -> bool {
   }
   return true;
 }
+
+auto TypeSubstitutionList::hasMissingComma() const -> bool { return m_missingComma; }
 
 auto operator<<(std::ostream& out, const TypeSubstitutionList& rhs) -> std::ostream& {
   out << '{';

--- a/tests/parse/expr_anon_func_test.cpp
+++ b/tests/parse/expr_anon_func_test.cpp
@@ -133,7 +133,23 @@ TEST_CASE("[parse] Parsing anonymous functions", "parse") {
                     ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
                     ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))),
                 COMMAS(0),
-                CPAREN),
+                CPAREN,
+                true),
+            std::nullopt,
+            errInvalidPrimaryExpr(END)));
+    CHECK_EXPR(
+        "lambda (int x int y,)",
+        errInvalidAnonFuncExpr(
+            {},
+            LAMBDA,
+            ArgumentListDecl(
+                OPAREN,
+                ARGS(
+                    ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
+                    ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))),
+                COMMAS(1),
+                CPAREN,
+                true),
             std::nullopt,
             errInvalidPrimaryExpr(END)));
     CHECK_EXPR(

--- a/tests/parse/expr_call_test.cpp
+++ b/tests/parse/expr_call_test.cpp
@@ -117,13 +117,23 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
   CHECK_EXPR(
       "fork (a)()",
       callExprNode(
-          {FORK}, parenExprNode(OPAREN, ID_EXPR("a"), CPAREN), OPAREN, NO_NODES, COMMAS(0), CPAREN));
+          {FORK},
+          parenExprNode(OPAREN, ID_EXPR("a"), CPAREN),
+          OPAREN,
+          NO_NODES,
+          COMMAS(0),
+          CPAREN));
 
   SECTION("Errors") {
     CHECK_EXPR(
         "a(1 1)",
-        errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(0), CPAREN));
-    CHECK_EXPR("a(", errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), END));
+        errInvalidCallExpr(
+            {}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(0), CPAREN, true));
+    CHECK_EXPR(
+        "a(1 1,)",
+        errInvalidCallExpr(
+            {}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(1), CPAREN, true));
+    CHECK_EXPR("a(", errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), END, false));
     CHECK_EXPR("a{", errInvalidIdExpr(ID("a"), TypeParamList(OCURLY, {}, COMMAS(0), END)));
     CHECK_EXPR(
         "a{}()",
@@ -147,7 +157,7 @@ TEST_CASE("[parse] Parsing call expressions", "parse") {
     CHECK_EXPR(
         "a(,",
         errInvalidCallExpr(
-            {}, ID_EXPR("a"), OPAREN, NODES(errInvalidPrimaryExpr(COMMA)), COMMAS(0), END));
+            {}, ID_EXPR("a"), OPAREN, NODES(errInvalidPrimaryExpr(COMMA)), COMMAS(0), END, true));
     CHECK_EXPR(
         "a(,)",
         callExprNode(

--- a/tests/parse/stmt_exec_test.cpp
+++ b/tests/parse/stmt_exec_test.cpp
@@ -67,20 +67,31 @@ TEST_CASE("[parse] Parsing execute statements", "parse") {
   CHECK_STMT(
       "(exec)()",
       execStmtNode(callExprNode(
-          {}, parenExprNode(OPAREN, ID_EXPR("exec"), CPAREN), OPAREN, NO_NODES, COMMAS(0), CPAREN)));
+          {},
+          parenExprNode(OPAREN, ID_EXPR("exec"), CPAREN),
+          OPAREN,
+          NO_NODES,
+          COMMAS(0),
+          CPAREN)));
   CHECK_STMT("1()", execStmtNode(callExprNode({}, INT(1), OPAREN, NO_NODES, COMMAS(0), CPAREN)));
 
   SECTION("Errors") {
     CHECK_STMT(
         "a(1 1)",
         execStmtNode(errInvalidCallExpr(
-            {}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(0), CPAREN)));
+            {}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(0), CPAREN, true)));
     CHECK_STMT(
-        "a(", execStmtNode(errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), END)));
+        "a(1 1,)",
+        execStmtNode(errInvalidCallExpr(
+            {}, ID_EXPR("a"), OPAREN, NODES(INT(1), INT(1)), COMMAS(1), CPAREN, true)));
+    CHECK_STMT(
+        "a(",
+        execStmtNode(
+            errInvalidCallExpr({}, ID_EXPR("a"), OPAREN, NO_NODES, COMMAS(0), END, false)));
     CHECK_STMT(
         "a(,",
         execStmtNode(errInvalidCallExpr(
-            {}, ID_EXPR("a"), OPAREN, NODES(errInvalidPrimaryExpr(COMMA)), COMMAS(0), END)));
+            {}, ID_EXPR("a"), OPAREN, NODES(errInvalidPrimaryExpr(COMMA)), COMMAS(0), END, true)));
     CHECK_STMT(
         "a(,)",
         execStmtNode(callExprNode(

--- a/tests/parse/stmt_func_decl_test.cpp
+++ b/tests/parse/stmt_func_decl_test.cpp
@@ -388,7 +388,8 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
                     ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
                     ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))),
                 COMMAS(0),
-                CPAREN),
+                CPAREN,
+                true),
             RetTypeSpec{ARROW, TYPE("x")},
             errInvalidPrimaryExpr(END)));
     CHECK_STMT(
@@ -404,7 +405,25 @@ TEST_CASE("[parse] Parsing function declaration statements", "parse") {
                     ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
                     ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))),
                 COMMAS(0),
-                CPAREN),
+                CPAREN,
+                true),
+            RetTypeSpec{ARROW, TYPE("int")},
+            INT(1)));
+    CHECK_STMT(
+        "fun a(int x int y,) -> int 1",
+        errInvalidStmtFuncDecl(
+            FUN,
+            {},
+            ID("a"),
+            std::nullopt,
+            ArgumentListDecl(
+                OPAREN,
+                ARGS(
+                    ArgumentListDecl::ArgSpec(TYPE("int"), ID("x")),
+                    ArgumentListDecl::ArgSpec(TYPE("int"), ID("y"))),
+                COMMAS(1),
+                CPAREN,
+                true),
             RetTypeSpec{ARROW, TYPE("int")},
             INT(1)));
     CHECK_STMT(


### PR DESCRIPTION
In various places the parser was actually accepting misplaced commas (as long as the amount of commas was correct).

So the following declaration was actually accepted:
![img](https://user-images.githubusercontent.com/14230060/111081721-63c73200-850d-11eb-8373-41ea03b8cd10.jpeg)

This pr fixes that.