### PR TITLE
opt: Fix crash due to missing enum conversion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,21 @@
       "pid": "${command:pickProcess}"
     },
     {
+      "name": "novc",
+      "preLaunchTask": "build",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/novc",
+      "args": [
+        "examples/raytracer/main.ns",
+        "-o",
+        "raytracer"
+      ],
+      "cwd": "${workspaceFolder}",
+      "terminal": "integrated",
+      "stopOnEntry": false
+    },
+    {
       "name": "novrt",
       "preLaunchTask": "build",
       "type": "lldb",

--- a/src/opt/treeshake.cpp
+++ b/src/opt/treeshake.cpp
@@ -20,6 +20,16 @@ auto treeshake(const prog::Program& prog) -> prog::Program {
     itr->getExpr().accept(&findFuncs);
   }
 
+  // Mark all 'NoOp' functions as used.
+  // This is a bit of a hack, but no-op functions are used for reinterpreting conversions, like
+  // converting an enum to its backing type. The optimizer should have the option to use these
+  // functions, even if they are not used in the original program.
+  for (auto itr = prog.beginFuncDecls(); itr != prog.endFuncDecls(); ++itr) {
+    if (itr->second.getKind() == prog::sym::FuncKind::NoOp) {
+      funcs.insert(itr->first);
+    }
+  }
+
   auto findTypes = internal::FindUsedTypes{prog, &types};
 
   // Find all types used in the execute statements.


### PR DESCRIPTION
Fixes crash in optimizer caused by the tree-shake step pruning the enum to int implicit conversion (because it was unused). As a fix the tree-shake step now leaves `NoOp` functions alone, those are always harmless as they don't emit any instructions in the resulting executable.