### PR TITLE
frontend:  Tune template type infer complexity

### DIFF
--- a/src/frontend/internal/func_template.hpp
+++ b/src/frontend/internal/func_template.hpp
@@ -32,6 +32,7 @@ public:
   [[nodiscard]] auto getNumOptArgs() const -> unsigned int;
   [[nodiscard]] auto getMinArgumentCount() const -> unsigned int;
   [[nodiscard]] auto getArgumentCount() const -> unsigned int;
+  [[nodiscard]] auto getTemplatedArgumentCount() const -> unsigned int;
 
   [[nodiscard]] auto getRetType(const prog::sym::TypeSet& typeParams)
       -> std::optional<prog::sym::TypeId>;


### PR DESCRIPTION
The complexity heuristic in inferring template type parameters to a function template is used to determine the best match when there are multiple overloaded function templates (it prefers matches with lower complexity).

Before it only took into account the sum of complexities of the inferred substitution types (how deep they are nested). Now it also takes into account how many templated arguments the function has.

This helps disambiguating more kinds of templated function overloading.