### PR TITLE
vm: By default run child-processes in the same process-group

### DIFF
--- a/examples/git-changelog.ns
+++ b/examples/git-changelog.ns
@@ -47,7 +47,7 @@ fun commitParser()
 // -- Actions
 
 act runGit(List{string} args) -> Either{string, Error}
-  run("git", args, ProcessFlags.PipeInOut).wait().map(impure lambda (ProcessResult r)
+  run("git", args, ProcessFlags.PipeInOut | ProcessFlags.NewGroup).wait().map(impure lambda (ProcessResult r)
     r.isSuccess() ? (r.stdOut ?? "") : Error("Failed to run git: " + (r.stdErr ?? "").trim())
   )
 

--- a/examples/run-tests.ns
+++ b/examples/run-tests.ns
@@ -27,7 +27,6 @@ act startTests()
     if platform() == Platform.Windows -> runPowerShell( "scripts/test.ps1", "-Dir"  :: "build")
     else                              -> runBash(       "scripts/test.sh",  "--dir" :: "build")
   );
-  atInterupt(shutdown[process]);
   TestRun(timeNow(), process)
 
 act getResult(TestRun run)

--- a/src/vm/internal/thread.cpp
+++ b/src/vm/internal/thread.cpp
@@ -58,7 +58,7 @@ auto threadSleepNano(int64_t time) noexcept -> bool {
 
   // TODO: This only has milliseconds resolution, investigate win32 alternatives with better
   // resolution.
-  unsigned long timeMilli = static_cast<unsigned long>(time) / 1'000'000;
+  auto timeMilli = static_cast<unsigned long>(time / 1'000'000);
   Sleep(timeMilli > 0 ? timeMilli : 1);
   return true; // The win32 sleep api cannot fail.
 

--- a/std/cli/api.ns
+++ b/std/cli/api.ns
@@ -21,6 +21,7 @@ struct CliCmd{T} =
 // -- Extension points
 
 fun cliIsInteruptable{T}(Type{T} commandInputType) true
+fun cliInteruptDelay{T}(Type{T} commandInputType) seconds(0)
 
 fun cliCleanupAction{T}(Type{T} commandInputType) cliNopCleanupAction()
 
@@ -32,7 +33,7 @@ fun cliCmdCfgFromRoutine{T}(CliCmd{T} c) -> Either{CliCmdCfg, Error}
 fun cliCmdCfgFromRoutine{T}(CliCmd{T} c, Meta{#9} structKind) -> Either{CliCmdCfg, Error}
   t = Type{T}();
   cliOptSetFromStruct(t).map(lambda (CliOptSet optSet)
-    CliCmdCfg(c.name, c.desc, optSet, cliIsInteruptable(t), cliCreateInvoker(c.routine), cliCleanupAction(t))
+    CliCmdCfg(c.name, c.desc, optSet, cliIsInteruptable(t), cliInteruptDelay(t), cliCreateInvoker(c.routine), cliCleanupAction(t))
   )
 
 fun cliCmdCfgFromRoutine{T, Idx}(CliCmd{T} c, Meta{Idx} unsupportedKind) -> Either{CliCmdCfg, Error}

--- a/std/cli/buildin.ns
+++ b/std/cli/buildin.ns
@@ -15,6 +15,7 @@ act cliBuildinCmd{T}(string name, string desc, action{T, CliResult, Option{Error
     desc,
     cliOptSetFromStruct(Type{T}()).failOnError(),
     false,
+    seconds(0),
     cliCreateInvoker(routine),
     cliNopCleanupAction())
 

--- a/std/cli/runner.ns
+++ b/std/cli/runner.ns
@@ -89,7 +89,7 @@ act cliPrintOverview(CliAppCfg app)
 act cliRunInteruptable(CliResult result) -> Option{Error}
   getUntilInterupt(fork result.cmd.routine(result)) as Error err
     ? cliReportError(result.app, result.cmd, err)
-    : interuptIsRequested() ? (print(" interrupted"); sleep(result.cmd.interuptDelay)) : None()
+    : interuptIsRequested() ? (sleep(result.cmd.interuptDelay); print(" interrupted")) : None()
 
 act cliRunNonInteruptable(CliResult result) -> Option{Error}
   result.cmd.routine(result) as Error err

--- a/std/cli/runner.ns
+++ b/std/cli/runner.ns
@@ -13,6 +13,7 @@ struct CliCmdCfg =
   string                            desc,
   CliOptSet                         opts,
   bool                              interuptable,
+  Duration                          interuptDelay,
   action{CliResult, Option{Error}}  routine,
   action{Option{Error}}             cleanup
 
@@ -39,7 +40,7 @@ fun CliCmdCfg()
   CliCmdCfg(CliOptSet())
 
 fun CliCmdCfg(CliOptSet optSet)
-  CliCmdCfg("", "", optSet, true,
+  CliCmdCfg("", "", optSet, true, seconds(0),
   impure lambda (CliResult r) Option{Error}(Error("Not implemented")),
   cliNopCleanupAction())
 
@@ -88,7 +89,7 @@ act cliPrintOverview(CliAppCfg app)
 act cliRunInteruptable(CliResult result) -> Option{Error}
   getUntilInterupt(fork result.cmd.routine(result)) as Error err
     ? cliReportError(result.app, result.cmd, err)
-    : interuptIsRequested() ? print(" interrupted") : None()
+    : interuptIsRequested() ? (print(" interrupted"); sleep(result.cmd.interuptDelay)) : None()
 
 act cliRunNonInteruptable(CliResult result) -> Option{Error}
   result.cmd.routine(result) as Error err

--- a/std/io/process.ns
+++ b/std/io/process.ns
@@ -9,12 +9,13 @@ struct ProcessId  = long id
 struct ExitCode   = int code
 
 enum ProcessFlags =
-  None        : 0b000,
-  PipeStdIn   : 0b001,
-  PipeStdOut  : 0b010,
-  PipeStdErr  : 0b100,
-  PipeOut     : 0b110,
-  PipeInOut   : 0b111
+  None        : 0b0000,
+  PipeStdIn   : 0b0001,
+  PipeStdOut  : 0b0010,
+  PipeStdErr  : 0b0100,
+  PipeOut     : 0b0110,
+  PipeInOut   : 0b0111,
+  NewGroup    : 0b1000
 
 enum Signal =
   Interupt  : 0,

--- a/tests/vm/io_process_test.cpp
+++ b/tests/vm/io_process_test.cpp
@@ -546,7 +546,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that waits until its interupted.
           asmb->addLoadLitString(novrtPath + " " + waitForInteruptNx());
-          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
+          asmb->addLoadLitInt(15); // Pipe stdIn, stdOut and stdErr and create a new process group.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.
@@ -585,7 +585,7 @@ TEST_CASE("[vm] Execute process platform-calls", "vm") {
 
           // Run a program that runs an infinite loop.
           asmb->addLoadLitString(novrtPath + " " + infiniteLoopNx());
-          asmb->addLoadLitInt(7); // Pipe stdIn, stdOut and stdErr.
+          asmb->addLoadLitInt(15); // Pipe stdIn, stdOut and stdErr and create a new process group.
           asmb->addPCall(novasm::PCallCode::ProcessStart);
           asmb->addDup(); // Duplicate the process.
           asmb->addDup(); // Duplicate the process.

--- a/utilities/nov-watch.ns
+++ b/utilities/nov-watch.ns
@@ -74,6 +74,8 @@ act evaluateAction(Context ctx)
     if run as Process process -> process.wait(); None()
   )
 
+fun cliInteruptDelay(Type{EvaluateSettings} t) seconds(1)
+
 act evaluateCmd(EvaluateSettings s)
   ctx   = Context(s, consoleOpen().failOnError(), EndsWithTextPattern(".ns"));
   path  = ctx.getPath();


### PR DESCRIPTION
By default run child processes in the same process-group, adds a new process creation flag for creating a new group.