### PR TITLE
vm: Support running non-piped child processes

### DIFF
--- a/examples/git-changelog.ns
+++ b/examples/git-changelog.ns
@@ -47,8 +47,8 @@ fun commitParser()
 // -- Actions
 
 act runGit(List{string} args) -> Either{string, Error}
-  run("git", args).wait().map(impure lambda (ProcessResult r)
-    r.isSuccess() ? r.stdOut : Error("Failed to run git: " + r.stdErr.trim())
+  run("git", args, ProcessFlags.PipeInOut).wait().map(impure lambda (ProcessResult r)
+    r.isSuccess() ? (r.stdOut ?? "") : Error("Failed to run git: " + (r.stdErr ?? "").trim())
   )
 
 act runGit{T}(List{string} args, Parser{T} parser) -> Either{T, Error}

--- a/examples/run-tests.ns
+++ b/examples/run-tests.ns
@@ -30,12 +30,6 @@ act startTests()
   atInterupt(shutdown[process]);
   TestRun(timeNow(), process)
 
-act printOutput(TestRun run)
-  c   = consoleOpen().failOnError();
-  out = fork copy(run.process.stdOut, c.stdOut);
-  err = fork copy(run.process.stdErr, c.stdErr);
-  waitAll(out :: err)
-
 act getResult(TestRun run)
   res = run.process.wait().failOnError();
   TestResult(res.isSuccess(), timeNow() - run.startTime)
@@ -45,9 +39,10 @@ struct Settings
 act main(Settings s)
   print("-- Starting tests");
   run = startTests();
-  printOutput(run);
   result = run.getResult();
   if result.success -> print(   "-- Tests succeeded in " + result.duration, TtyStyle.FgGreen)
   else              -> printErr("-- Tests failed in "   + result.duration, TtyStyle.FgRed)
+
+fun cliIsInteruptable(Type{Settings} s) false
 
 cli(main)

--- a/include/novasm/pcall_code.hpp
+++ b/include/novasm/pcall_code.hpp
@@ -19,7 +19,7 @@ enum class PCallCode : uint8_t {
   StreamSetOptions   = 13, // (int, stream)    -> (int)     Set options, returns success.
   StreamUnsetOptions = 14, // (int, stream)    -> (int)     Unset options, returns success.
 
-  ProcessStart = 20, // (string)  -> (process) Start a new sys process from the given cmdline str.
+  ProcessStart = 20, // (int, string)-> (process) Start a new process from the given cmdline str.
   ProcessBlock = 21, // (process) -> (int)     Block until the process has exited, returns exitcode.
   ProcessOpenStream = 22, // (int, process) -> (stream)  Get a stream to stdin, stdout or stderr.
   ProcessGetId      = 23, // (process)      -> (long) Retrieve the native process id.

--- a/include/novasm/serialization.hpp
+++ b/include/novasm/serialization.hpp
@@ -7,7 +7,7 @@ namespace novasm {
 // Version number for the binary representation of the novus assembly format.
 // Increase this when performing breaking changes to the format.
 // TODO(bastian): Add system for defining migrations.
-const uint16_t executableFormatVersion = 17U;
+const uint16_t executableFormatVersion = 18U;
 
 // Write a binary representation of the executable file to the output iterator.
 template <typename OutputItr>

--- a/include/vm/file.hpp
+++ b/include/vm/file.hpp
@@ -25,4 +25,9 @@ auto fileSeek(FileHandle file, size_t position) noexcept -> bool;
 
 auto fileClose(FileHandle file) noexcept -> void;
 
+template <typename... FileHandles>
+auto fileClose(FileHandles... files) {
+  (fileClose(files), ...);
+}
+
 } // namespace vm

--- a/src/prog/program.cpp
+++ b/src/prog/program.cpp
@@ -212,7 +212,7 @@ Program::Program() :
       m_bool);
 
   m_funcDecls.registerIntrinsicAction(
-      *this, Fk::ActionProcessStart, "process_start", sym::TypeSet{m_string}, m_sysProcess);
+      *this, Fk::ActionProcessStart, "process_start", sym::TypeSet{m_string, m_int}, m_sysProcess);
   m_funcDecls.registerIntrinsicAction(
       *this, Fk::ActionProcessBlock, "process_block", sym::TypeSet{m_sysProcess}, m_int);
   m_funcDecls.registerIntrinsicAction(

--- a/src/vm/internal/pcall.hpp
+++ b/src/vm/internal/pcall.hpp
@@ -130,9 +130,10 @@ auto inline pcall(
   } break;
 
   case PCallCode::ProcessStart: {
+    auto flags          = static_cast<ProcessFlags>(POP_INT());
     auto* cmdLineStrRef = getStringRef(refAlloc, POP());
     CHECK_ALLOC(cmdLineStrRef);
-    PUSH_REF(processStart(refAlloc, pErr, cmdLineStrRef));
+    PUSH_REF(processStart(refAlloc, pErr, cmdLineStrRef, flags));
   } break;
   case PCallCode::ProcessBlock: {
     // Note: Keep the process on the stack, reason is gc could run while we are blocked.

--- a/src/vm/internal/ref_stream_file.hpp
+++ b/src/vm/internal/ref_stream_file.hpp
@@ -29,11 +29,11 @@ enum class FileStreamMode : uint8_t {
 };
 
 enum FileStreamFlags : uint8_t {
-  AutoRemoveFile = 1, // File is deleted when the reference to it is freed.
+  AutoRemoveFile = 1u << 0, // File is deleted when the reference to it is freed.
 };
 
 enum FileListDirFlags : uint8_t {
-  IncludeSymlinks = 1, // Should symbolic links be included in directory listings.
+  IncludeSymlinks = 1u << 0, // Should symbolic links be included in directory listings.
 };
 
 auto getFilePlatformError() noexcept -> PlatformError;

--- a/src/vm/internal/ref_stream_process.hpp
+++ b/src/vm/internal/ref_stream_process.hpp
@@ -112,11 +112,11 @@ private:
   [[nodiscard]] auto getFile() noexcept -> FileHandle {
     switch (m_streamKind) {
     case ProcessStreamKind::StdIn:
-      return m_process->getStdIn();
+      return m_process->getStdInPipe();
     case ProcessStreamKind::StdOut:
-      return m_process->getStdOut();
+      return m_process->getStdOutPipe();
     case ProcessStreamKind::StdErr:
-      return m_process->getStdErr();
+      return m_process->getStdErrPipe();
     }
     return fileInvalid();
   }

--- a/std/io/process.ns
+++ b/std/io/process.ns
@@ -8,22 +8,30 @@ import "std/prim.ns"
 struct ProcessId  = long id
 struct ExitCode   = int code
 
+enum ProcessFlags =
+  None        : 0b000,
+  PipeStdIn   : 0b001,
+  PipeStdOut  : 0b010,
+  PipeStdErr  : 0b100,
+  PipeOut     : 0b110,
+  PipeInOut   : 0b111
+
 enum Signal =
   Interupt  : 0,
   Kill      : 1
 
 struct Process =
-  string      cmdLine,
-  sys_process handle,
-  ProcessId   id,
-  sys_stream  stdIn,
-  sys_stream  stdOut,
-  sys_stream  stdErr
+  string              cmdLine,
+  sys_process         handle,
+  ProcessId           id,
+  Option{sys_stream}  stdInPipe,
+  Option{sys_stream}  stdOutPipe,
+  Option{sys_stream}  stdErrPipe
 
 struct ProcessResult =
-  string    stdOut,
-  string    stdErr,
-  ExitCode  exitCode
+  Option{string}  stdOut,
+  Option{string}  stdErr,
+  ExitCode        exitCode
 
 // -- Conversions
 
@@ -31,7 +39,12 @@ fun string(Process p)
   "(pid:" + p.id + ", " + p.cmdLine + ")"
 
 fun string(ProcessResult r)
-  "(out:'" + r.stdOut.escapeForPrinting() + "' err:'" + r.stdErr.escapeForPrinting() + "' code:" + r.exitCode + ")"
+  "(out:'" + (r.stdOut ?? "").escapeForPrinting() +
+  "' err:'" + (r.stdErr ?? "").escapeForPrinting() +
+  "' code:" + r.exitCode + ")"
+
+fun string(ProcessFlags f)
+  toEnumFlagNames(f).string()
 
 // -- Functions
 
@@ -47,19 +60,19 @@ fun isSuccess(ProcessResult r)
 
 // -- Actions
 
-act run(string prog, List{string} args) -> Either{Process, Error}
-  run(toCmdLine(prog, args))
+act run(string prog, List{string} args, ProcessFlags flags = ProcessFlags.None) -> Either{Process, Error}
+  run(toCmdLine(prog, args), flags)
 
-act run(string cmdLine) -> Either{Process, Error}
-  handle  = intrinsic{process_start}(cmdLine);
+act run(string cmdLine, ProcessFlags flags = ProcessFlags.None) -> Either{Process, Error}
+  handle  = intrinsic{process_start}(cmdLine, flags);
   pid     = ProcessId(intrinsic{process_getid}(handle));
   if pid.id < 0 -> platformError("Failed to run: '" + cmdLine + "'")
   else          ->
     Process(
       cmdLine, handle, pid,
-      intrinsic{process_openstream}(handle, 0),
-      intrinsic{process_openstream}(handle, 1),
-      intrinsic{process_openstream}(handle, 2))
+      (flags & ProcessFlags.PipeStdIn) != 0 ? Option(intrinsic{process_openstream}(handle, 0)) : None(),
+      (flags & ProcessFlags.PipeStdOut) != 0 ? Option(intrinsic{process_openstream}(handle, 1)) : None(),
+      (flags & ProcessFlags.PipeStdErr) != 0 ? Option(intrinsic{process_openstream}(handle, 2)) : None())
 
 act sendInterupt(Process p) -> Option{Error}
   p.sendSignal(Signal.Interupt)
@@ -69,19 +82,24 @@ act sendSignal(Process p, Signal s) -> Option{Error}
     ? None()
     : Error("Failed to send signal: '" + s + "'")
 
+act readProcessOutPipe(Process p) -> Either{Option{string}, Error}
+  if p.stdOutPipe as sys_stream s -> s.readToEnd().map(lambda (string s) Option(s))
+  else                            -> Option{string}()
+
+act readProcessErrPipe(Process p) -> Either{Option{string}, Error}
+  if p.stdErrPipe as sys_stream s -> s.readToEnd().map(lambda (string s) Option(s))
+  else                            -> Option{string}()
+
 act wait(Either{Process, Error} pOrErr) -> Either{ProcessResult, Error}
   pOrErr.map(impure lambda (Process p) p.wait())
 
 act wait(Process p) -> Either{ProcessResult, Error}
-  stdOutRes = p.stdOut.readToEnd();
-  stdErrRes = p.stdErr.readToEnd();
+  exitCode = ExitCode(intrinsic{process_block}(p.handle));
+  stdOutRes = p.readProcessOutPipe();
+  stdErrRes = p.readProcessErrPipe();
   if stdOutRes as Error outErr -> outErr
   if stdErrRes as Error errErr -> errErr
-  else ->
-    ProcessResult(
-      stdOutRes ?? "",
-      stdErrRes ?? "",
-      ExitCode(intrinsic{process_block}(p.handle)))
+  else -> ProcessResult(stdOutRes ?? Option{string}(), stdErrRes ?? Option{string}(), exitCode)
 
 act waitAsync(Process p) -> future{Either{ProcessResult, Error}}
   fork p.wait()
@@ -105,25 +123,25 @@ assert(
     p.cmdLine == "'cmake' '-E' 'echo' 'Hello world'")
 
 assert(
-  run("cmake", "-E" :: "echo" :: "Hello world").wait(),
+  run("cmake", "-E" :: "echo" :: "Hello world", ProcessFlags.PipeInOut).wait(),
   lambda (Either{ProcessResult, Error} e)
-    e as ProcessResult r                &&
-    r.stdOut.startsWith("Hello world")  &&
-    r.stdErr.isEmpty()                  &&
+    e as ProcessResult r                        &&
+    (r.stdOut ?? "").startsWith("Hello world")  &&
+    (r.stdErr ?? "").isEmpty()                  &&
     r.exitCode == ExitCode(0))
 
 assert(
-  run("cmake", "--version" :: List{string}()).wait(),
+  run("cmake", "--version" :: List{string}(), ProcessFlags.PipeInOut).wait(),
   lambda (Either{ProcessResult, Error} e)
-    e as ProcessResult r                  &&
-    r.stdOut.startsWith("cmake version")  &&
-    r.stdErr.isEmpty()                    &&
+    e as ProcessResult r                          &&
+    (r.stdOut ?? "").startsWith("cmake version")  &&
+    (r.stdErr ?? "").isEmpty()                    &&
     r.exitCode == ExitCode(0))
 
 assert(
-  run("cmake", "invalid" :: List{string}()).wait(),
+  run("cmake", "invalid" :: List{string}(), ProcessFlags.PipeInOut).wait(),
   lambda (Either{ProcessResult, Error} e)
-    e as ProcessResult r                &&
-    r.stdOut.isEmpty()                  &&
-    r.stdErr.startsWith("CMake Error")  &&
+    e as ProcessResult r                        &&
+    (r.stdOut ?? "").isEmpty()                  &&
+    (r.stdErr ?? "").startsWith("CMake Error")  &&
     r.exitCode == ExitCode(1))

--- a/tests/vm/io_process_test.cpp
+++ b/tests/vm/io_process_test.cpp
@@ -176,6 +176,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that exits with code 0.
           asmb->addLoadLitString(novrtPath + " " + assertTrueNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -185,6 +186,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that exits with code 1.
           asmb->addLoadLitString(novrtPath + " " + failNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -194,6 +196,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that exits with code 14.
           asmb->addLoadLitString(novrtPath + " " + divByZeroNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -215,6 +218,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that prints to stdOut.
           asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -245,6 +249,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that prints to stdErr.
           asmb->addLoadLitString(novrtPath + " " + helloWorldErrNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -275,6 +280,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that reads a line from stdIn and write to stdOut.
           asmb->addLoadLitString(novrtPath + " " + readLineNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.
@@ -306,6 +312,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           // Run a program that prints the number of environment arguments.
           asmb->addLoadLitString(
               novrtPath + " " + printNumEnvArgsNx() + " a --b -ce hello 'hello world'");
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -328,6 +335,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessGetId);
 
@@ -349,6 +357,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addPop();
@@ -365,6 +374,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           // Sleep for 500 ms to give the child-process time to finish.
@@ -392,6 +402,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Start a process and save it in a variable.
           asmb->addLoadLitString(novrtPath + " " + helloWorldNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addStackStore(0);
 
@@ -433,6 +444,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString("non-existent arg1 arg2");
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -452,6 +464,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString("");
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -471,6 +484,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString(" ");
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -490,6 +504,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString(" \t \n \r " + novrtPath + " " + helloWorldNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addPCall(novasm::PCallCode::ProcessBlock);
 
@@ -508,6 +523,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
           asmb->setEntrypoint("entry");
 
           asmb->addLoadLitString(novrtPath + " " + printFirstArgNx() + " non-quoted\\'quoted\\'");
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
 
           asmb->addDup(); // Duplicate the process.
@@ -530,6 +546,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that waits until its interupted.
           asmb->addLoadLitString(novrtPath + " " + waitForInteruptNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.
@@ -568,6 +585,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that runs an infinite loop.
           asmb->addLoadLitString(novrtPath + " " + infiniteLoopNx());
+          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.


### PR DESCRIPTION
When running a child-process you can now specify what streams (stdin, stdout, stderr) to pipe and what streams to share. 

Previously streams where always piped, but this is less convenient for 'launcher' style applications that want to passthrough the streams to the child process.

This can be specified using a new `ProcessFlags` enum:
```
enum ProcessFlags =
  None        : 0b000,
  PipeStdIn   : 0b001,
  PipeStdOut  : 0b010,
  PipeStdErr  : 0b100,
  PipeOut     : 0b110,
  PipeInOut   : 0b111
  ```