### PR TITLE
ci: Update to gcc9 in ubuntu release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,9 +105,9 @@ jobs:
             image: ubuntu-16.04,
             arch: x86_64,
             os: ubuntu,
-            compiler: gcc7,
-            cc: gcc-7,
-            cxx: g++-7
+            compiler: gcc9,
+            cc: gcc-9,
+            cxx: g++-9
           }
         - {
             image: ubuntu-16.04,


### PR DESCRIPTION
Github Actions removed gcc7 from the ubuntu 16 vm:
https://github.com/actions/virtual-environments/pull/3044