### PR TITLE
std: Add support for filtered help in cli lib

### DIFF
--- a/std/cli/buildin.ns
+++ b/std/cli/buildin.ns
@@ -41,11 +41,24 @@ act cliVersionCmd(CliVersionConfig cfg, CliResult res)
 // -- Help
 
 struct CliHelpConfig =
-  bool color,
-  bool noColor
+  CliPositional{Option{string}} command,
+  bool                          color,
+  bool                          noColor
+
+fun cliGetHelpCmd(CliResult res, string name) -> Option{CliHelpCmd}
+  if res.app.cmds.first(lambda (CliCmdCfg c) name == c.name) as CliCmdCfg cmd -> CliHelpCmd(res.app, cmd)
+  else                                                                        -> None()
 
 act cliHelpCmd(CliHelpConfig cfg, CliResult res)
   consoleOpen().map(impure lambda (Console c)
     helpWriterCfg = CliHelpCfg((cfg.color || c.allowColor()) && !cfg.noColor);
-    c.writeOut(cliHelpWriter(helpWriterCfg), res.app)
+    if cfg.command.val as string cmdName ->
+    (
+      if cliGetHelpCmd(res, cmdName) as CliHelpCmd cmd -> c.writeOut(cliHelpCmdWriter(helpWriterCfg), cmd)
+      else                                             -> cliReportUnknownCommand(res.app, cmdName)
+    )
+    else ->
+    (
+      c.writeOut(cliHelpWriter(helpWriterCfg), res.app)
+    )
   )


### PR DESCRIPTION
Add support for printing the help page for a single command only in the cli lib:
![image](https://user-images.githubusercontent.com/14230060/118323212-f766b000-b508-11eb-9207-d8b88d8396fb.png)

Even for the help page itself :)
![image](https://user-images.githubusercontent.com/14230060/118323254-02b9db80-b509-11eb-9d94-1a4a5aa7c892.png)
