### PR TITLE
frontend: Fix disallowing non-pure func lits from a pure context

### DIFF
--- a/src/frontend/internal/get_expr.cpp
+++ b/src/frontend/internal/get_expr.cpp
@@ -433,16 +433,12 @@ auto GetExpr::visit(const parse::IdExprNode& n) -> void {
       assert(m_ctx->hasErrors());
       return;
     }
-    const auto instances = m_ctx->getFuncTemplates()->instantiate(name, *typeSet, getOvOptions(-1));
+    const auto instances = m_ctx->getFuncTemplates()->instantiate(
+        name, *typeSet, prog::OvOptions{prog::OvFlags::ExclNonUser, -1});
+
     if (instances.empty()) {
       const auto typeParamNames = getDisplayNames(*m_ctx, *typeSet);
-      if (hasFlag<Flags::AllowPureFuncCalls>() && hasFlag<Flags::AllowActionCalls>()) {
-        m_ctx->reportDiag(errNoFuncOrActionFoundToInstantiate, n.getSpan(), name, typeParamNames);
-      } else if (hasFlag<Flags::AllowPureFuncCalls>()) {
-        m_ctx->reportDiag(errNoPureFuncFoundToInstantiate, n.getSpan(), name, typeParamNames);
-      } else {
-        m_ctx->reportDiag(errNoActionFoundToInstantiate, n.getSpan(), name, typeParamNames);
-      }
+      m_ctx->reportDiag(errNoFuncOrActionFoundToInstantiate, n.getSpan(), name, typeParamNames);
       return;
     }
     if (instances.size() != 1) {
@@ -455,7 +451,7 @@ auto GetExpr::visit(const parse::IdExprNode& n) -> void {
   }
 
   // Non-templated function literal.
-  auto funcs = m_ctx->getProg()->lookupFunc(name, getOvOptions(-1, true));
+  auto funcs = m_ctx->getProg()->lookupFunc(name, prog::OvOptions{prog::OvFlags::ExclNonUser, -1});
   if (!funcs.empty()) {
     if (funcs.size() != 1) {
       m_ctx->reportDiag(errAmbiguousFunction, n.getSpan(), name);

--- a/tests/frontend/get_call_dyn_expr_test.cpp
+++ b/tests/frontend/get_call_dyn_expr_test.cpp
@@ -236,7 +236,7 @@ TEST_CASE("[frontend] Analyzing call dynamic expressions", "frontend") {
         "fun f2() -> int op = f1{int}; op(1)",
         errAmbiguousTemplateFunction(NO_SRC, "f1", 1),
         errUndeclaredPureFunc(NO_SRC, "op", {"int"}));
-    CHECK_DIAG("fun f() f1{float}", errNoPureFuncFoundToInstantiate(NO_SRC, "f1", {"float"}));
+    CHECK_DIAG("fun f() f1{float}", errNoFuncOrActionFoundToInstantiate(NO_SRC, "f1", {"float"}));
     CHECK_DIAG("act a() f1{float}", errNoFuncOrActionFoundToInstantiate(NO_SRC, "f1", {"float"}));
     CHECK_DIAG(
         "fun f1{T}() -> T T() "


### PR DESCRIPTION
We disallowed referencing impure function literals from a pure context.
Which is incorrect as creating a reference to a impure function itself
is still pure. Only invoking a impure function literal is not allowed.