### PR TITLE
cdb: Minor 'edit' command fixes

### DIFF
--- a/std/io/path.ns
+++ b/std/io/path.ns
@@ -142,6 +142,16 @@ fun pathCannonize(PathRelative p) -> PathRelative
     ), Tuple(List{string}(), 0)).f1
   )
 
+fun pathContainsWhitespace(Path p)
+  if p as PathAbsolute abs -> abs.pathContainsWhitespace()
+  if p as PathRelative rel -> rel.pathContainsWhitespace()
+
+fun pathContainsWhitespace(PathRelative p)
+  p.segments.any(lambda (string s) s.any(isWhitespace))
+
+fun pathContainsWhitespace(PathAbsolute p)
+  p.root.any(isWhitespace) || p.path.pathContainsWhitespace()
+
 // -- Parsers
 
 fun pathRelParser{UntilT}(Parser{UntilT} until = endParser()) -> Parser{PathRelative}

--- a/utilities/cdb/cmd/edit.ns
+++ b/utilities/cdb/cmd/edit.ns
@@ -11,10 +11,11 @@ struct EditSettings =
   CliPositional{Option{List{string}}} args
 
 act editInteractive(Console c, Cmd cmd, EditSettings s) -> Either{Cmd, Error}
-  inStream    = c.stdIn;
-  outStream   = getInteractiveOutputStream(c).failOnError();
-  rlSettings  = RlSettings(inStream, outStream, List{string}(), cmdWriter().run(cmd), "> ", !s.noColor);
-  res         = ttyReadLine(rlSettings).failOnError();
+  inStream      = c.stdIn;
+  outStream     = getInteractiveOutputStream(c).failOnError();
+  cmdWriteFlags = cmd.path.pathContainsWhitespace() ? CmdWriteFlags.QuotePath : CmdWriteFlags.None;
+  rlSettings    = RlSettings(inStream, outStream, List{string}(), cmdWriter(cmdWriteFlags).run(cmd), "> ", !s.noColor);
+  res           = ttyReadLine(rlSettings).failOnError();
   if res as RlResultSuccess success -> buildCmd(success.text)
   if res is RlResultCancelled       -> Error("Cancelled")
 

--- a/utilities/cdb/cmd/edit.ns
+++ b/utilities/cdb/cmd/edit.ns
@@ -27,7 +27,8 @@ act editCmd(EditSettings s) -> Option{Error}
   if db[s.key.val] as Entry entry ->
   ( newCmd = ( s.path.val as Path p ? buildCmd(p, s.args.val ?? List{string}())
                                     : editInteractive(c, entry.value, s) ).failOnError();
-    transaction(updateDbEntry[Entry(entry.key, newCmd, entry.creationTime, entry.accessTime)]).failOnError();
+    newEntry = Entry(entry.key, newCmd, entry.creationTime, entry.accessTime);
+    transaction(updateDbEntry[newEntry], TransactionFlags.Backup).failOnError();
     writer = litWriter("Updated '") & stringWriter() & litWriter("': ") & cmdWriter() & newlineWriter();
     c.writeOut(writer, Tuple(entry.key, newCmd))
   )

--- a/utilities/cdb/utils.ns
+++ b/utilities/cdb/utils.ns
@@ -17,6 +17,13 @@ fun orderEntryPath(Entry e1, Entry e2)
 fun getMaxEntryKeySize(List{Entry} entries)
   entries.fold(lambda (int max, Entry e) e.key.length() > max ? e.key.length() : max)
 
+fun splitCommandLineString(string str) -> Either{List{string}, Error}
+  makeQuotedParser  = (lambda (char q) qp = matchParser(q); qp >> untilParser(qp) << qp);
+  singleQuoteParser = makeQuotedParser('\'') << whitespaceParser();
+  doubleQuoteParser = makeQuotedParser('\"') << whitespaceParser();
+  nonQuotedParser   = untilParser(isWhitespace) << whitespaceParser();
+  manyParser(singleQuoteParser | doubleQuoteParser | nonQuotedParser).run(str)
+
 // -- Utility actions
 
 act getInteractiveOutputStream(Console c) -> Either{sys_stream, Error}
@@ -28,10 +35,12 @@ act updateTimeToLocal(Entry e) -> Entry
   Entry(e.key, e.value, timeToLocal(e.creationTime), timeToLocal(e.accessTime))
 
 act buildCmd(string str) -> Either{Cmd, Error}
-  parts = str.split(equals{char}[' ']);
-  if parts.front() as string path ->
-    pathAbsParser().run(path).map(impure lambda (PathAbsolute absPath) buildCmd(absPath, parts.pop()))
-  else -> Error("Invalid command string")
+  partsOrErr = splitCommandLineString(str);
+  if partsOrErr as Error        err -> err
+  if partsOrErr as List{string} parts ->
+    if parts.front() as string path ->
+      pathAbsParser().run(path).map(impure lambda (PathAbsolute absPath) buildCmd(absPath, parts.pop()))
+    else -> Error("Invalid command string")
 
 act buildCmd(Path path, List{string} args) -> Either{Cmd, Error}
   buildCmd(pathAbsolute(path), args)


### PR DESCRIPTION
Minor fixes:
* Support spaces in path with the `edit` command.
* Run `edit` command as a backed-up transaction (so i can be `undo`ed)