### PR TITLE
vm: Add support for specifing float format options

### DIFF
--- a/include/novasm/op_code.hpp
+++ b/include/novasm/op_code.hpp
@@ -89,19 +89,19 @@ enum class OpCode : uint8_t {
   CheckIntZero      = 103, // [] (int)                    -> (int) Check if integer is zero.
   CheckStringEmpty  = 104, // [] (string)                 -> (int) Check if string is empty.
 
-  ConvIntLong     = 111, // [] (int)   -> (long)     Convert int to long.
-  ConvIntFloat    = 112, // [] (int)   -> (float)    Convert int to float.
-  ConvLongInt     = 113, // [] (long)  -> (int)      Convert long to int.
-  ConvLongFloat   = 114, // [] (long)  -> (float)    Convert long to float.
-  ConvFloatInt    = 115, // [] (float) -> (int)      Convert float to int.
-  ConvIntString   = 116, // [] (int)   -> (string)   Convert int to string.
-  ConvLongString  = 117, // [] (long)  -> (string)   Convert long to string.
-  ConvFloatString = 118, // [] (float) -> (string)   Convert float to string.
-  ConvCharString  = 119, // [] (int)   -> (string)   Convert char to string (8 bit).
-  ConvIntChar     = 120, // [] (int)   -> (int)      Convert int to char (8 bit).
-  ConvLongChar    = 121, // [] (long)  -> (int)      Convert long to char (8 bit).
-  ConvFloatChar   = 122, // [] (float) -> (int)      Convert float to char (8 bit).
-  ConvFloatLong   = 123, // [] (float) -> (long)     Convert float to long.
+  ConvIntLong     = 111, // [] (int)        -> (long)   Convert int to long.
+  ConvIntFloat    = 112, // [] (int)        -> (float)  Convert int to float.
+  ConvLongInt     = 113, // [] (long)       -> (int)    Convert long to int.
+  ConvLongFloat   = 114, // [] (long)       -> (float)  Convert long to float.
+  ConvFloatInt    = 115, // [] (float)      -> (int)    Convert float to int.
+  ConvIntString   = 116, // [] (int)        -> (string) Convert int to string.
+  ConvLongString  = 117, // [] (long)       -> (string) Convert long to string.
+  ConvFloatString = 118, // [] (int, float) -> (string) Convert float to string (takes options).
+  ConvCharString  = 119, // [] (int)        -> (string) Convert char to string (8 bit).
+  ConvIntChar     = 120, // [] (int)        -> (int)    Convert int to char (8 bit).
+  ConvLongChar    = 121, // [] (long)       -> (int)    Convert long to char (8 bit).
+  ConvFloatChar   = 122, // [] (float)      -> (int)    Convert float to char (8 bit).
+  ConvFloatLong   = 123, // [] (float)      -> (long)   Convert float to long.
 
   MakeAtomic        = 180, // [int32]        ()       -> (atomic) Create a new atomic value.
   AtomicLoad        = 181, // []             (atomic) -> (int)    Load the value of the atomic.

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -7,7 +7,7 @@ namespace novasm {
 // Version number for the binary representation of the novus assembly format.
 // Increase this when performing breaking changes to the format.
 // TODO(bastian): Add system for defining migrations.
-const uint16_t executableFormatVersion = 16U;
+const uint16_t executableFormatVersion = 17U;
 
 // Write a binary representation of the executable file to the output iterator.
 template <typename OutputItr>

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -163,7 +163,7 @@ Program::Program() :
   m_funcDecls.registerIntrinsic(
       *this, Fk::ConvLongString, "long_to_string", sym::TypeSet{m_long}, m_string);
   m_funcDecls.registerIntrinsic(
-      *this, Fk::ConvFloatString, "float_to_string", sym::TypeSet{m_float}, m_string);
+      *this, Fk::ConvFloatString, "float_to_string", sym::TypeSet{m_float, m_int}, m_string);
   m_funcDecls.registerIntrinsic(
       *this, Fk::ConvCharString, "char_to_string", sym::TypeSet{m_char}, m_string);
   m_funcDecls.registerIntrinsic(*this, Fk::NoOp, "char_as_int", sym::TypeSet{m_char}, m_int);

--- a/src/vm/internal/executor.cpp
+++ b/src/vm/internal/executor.cpp
@@ -691,7 +691,12 @@ auto execute(
       PUSH_REF(intToString(refAlloc, getLong(POP())));
     } break;
     case OpCode::ConvFloatString: {
-      PUSH_REF(floatToString(refAlloc, POP_FLOAT()));
+      // Flags are stored in the least significant 8 bits.
+      // Precision is stored in the 8 bits before (more significant).
+      const auto options   = POP_INT();
+      const auto flags     = static_cast<FloatToStringFlags>(options);
+      const auto precision = static_cast<uint8_t>(options >> 8U);
+      PUSH_REF(floatToString(refAlloc, POP_FLOAT(), precision, flags));
     } break;
     case OpCode::ConvCharString: {
       PUSH_REF(charToString(refAlloc, static_cast<uint8_t>(POP_INT())));

--- a/std/format/writer.ns
+++ b/std/format/writer.ns
@@ -240,9 +240,9 @@ fun txtHexWriter(int minDigits = 0)
     s.write(string('0', minDigits - str.length()) + str)
   )
 
-fun txtFloatWriter()
+fun txtFloatWriter(int precision = 6, FloatToStringFlags flags = FloatToStringFlags.Normal)
   Writer(lambda (WriterState s, float f)
-    s.write(f.string())
+    s.write(f.string(precision, flags))
   )
 
 fun txtBoolWriter(string trueTxt = "true", string falseTxt = "false")

--- a/std/prim/string.ns
+++ b/std/prim/string.ns
@@ -3,6 +3,13 @@ import "type.ns"
 import "std/core.ns"
 import "std/diag.ns"
 
+// -- Types
+
+enum FloatToStringFlags =
+  Normal            : 0b00,
+  NeverScientific   : 0b01,
+  AlwaysScientific  : 0b10
+
 // -- Constructors
 
 fun string() ""
@@ -15,8 +22,8 @@ fun string(int i)
 fun string(long l)
   intrinsic{long_to_string}(l)
 
-fun string(float f)
-  intrinsic{float_to_string}(f)
+fun string(float f, int precision = 6, FloatToStringFlags flags = FloatToStringFlags.Normal)
+  intrinsic{float_to_string}(f, int(flags) | precision << 8)
 
 fun string(bool b)
   b ? "true" : "false"
@@ -111,6 +118,51 @@ assertEq(string("hello", 2), "hellohello")
 assertEq(string("hello", 3), "hellohellohello")
 assertEq(string("hello", 0), "")
 assertEq(string("hello", -1), "")
+
+assertEq(string(nan()), "nan")
+assertEq(string(42.0, 6, FloatToStringFlags.Normal), "42")
+assertEq(string(42.1337, 6, FloatToStringFlags.Normal), "42.1337")
+assertEq(string(420000000.0, 6, FloatToStringFlags.Normal), "4.2e+08")
+assertEq(string(.0000042, 6, FloatToStringFlags.Normal), "4.2e-06")
+assertEq(string(.000004242, 6, FloatToStringFlags.Normal), "4.242e-06")
+assertEq(string(.000004242, 7, FloatToStringFlags.Normal), "4.242e-06")
+assertEq(string(.000004242, 5, FloatToStringFlags.Normal), "4.242e-06")
+
+assertEq(string(42.0, 7, FloatToStringFlags.NeverScientific), "42.0000000")
+assertEq(string(42.1337, 7, FloatToStringFlags.NeverScientific), "42.1337013")
+assertEq(string(42.1337, 6, FloatToStringFlags.NeverScientific), "42.133701")
+assertEq(string(42.1337, 5, FloatToStringFlags.NeverScientific), "42.13370")
+assertEq(string(42.1337, 4, FloatToStringFlags.NeverScientific), "42.1337")
+assertEq(string(42.1337, 3, FloatToStringFlags.NeverScientific), "42.134")
+assertEq(string(42.1337, 2, FloatToStringFlags.NeverScientific), "42.13")
+assertEq(string(42.1337, 1, FloatToStringFlags.NeverScientific), "42.1")
+assertEq(string(42.1337, 0, FloatToStringFlags.NeverScientific), "42")
+assertEq(string(-42.1337, 7, FloatToStringFlags.NeverScientific), "-42.1337013")
+assertEq(string(-42.1337, 6, FloatToStringFlags.NeverScientific), "-42.133701")
+assertEq(string(-42.1337, 5, FloatToStringFlags.NeverScientific), "-42.13370")
+assertEq(string(-42.1337, 4, FloatToStringFlags.NeverScientific), "-42.1337")
+assertEq(string(-42.1337, 3, FloatToStringFlags.NeverScientific), "-42.134")
+assertEq(string(-42.1337, 2, FloatToStringFlags.NeverScientific), "-42.13")
+assertEq(string(-42.1337, 1, FloatToStringFlags.NeverScientific), "-42.1")
+assertEq(string(-42.1337, 0, FloatToStringFlags.NeverScientific), "-42")
+
+assertEq(string(42.0, 7, FloatToStringFlags.AlwaysScientific), "4.2000000e+01")
+assertEq(string(42.1337, 7, FloatToStringFlags.AlwaysScientific), "4.2133701e+01")
+assertEq(string(42.1337, 6, FloatToStringFlags.AlwaysScientific), "4.213370e+01")
+assertEq(string(42.1337, 5, FloatToStringFlags.AlwaysScientific), "4.21337e+01")
+assertEq(string(42.1337, 4, FloatToStringFlags.AlwaysScientific), "4.2134e+01")
+assertEq(string(42.1337, 3, FloatToStringFlags.AlwaysScientific), "4.213e+01")
+assertEq(string(42.1337, 2, FloatToStringFlags.AlwaysScientific), "4.21e+01")
+assertEq(string(42.1337, 1, FloatToStringFlags.AlwaysScientific), "4.2e+01")
+assertEq(string(42.1337, 0, FloatToStringFlags.AlwaysScientific), "4e+01")
+assertEq(string(-42.1337, 7, FloatToStringFlags.AlwaysScientific), "-4.2133701e+01")
+assertEq(string(-42.1337, 6, FloatToStringFlags.AlwaysScientific), "-4.213370e+01")
+assertEq(string(-42.1337, 5, FloatToStringFlags.AlwaysScientific), "-4.21337e+01")
+assertEq(string(-42.1337, 4, FloatToStringFlags.AlwaysScientific), "-4.2134e+01")
+assertEq(string(-42.1337, 3, FloatToStringFlags.AlwaysScientific), "-4.213e+01")
+assertEq(string(-42.1337, 2, FloatToStringFlags.AlwaysScientific), "-4.21e+01")
+assertEq(string(-42.1337, 1, FloatToStringFlags.AlwaysScientific), "-4.2e+01")
+assertEq(string(-42.1337, 0, FloatToStringFlags.AlwaysScientific), "-4e+01")
 
 assert("".isEmpty())
 assertNot(" ".isEmpty())

--- a/tests/backend/call_expr_test.cpp
+++ b/tests/backend/call_expr_test.cpp
@@ -345,10 +345,12 @@ TEST_CASE("[backend] Generate assembly for call expressions", "backend") {
       asmb->addLoadLitLong(42);
       asmb->addConvLongString();
     });
-    CHECK_EXPR_STRING("intrinsic{float_to_string}(.1337)", [](novasm::Assembler* asmb) -> void {
-      asmb->addLoadLitFloat(0.1337F);
-      asmb->addConvFloatString();
-    });
+    CHECK_EXPR_STRING(
+        "intrinsic{float_to_string}(.1337, 1536)", [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitFloat(0.1337F);
+          asmb->addLoadLitInt(1536);
+          asmb->addConvFloatString();
+        });
     CHECK_EXPR_STRING("intrinsic{char_to_string}('a')", [](novasm::Assembler* asmb) -> void {
       asmb->addLoadLitInt('a');
       asmb->addConvCharString();

--- a/tests/frontend/user_type_templates_test.cpp
+++ b/tests/frontend/user_type_templates_test.cpp
@@ -93,7 +93,7 @@ TEST_CASE("[frontend] Analyzing user-type templates", "frontend") {
     const auto& output =
         ANALYZE("fun +(string x, string y) -> string intrinsic{string_add_string}(x, y) "
                 "fun string(int i) intrinsic{int_to_string}(i) "
-                "fun string(float f) intrinsic{float_to_string}(f) "
+                "fun string(float f) intrinsic{float_to_string}(f, 1536) "
                 "struct tuple{T1, T2} = T1 a, T2 b "
                 "fun string{T1, T2}(tuple{T1, T2} t) t.a.string() + \",\" + t.b.string() "
                 "fun f(tuple{int, float} t) string{int, float}(t)");

--- a/tests/opt/precompute_literals_test.cpp
+++ b/tests/opt/precompute_literals_test.cpp
@@ -135,13 +135,31 @@ TEST_CASE("[opt] Precompute literals", "opt") {
     ASSERT_EXPR_INT(precomputeLiterals, "intrinsic{float_to_int}(1337.0)", litIntNode(prog, 1337));
     ASSERT_EXPR_STRING(
         precomputeLiterals,
-        "intrinsic{float_to_string}(intrinsic{float_div_float}(0.0, 0.0))",
+        "intrinsic{float_to_string}(intrinsic{float_div_float}(0.0, 0.0), 1536)",
         litStringNode(prog, "nan"));
     ASSERT_EXPR_STRING(
-        precomputeLiterals, "intrinsic{float_to_string}(42.1337)", litStringNode(prog, "42.1337"));
+        precomputeLiterals,
+        "intrinsic{float_to_string}(42.1337, 1536)",
+        litStringNode(prog, "42.1337"));
     ASSERT_EXPR_STRING(
         precomputeLiterals,
-        "intrinsic{float_to_string}(intrinsic{float_neg}(42.1337))",
+        "intrinsic{float_to_string}(.00001337, 1536)",
+        litStringNode(prog, "1.337e-05"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{float_to_string}(.00001337, 1537)",
+        litStringNode(prog, "0.000013"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{float_to_string}(.00001337, 2049)",
+        litStringNode(prog, "0.00001337"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{float_to_string}(42.1337, 1538)",
+        litStringNode(prog, "4.213370e+01"));
+    ASSERT_EXPR_STRING(
+        precomputeLiterals,
+        "intrinsic{float_to_string}(intrinsic{float_neg}(42.1337), 1536)",
         litStringNode(prog, "-42.1337"));
     ASSERT_EXPR_CHAR(precomputeLiterals, "intrinsic{float_to_char}(230.0)", litCharNode(prog, 230));
     ASSERT_EXPR_LONG(precomputeLiterals, "intrinsic{float_to_long}(230.0)", litLongNode(prog, 230));

--- a/tests/vm/conv_test.cpp
+++ b/tests/vm/conv_test.cpp
@@ -11,7 +11,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
           asmb->addLoadLitInt(42);
           asmb->addConvIntFloat();
 
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -21,7 +21,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
           asmb->addLoadLitInt(-2147483647);
           asmb->addConvIntFloat();
 
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -90,7 +90,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
           asmb->addLoadLitLong(42);
           asmb->addConvLongFloat();
 
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -100,7 +100,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
           asmb->addLoadLitLong(51474836478);
           asmb->addConvLongFloat();
 
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -240,7 +240,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.0F);
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -248,23 +248,63 @@ TEST_CASE("[vm] Execute conversions", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(42.0F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
         "42");
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitFloat(42.0F); // NOLINT: Magic numbers
+          ADD_FLOAT_TO_STRING(asmb, 6, 1);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "42.000000");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitFloat(42.0F); // NOLINT: Magic numbers
+          ADD_FLOAT_TO_STRING(asmb, 2, 1);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "42.00");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitFloat(42.0F); // NOLINT: Magic numbers
+          ADD_FLOAT_TO_STRING(asmb, 0, 1);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "42");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitFloat(42.0F); // NOLINT: Magic numbers
+          ADD_FLOAT_TO_STRING(asmb, 6, 2);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "4.200000e+01");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(42.1337F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
         "42.1337");
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitFloat(42.1337F); // NOLINT: Magic numbers
+          ADD_FLOAT_TO_STRING(asmb, 1, 1);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "42.1");
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.42F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -272,7 +312,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(999999.0F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -280,7 +320,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(99999.1F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -288,7 +328,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.000001F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -296,15 +336,23 @@ TEST_CASE("[vm] Execute conversions", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(9999999999.0F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
         "1e+10"); // Rounding error.
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
+          asmb->addLoadLitFloat(9999999999.0F); // NOLINT: Magic numbers
+          ADD_FLOAT_TO_STRING(asmb, 4, 1);
+          ADD_PRINT(asmb);
+        },
+        "input",
+        "10000000000.0000"); // Rounding error.
+    CHECK_EXPR(
+        [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(-0.42F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -312,7 +360,7 @@ TEST_CASE("[vm] Execute conversions", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(-9999999999.0F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",

--- a/tests/vm/float_op_test.cpp
+++ b/tests/vm/float_op_test.cpp
@@ -11,7 +11,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(0.1337F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(0.1F);    // NOLINT: Magic numbers
           asmb->addAddFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -21,7 +21,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(9999.0F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(1.0F);
           asmb->addAddFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -34,7 +34,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(0.1337F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(0.1F);    // NOLINT: Magic numbers
           asmb->addSubFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -44,7 +44,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(0.1F);    // NOLINT: Magic numbers
           asmb->addLoadLitFloat(0.1337F); // NOLINT: Magic numbers
           asmb->addSubFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -57,7 +57,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(0.1337F);  // NOLINT: Magic numbers
           asmb->addLoadLitFloat(10000.0F); // NOLINT: Magic numbers
           asmb->addMulFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -67,7 +67,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1337.0F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(0.0001F); // NOLINT: Magic numbers
           asmb->addMulFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -80,7 +80,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.0F);
           asmb->addLoadLitFloat(50.0F); // NOLINT: Magic numbers
           asmb->addDivFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -90,7 +90,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.0F);
           asmb->addLoadLitFloat(0.0F);
           asmb->addDivFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -100,7 +100,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(0.0F);
           asmb->addLoadLitFloat(0.0F);
           asmb->addDivFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -113,7 +113,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.3F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(1.0F);
           asmb->addModFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -123,7 +123,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.25F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(.25F);  // NOLINT: Magic numbers
           asmb->addModFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -133,7 +133,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.3F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(-1.0F);
           asmb->addModFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -143,7 +143,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.3F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(0.0F);
           asmb->addModFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -156,7 +156,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.0F);
           asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
           asmb->addPowFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -166,7 +166,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
           asmb->addPowFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -176,7 +176,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(4.0F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(4.0F); // NOLINT: Magic numbers
           asmb->addPowFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -186,7 +186,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(4.0F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(0.0F);
           asmb->addPowFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -196,7 +196,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(-2.0F); // NOLINT: Magic numbers
           asmb->addLoadLitFloat(2.0F);  // NOLINT: Magic numbers
           asmb->addPowFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -206,7 +206,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(2.0F);  // NOLINT: Magic numbers
           asmb->addLoadLitFloat(-2.0F); // NOLINT: Magic numbers
           asmb->addPowFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -218,7 +218,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(2.0F); // NOLINT: Magic numbers
           asmb->addSqrtFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -227,7 +227,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(4.0F); // NOLINT: Magic numbers
           asmb->addSqrtFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -236,7 +236,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.0F);
           asmb->addSqrtFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -245,7 +245,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(-1.0F); // NOLINT: Magic numbers
           asmb->addSqrtFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -257,7 +257,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.0F);
           asmb->addSinFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -269,7 +269,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.0F);
           asmb->addCosFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -281,7 +281,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.0F);
           asmb->addTanFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -294,7 +294,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.0F);
           asmb->addSinFloat();
           asmb->addASinFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -307,7 +307,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.0F);
           asmb->addCosFloat();
           asmb->addACosFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -320,7 +320,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(1.0F);
           asmb->addTanFloat();
           asmb->addATanFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -333,7 +333,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(0.0F);
           asmb->addLoadLitFloat(0.0F);
           asmb->addATan2Float();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -345,7 +345,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.1337F); // NOLINT: Magic numbers
           asmb->addNegFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -354,7 +354,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.0F);
           asmb->addNegFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -364,7 +364,7 @@ TEST_CASE("[vm] Execute float operations", "vm") {
           asmb->addLoadLitFloat(0.1337F); // NOLINT: Magic numbers
           asmb->addNegFloat();
           asmb->addNegFloat();
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",

--- a/tests/vm/helpers.hpp
+++ b/tests/vm/helpers.hpp
@@ -134,4 +134,10 @@ inline auto prepareStdIn(std::string input) -> FileHandle {
     (ASMB)->label(endLabel);                                                                       \
   }
 
+#define ADD_FLOAT_TO_STRING(ASMB, PRECISION, FLAGS)                                                \
+  {                                                                                                \
+    (ASMB)->addLoadLitInt((FLAGS) | ((PRECISION) << 8u));                                          \
+    (ASMB)->addConvFloatString();                                                                  \
+  }
+
 } // namespace vm

--- a/tests/vm/literal_test.cpp
+++ b/tests/vm/literal_test.cpp
@@ -47,7 +47,7 @@ TEST_CASE("[vm] Execute literals", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(0.1337F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",
@@ -55,7 +55,7 @@ TEST_CASE("[vm] Execute literals", "vm") {
     CHECK_EXPR(
         [](novasm::Assembler* asmb) -> void {
           asmb->addLoadLitFloat(-0.1337F); // NOLINT: Magic numbers
-          asmb->addConvFloatString();
+          ADD_FLOAT_TO_STRING(asmb, 6, 0);
           ADD_PRINT(asmb);
         },
         "input",


### PR DESCRIPTION
Add two configuration options to the 'float to string' intrinsic, `precision` and `flags`:
```c
enum FloatToStringFlags =
  Normal            : 0b00,
  NeverScientific   : 0b01,
  AlwaysScientific  : 0b10

fun string(float f, int precision = 6, FloatToStringFlags flags = FloatToStringFlags.Normal)
```
Eventually this should probably be implemented on the library side instead of in the runtime for more flexibility, but until that time this allows us to customize the output.