### PR TITLE
frontend: Allow duplicate values in enum

### DIFF
--- a/include/frontend/diag_defs.hpp
+++ b/include/frontend/diag_defs.hpp
@@ -56,9 +56,6 @@ errFieldNameConflictsWithTypeSubstitution(prog::sym::SourceId src, const std::st
 [[nodiscard]] auto
 errDuplicateEntryNameInEnum(prog::sym::SourceId src, const std::string& entryName) -> Diag;
 
-[[nodiscard]] auto errDuplicateEntryValueInEnum(prog::sym::SourceId src, int32_t entryValue)
-    -> Diag;
-
 [[nodiscard]] auto errValueNotFoundInEnum(
     prog::sym::SourceId src, const std::string& entryName, const std::string& enumName) -> Diag;
 

--- a/src/frontend/diag_defs.cpp
+++ b/src/frontend/diag_defs.cpp
@@ -141,12 +141,6 @@ auto errDuplicateEntryNameInEnum(prog::sym::SourceId src, const std::string& ent
   return error(oss.str(), src);
 }
 
-auto errDuplicateEntryValueInEnum(prog::sym::SourceId src, int32_t entryValue) -> Diag {
-  std::ostringstream oss;
-  oss << "Value '" << entryValue << "' conflicts with a previous entry in the same enum";
-  return error(oss.str(), src);
-}
-
 auto errValueNotFoundInEnum(
     prog::sym::SourceId src, const std::string& entryName, const std::string& enumName) -> Diag {
   std::ostringstream oss;

--- a/src/frontend/internal/define_user_types.cpp
+++ b/src/frontend/internal/define_user_types.cpp
@@ -95,7 +95,6 @@ auto defineType(
 auto defineType(Context* ctx, prog::sym::TypeId id, const parse::EnumDeclStmtNode& n) -> bool {
 
   auto isValid      = true;
-  auto values       = std::unordered_set<int32_t>{};
   auto keys         = std::unordered_set<std::string>{};
   auto entries      = std::vector<prog::sym::EnumDef::Pair>{};
   int32_t lastValue = -1;
@@ -107,10 +106,6 @@ auto defineType(Context* ctx, prog::sym::TypeId id, const parse::EnumDeclStmtNod
 
     if (!keys.insert(name).second) {
       ctx->reportDiag(errDuplicateEntryNameInEnum, entry.getSpan(), name);
-      isValid = false;
-    }
-    if (!values.insert(value).second) {
-      ctx->reportDiag(errDuplicateEntryValueInEnum, entry.getSpan(), value);
       isValid = false;
     }
     entries.emplace_back(std::move(name), value);

--- a/tests/frontend/define_user_types_test.cpp
+++ b/tests/frontend/define_user_types_test.cpp
@@ -138,7 +138,6 @@ TEST_CASE("[frontend] Analyzing user-type definitions", "frontend") {
 
   SECTION("Enum diagnostics") {
     CHECK_DIAG("enum e = a, b, a", errDuplicateEntryNameInEnum(NO_SRC, "a"));
-    CHECK_DIAG("enum e = a : 1, b, c : 1", errDuplicateEntryValueInEnum(NO_SRC, 1));
   }
 }
 


### PR DESCRIPTION
Useful for flag enums:
```
enum PrettyTimeFlags =
  None            : 0b00,
  Default         : 0b10,
  IncludeMillies  : 0b01,
  IncludeTimeZone : 0b10
```