### PR TITLE
cdb: Edit mode and various improvements

### DIFF
--- a/std/cli/api.ns
+++ b/std/cli/api.ns
@@ -99,3 +99,11 @@ act cli{T1, T2, T3, T4, T5, T6, T7}(CliCmd{T1} cmd1, CliCmd{T2} cmd2, CliCmd{T3}
 act cli{T1, T2, T3, T4, T5, T6, T7, T8}(CliCmd{T1} cmd1, CliCmd{T2} cmd2, CliCmd{T3} cmd3, CliCmd{T4} cmd4, CliCmd{T5} cmd5, CliCmd{T6} cmd6, CliCmd{T7} cmd7, CliCmd{T8} cmd8, CliAppInfo appInfo = cliAppInfo())
   cmds = cliCmdCfgFromRoutines(Tuple(cmd1, cmd2, cmd3, cmd4, cmd5, cmd6, cmd7, cmd8)).failOnError();
   cliRun(CliAppCfg(appInfo.name, appInfo.desc, appInfo.ver, appInfo.bin, None(), cmds :: cliBuildinCmds()))
+
+act cli{T1, T2, T3, T4, T5, T6, T7, T8, T9}(CliCmd{T1} cmd1, CliCmd{T2} cmd2, CliCmd{T3} cmd3, CliCmd{T4} cmd4, CliCmd{T5} cmd5, CliCmd{T6} cmd6, CliCmd{T7} cmd7, CliCmd{T8} cmd8, CliCmd{T9} cmd9, CliAppInfo appInfo = cliAppInfo())
+  cmds = cliCmdCfgFromRoutines(Tuple(cmd1, cmd2, cmd3, cmd4, cmd5, cmd6, cmd7, cmd8, cmd9)).failOnError();
+  cliRun(CliAppCfg(appInfo.name, appInfo.desc, appInfo.ver, appInfo.bin, None(), cmds :: cliBuildinCmds()))
+
+act cli{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}(CliCmd{T1} cmd1, CliCmd{T2} cmd2, CliCmd{T3} cmd3, CliCmd{T4} cmd4, CliCmd{T5} cmd5, CliCmd{T6} cmd6, CliCmd{T7} cmd7, CliCmd{T8} cmd8, CliCmd{T9} cmd9, CliCmd{T10} cmd10, CliAppInfo appInfo = cliAppInfo())
+  cmds = cliCmdCfgFromRoutines(Tuple(cmd1, cmd2, cmd3, cmd4, cmd5, cmd6, cmd7, cmd8, cmd9, cmd10)).failOnError();
+  cliRun(CliAppCfg(appInfo.name, appInfo.desc, appInfo.ver, appInfo.bin, None(), cmds :: cliBuildinCmds()))

--- a/std/io/readline.ns
+++ b/std/io/readline.ns
@@ -9,6 +9,7 @@ struct RlSettings =
   sys_stream    in,
   sys_stream    out,
   List{string}  options,
+  string        startingLine,
   string        prompt,
   bool          useColor
 
@@ -191,7 +192,7 @@ fun rlApplyInput(RlState s, RlInput input) -> RlState
   else                        -> s
 
 act rlLoop(RlSettings s) -> Either{RlResult, Error}
-  state       = RlState("", 0, 0);
+  state       = RlState(s.startingLine, s.startingLine.length(), 0);
   inputParser = rlInputListParser();
   renderer    = rlStateWriter(s);
   if rlRenderState(s, state, renderer) as Error renderErr -> renderErr
@@ -212,7 +213,7 @@ act rlLoop(RlSettings s, RlState state, Parser{List{RlInput}} parser, Writer{RlS
 // -- Api
 
 act rlSettings(Console c, List{string} options = List{string}(), string prompt = "> ") -> RlSettings
-  RlSettings(c.stdIn, c.stdOut, options, prompt, c.allowColor())
+  RlSettings(c.stdIn, c.stdOut, options, "", prompt, c.allowColor())
 
 act ttyReadLine(Console c) -> Either{RlResult, Error}
   ttyReadLine(rlSettings(c))

--- a/utilities/cdb/app.ns
+++ b/utilities/cdb/app.ns
@@ -4,6 +4,7 @@
 import "std.ns"
 
 import "cmd/add.ns"
+import "cmd/edit.ns"
 import "cmd/export.ns"
 import "cmd/get.ns"
 import "cmd/import.ns"
@@ -17,9 +18,10 @@ cli(cliCmd("get",     getCmd,     "Get an entry from the database"),
     cliCmd("rm",      removeCmd,  "Remove entries from the database"),
     cliCmd("list",    listCmd,    "List all commands stored in the database"),
     cliCmd("undo",    undoCmd,    "Restore the latest backup"),
+    cliCmd("edit",    editCmd,    "Edit an entry in the database"),
     cliCmd("install", installCmd, "Install shell aliases"),
     cliCmd("export",  exportCmd,  "Export the database to a json file"),
     cliCmd("import",  importCmd,  "Import a database json file"),
     cliAppInfo(
       "Command DataBase", "Simple database for storing shell commands.",
-      Version(0, 7, 0)))
+      Version(0, 8, 0)))

--- a/utilities/cdb/cmd/add.ns
+++ b/utilities/cdb/cmd/add.ns
@@ -1,6 +1,7 @@
 import "std.ns"
 
 import "../database.ns"
+import "../utils.ns"
 import "../writer.ns"
 
 struct AddSettings =
@@ -8,19 +9,13 @@ struct AddSettings =
   CliPositional{Option{Path}}         path,
   CliPositional{Option{List{string}}} args
 
-act createCmd(AddSettings s) -> Either{Cmd, Error}
-  args = (s.args.val ?? List{string}());
-  absPath = pathAbsolute(s.path.val ?? pathCurrent());
-  if !fileExists(absPath) -> Error("No file found at path: '" + absPath + '\'')
-  else                    -> Cmd(absPath, args)
-
 act addToDb(Database db, string key, Cmd cmd) -> Either{Database, Error}
   if db[key] is Entry -> Error("Key '" + key + "' already exists")
   else                -> db.addEntry(Entry(key, cmd, timeNow(), timeNow()))
 
 act addCmd(AddSettings s) -> Option{Error}
   c   = consoleOpen().failOnError();
-  cmd = createCmd(s).failOnError();
+  cmd = buildCmd(s.path.val ?? pathCurrent(), s.args.val ?? List{string}()).failOnError();
   key = s.key.val;
   transaction(addToDb[cmd][key], TransactionFlags.Backup).failOnError();
   writer = litWriter("Added '") & stringWriter() & litWriter("': ") & cmdWriter() & newlineWriter();

--- a/utilities/cdb/cmd/edit.ns
+++ b/utilities/cdb/cmd/edit.ns
@@ -1,0 +1,33 @@
+import "std.ns"
+
+import "../database.ns"
+import "../utils.ns"
+import "../writer.ns"
+
+struct EditSettings =
+  bool                                noColor,
+  CliPositional{string}               key,
+  CliPositional{Option{Path}}         path,
+  CliPositional{Option{List{string}}} args
+
+act editInteractive(Console c, Cmd cmd, EditSettings s) -> Either{Cmd, Error}
+  inStream    = c.stdIn;
+  outStream   = getInteractiveOutputStream(c).failOnError();
+  rlSettings  = RlSettings(inStream, outStream, List{string}(), cmdWriter().run(cmd), "> ", !s.noColor);
+  res         = ttyReadLine(rlSettings).failOnError();
+  if res as RlResultSuccess success -> buildCmd(success.text)
+  if res is RlResultCancelled       -> Error("Cancelled")
+
+act updateDbEntry(Database db, Entry entry) -> Either{Database, Error}
+  db.updateEntry(entry)
+
+act editCmd(EditSettings s) -> Option{Error}
+  c  = consoleOpen().failOnError();
+  db = loadDb().failOnError();
+  if db[s.key.val] as Entry entry ->
+  ( newCmd = ( s.path.val as Path p ? buildCmd(p, s.args.val ?? List{string}())
+                                    : editInteractive(c, entry.value, s) ).failOnError();
+    transaction(updateDbEntry[Entry(entry.key, newCmd, entry.creationTime, entry.accessTime)]) )
+  else -> Error("No entry found with key: '" + s.key.val + '\'')
+
+fun cliIsInteruptable(Type{EditSettings} s) false

--- a/utilities/cdb/cmd/edit.ns
+++ b/utilities/cdb/cmd/edit.ns
@@ -27,7 +27,10 @@ act editCmd(EditSettings s) -> Option{Error}
   if db[s.key.val] as Entry entry ->
   ( newCmd = ( s.path.val as Path p ? buildCmd(p, s.args.val ?? List{string}())
                                     : editInteractive(c, entry.value, s) ).failOnError();
-    transaction(updateDbEntry[Entry(entry.key, newCmd, entry.creationTime, entry.accessTime)]) )
+    transaction(updateDbEntry[Entry(entry.key, newCmd, entry.creationTime, entry.accessTime)]).failOnError();
+    writer = litWriter("Updated '") & stringWriter() & litWriter("': ") & cmdWriter() & newlineWriter();
+    c.writeOut(writer, Tuple(entry.key, newCmd))
+  )
   else -> Error("No entry found with key: '" + s.key.val + '\'')
 
 fun cliIsInteruptable(Type{EditSettings} s) false

--- a/utilities/cdb/cmd/get.ns
+++ b/utilities/cdb/cmd/get.ns
@@ -39,7 +39,7 @@ act getCmdInteractive(GetSettings s)
   outStream   = getInteractiveOutputStream(c).failOnError();
   db          = loadDb().failOnError();
   keys        = db.entries.filterEntries(s.type).sort(getCmdEntryOrder).map(lambda (Entry e) e.key);
-  rlSettings  = RlSettings(inStream, outStream, keys, "> ", !s.noColor);
+  rlSettings  = RlSettings(inStream, outStream, keys, "", "> ", !s.noColor);
   res         = ttyReadLine(rlSettings).failOnError();
   if res as RlResultSuccess success -> getCmdWithKey(s, success.text)
   if res is RlResultCancelled       -> fail("Cancelled")

--- a/utilities/cdb/cmd/list.ns
+++ b/utilities/cdb/cmd/list.ns
@@ -11,7 +11,8 @@ struct ListSettings =
   Option{int}   width,
   bool          time,
   ListSortMode  sort,
-  bool          noColor
+  bool          noColor,
+  bool          keysOnly
 
 fun orderListEntry(Entry e1, Entry e2, ListSettings s)
   if s.sort == ListSortMode.CreationTime  -> orderEntryCreationTime(e1, e2)
@@ -38,7 +39,8 @@ act listCmd(ListSettings s) -> Option{Error}
   entries       = db.entries.filterEntries(s.type).map(updateTimeToLocal).sortListEntries(s);
   maxKeyWidth   = getMaxEntryKeySize(entries);
   maxTotalWidth = s.width ?? (c.termGetWidth() ?? 80);
-  writer        = listWriter(entryWriter(s.time, maxKeyWidth, maxTotalWidth, color), newlineWriter()) & newlineWriter();
+  entryWriter   = s.keysOnly ? entryKeyWriter() : entryWriter(s.time, maxKeyWidth, maxTotalWidth, color);
+  writer        = listWriter(entryWriter, newlineWriter()) & newlineWriter();
   if entries.isEmpty() -> c.writeOut(getListErrorMessage(s))
   else                 -> c.writeOut(writer, entries)
 

--- a/utilities/cdb/cmd/list.ns
+++ b/utilities/cdb/cmd/list.ns
@@ -7,12 +7,13 @@ import "../writer.ns"
 enum ListSortMode = Key, Path, CreationTime, AccessTime
 
 struct ListSettings =
-  EntryType     type,
-  Option{int}   width,
-  bool          time,
-  ListSortMode  sort,
-  bool          noColor,
-  bool          keysOnly
+  EntryType       type,
+  GlobTextPattern filter,
+  Option{int}     width,
+  bool            time,
+  ListSortMode    sort,
+  bool            noColor,
+  bool            keysOnly
 
 fun orderListEntry(Entry e1, Entry e2, ListSettings s)
   if s.sort == ListSortMode.CreationTime  -> orderEntryCreationTime(e1, e2)
@@ -29,14 +30,15 @@ fun getListErrorMessage(ListSettings s)
   else                              -> "No entries in database\n"
 
 fun cliDefaults(Type{ListSettings} t)
-  CliDefault("type", "any") ::
-  CliDefault("sort", "key")
+  CliDefault("type",    "any") ::
+  CliDefault("filter",  "*")   ::
+  CliDefault("sort",    "key")
 
 act listCmd(ListSettings s) -> Option{Error}
   c             = consoleOpen().failOnError();
   db            = loadDb().failOnError();
   color         = !s.noColor && c.allowColor();
-  entries       = db.entries.filterEntries(s.type).map(updateTimeToLocal).sortListEntries(s);
+  entries       = db.entries.filterEntries(s.type, s.filter).map(updateTimeToLocal).sortListEntries(s);
   maxKeyWidth   = getMaxEntryKeySize(entries);
   maxTotalWidth = s.width ?? (c.termGetWidth() ?? 80);
   entryWriter   = s.keysOnly ? entryKeyWriter() : entryWriter(s.time, maxKeyWidth, maxTotalWidth, color);

--- a/utilities/cdb/cmd/remove.ns
+++ b/utilities/cdb/cmd/remove.ns
@@ -3,7 +3,7 @@ import "std.ns"
 import "../database.ns"
 
 struct RemoveSettings =
-  CliPositional{List{string}} keys
+  CliPositional{Option{List{string}}} keys
 
 act removeFromDb(Database db, List{string} keys) -> Either{Database, Error}
   keys.fold(lambda (Either{Database, Error} res, string key) -> Either{Database, Error}
@@ -13,9 +13,20 @@ act removeFromDb(Database db, List{string} keys) -> Either{Database, Error}
       else                -> db.removeEntry(key)
   , Either{Database, Error}(db))
 
+act getRemoveInputText(Console c) -> string
+  if c.isTerm() -> ttyReadLine(c).failOnError() as RlResultSuccess success ? success.text : ""
+  else          -> (getUntilInterupt(fork c.readToEnd()) ?? "").failOnError()
+
+act getKeysToRemoveFromInput(Console c) -> List{string}
+  getRemoveInputText(c).split(equals{char}['\n'])
+
+act getKeysToRemove(RemoveSettings s, Console c) -> List{string}
+  if s.keys.val as List{string} keys -> keys
+  else                               -> getKeysToRemoveFromInput(c)
+
 act removeCmd(RemoveSettings s) -> Option{Error}
   c     = consoleOpen().failOnError();
-  keys  = s.keys.val;
+  keys  = getKeysToRemove(s, c);
   if transaction(removeFromDb[keys], TransactionFlags.Backup) as Error err  -> fail(err)
   else ->
     writer = listWriter(litWriter("Removed '") & stringWriter() & litWriter('\'') & newlineWriter());

--- a/utilities/cdb/utils.ns
+++ b/utilities/cdb/utils.ns
@@ -27,6 +27,19 @@ act getInteractiveOutputStream(Console c) -> Either{sys_stream, Error}
 act updateTimeToLocal(Entry e) -> Entry
   Entry(e.key, e.value, timeToLocal(e.creationTime), timeToLocal(e.accessTime))
 
+act buildCmd(string str) -> Either{Cmd, Error}
+  parts = str.split(equals{char}[' ']);
+  if parts.front() as string path ->
+    pathAbsParser().run(path).map(impure lambda (PathAbsolute absPath) buildCmd(absPath, parts.pop()))
+  else -> Error("Invalid command string")
+
+act buildCmd(Path path, List{string} args) -> Either{Cmd, Error}
+  buildCmd(pathAbsolute(path), args)
+
+act buildCmd(PathAbsolute path, List{string} args) -> Either{Cmd, Error}
+  if !fileExists(path) -> Error("No file found at path: '" + path + '\'')
+  else                 -> Cmd(path, args)
+
 // -- Filtering
 
 enum EntryType = Directory, File, Any

--- a/utilities/cdb/utils.ns
+++ b/utilities/cdb/utils.ns
@@ -44,10 +44,12 @@ act buildCmd(PathAbsolute path, List{string} args) -> Either{Cmd, Error}
 
 enum EntryType = Directory, File, Any
 
-act entryMatchesFilter(Entry e, EntryType t)
-  if t == EntryType.Directory -> fileType(e.value.path) == FileType.Directory
-  if t == EntryType.File      -> ft = fileType(e.value.path); ft == FileType.Regular || ft == FileType.Symlink
-  else                        -> true
+act entryMatchesFilter(Entry e, EntryType t, TextPattern filter = AnyTextPattern())
+  if !filter.textMatch(e.key) -> false
+  else -> (
+    if t == EntryType.Directory -> fileType(e.value.path) == FileType.Directory
+    if t == EntryType.File      -> ft = fileType(e.value.path); ft == FileType.Regular || ft == FileType.Symlink
+    else                        -> true )
 
-act filterEntries(List{Entry} entries, EntryType t)
-  entries.filter(entryMatchesFilter[t])
+act filterEntries(List{Entry} entries, EntryType t, TextPattern filter = AnyTextPattern()) -> List{Entry}
+  entries.filter(entryMatchesFilter[filter][t])

--- a/utilities/cdb/writer.ns
+++ b/utilities/cdb/writer.ns
@@ -34,3 +34,6 @@ fun entryWriter(bool includeTime, int padKeyUntilCol = 15, int maxCol = 80, bool
     splitWriter(cmdWriter(), wrapWriter(stringWriter(), maxCol, newlineWriter() & padUntilWriter(padKeyUntilCol + 4))) &
     ?(newlineWriter() & entryTimeWriter(padKeyUntilCol + 2, color))
   ).map(lambda (Entry e) Tuple(e.key, e.value, includeTime ? e : None()))
+
+fun entryKeyWriter() -> Writer{Entry}
+  stringWriter().map(lambda (Entry e) e.key)


### PR DESCRIPTION
Add an `edit` command to cdb for editing existing entries:
[![asciicast](https://asciinema.org/a/4OPWoRqZ0ZqCIWt2ukPoS2f5H.svg)](https://asciinema.org/a/4OPWoRqZ0ZqCIWt2ukPoS2f5H)

Also includes various other improvements, like the `list` cmd now has a filter and `--keys-only` flag and `rm` cmd can take the keys to remove from the input stream. This allows pipe-lining them:
```bash
cdb list -f "novus*" -k | cdb rm
```
[![asciicast](https://asciinema.org/a/414101.svg)](https://asciinema.org/a/414101)