### PR TITLE
Feature/cdb 0.10

### DIFF
--- a/std/io/console.ns
+++ b/std/io/console.ns
@@ -149,13 +149,19 @@ act setNoBlockInput(Console c) -> Option{Error}
 act unsetNoBlockInput(Console c) -> Option{Error}
   c.stdIn.unsetOptions(StreamOptions.NoBlock)
 
-act termGetWidth(Console c) -> Either{int, Error}
-  w = intrinsic{term_getwidth}(c.stdOut);
+act termGetWidth(sys_stream stream) -> Either{int, Error}
+  w = intrinsic{term_getwidth}(stream);
   w >= 0 ? w : platformError("Failed to get the terminal width")
 
-act termGetHeight(Console c) -> Either{int, Error}
-  h = intrinsic{term_getheight}(c.stdOut);
+act termGetWidth(Console c) -> Either{int, Error}
+  termGetWidth(c.stdOut)
+
+act termGetHeight(sys_stream stream) -> Either{int, Error}
+  h = intrinsic{term_getheight}(stream);
   h >= 0 ? h : platformError("Failed to get the terminal height")
+
+act termGetHeight(Console c) -> Either{int, Error}
+  termGetHeight(c.stdOut)
 
 act termSetOptions(sys_stream s, TerminalOptions opts) -> Option{Error}
   intrinsic{term_setoptions}(s, int(opts))

--- a/std/io/readline.ns
+++ b/std/io/readline.ns
@@ -18,12 +18,15 @@ struct RlSettings =
 fun rlTermOpts() TerminalOptions.NoEcho | TerminalOptions.NoBuffer
 
 act rlSetup(RlSettings s) -> Option{Error}
-  if !s.in.isTerm() || !s.out.isTerm()  -> Error("ReadLine requires an interactive input and output stream")
-  else                                  -> s.in.termSetOptions(rlTermOpts())
+  if !s.in.isTerm() || !s.out.isTerm() -> Error("ReadLine requires an interactive input and output stream")
+  else -> actSeq(
+    lazy s.out.write(ttyLitLineWrapWriter(false).run(None())),
+    lazy s.in.termSetOptions(rlTermOpts())
+  )
 
 act rlTeardown(RlSettings s) -> Option{Error}
   actSeq(
-    lazy s.out.write(ttyResetLineWriter().run(None())),
+    lazy s.out.write((ttyLitLineWrapWriter(true) & ttyResetLineWriter()).run(None())),
     lazy s.in.termUnsetOptions(rlTermOpts())
   )
 

--- a/std/io/tty.ns
+++ b/std/io/tty.ns
@@ -132,6 +132,14 @@ fun ttyCursorShowWriter() -> Writer{bool}
 fun ttyLitCursorShowWriter(bool show) -> Writer{None}
   litWriter(ttyEsc() + "[?25" + (show ? 'h' : 'l'))
 
+fun ttyLineWrapWriter() -> Writer{bool}
+  (
+    litWriter(ttyEsc() + "[?7") & charWriter()
+  ).map(lambda (bool wrap) wrap ? 'h' : 'l')
+
+fun ttyLitLineWrapWriter(bool wrap) -> Writer{None}
+  litWriter(ttyEsc() + "[?7" + (wrap ? 'h' : 'l'))
+
 fun ttyCursorBlinkWriter() -> Writer{bool}
   (
     litWriter(ttyEsc() + "[?12") & charWriter()

--- a/utilities/cdb/app.ns
+++ b/utilities/cdb/app.ns
@@ -24,4 +24,4 @@ cli(cliCmd("get",     getCmd,     "Get an entry from the database"),
     cliCmd("import",  importCmd,  "Import a database json file"),
     cliAppInfo(
       "Command DataBase", "Simple database for storing shell commands.",
-      Version(0, 8, 0)))
+      Version(0, 9, 0)))

--- a/utilities/cdb/cmd/add.ns
+++ b/utilities/cdb/cmd/add.ns
@@ -14,11 +14,14 @@ act addToDb(Database db, string key, Cmd cmd) -> Either{Database, Error}
   else                -> db.addEntry(Entry(key, cmd, timeNow(), timeNow()))
 
 act addCmd(AddSettings s) -> Option{Error}
-  c   = consoleOpen().failOnError();
-  cmd = buildCmd(s.path.val ?? pathCurrent(), s.args.val ?? List{string}()).failOnError();
-  key = s.key.val;
-  transaction(addToDb[cmd][key], TransactionFlags.Backup).failOnError();
-  writer = litWriter("Added '") & stringWriter() & litWriter("': ") & cmdWriter() & newlineWriter();
-  c.writeOut(writer, Tuple(key, cmd))
+  c         = consoleOpen().failOnError();
+  cmdOrErr  = buildCmd(s.path.val ?? pathCurrent(), s.args.val ?? List{string}());
+  if cmdOrErr as Error cmdErr -> cmdErr
+  if cmdOrErr as Cmd   cmd    ->
+    key      = s.key.val;
+    if transaction(addToDb[cmd][key], TransactionFlags.Backup) as Error transErr -> transErr
+    else ->
+      writer   = litWriter("Added '") & stringWriter() & litWriter("': ") & cmdWriter() & newlineWriter();
+      c.writeOut(writer, Tuple(key, cmd))
 
 fun cliIsInteruptable(Type{AddSettings} s) false

--- a/utilities/cdb/cmd/edit.ns
+++ b/utilities/cdb/cmd/edit.ns
@@ -17,10 +17,15 @@ act getEditKey(Console c, Database db, EditSettings s) -> Either{string, Error}
     outStream = getInteractiveOutputStream(c).failOnError();
     getKeyInteractive(db, EntryType.Any, inStream, outStream, !s.noColor)
 
+fun getEditCmdWriteFlags(Cmd cmd) -> CmdWriteFlags
+  CmdWriteFlags.None
+  | (cmd.path.pathContainsWhitespace() ? CmdWriteFlags.QuotePath : CmdWriteFlags.None)
+  | (cmd.args.any(lambda (string s) s.any(isWhitespace)) ? CmdWriteFlags.QuoteArgs : CmdWriteFlags.None)
+
 act editInteractive(Console c, Cmd cmd, EditSettings s) -> Either{Cmd, Error}
   inStream      = c.stdIn;
   outStream     = getInteractiveOutputStream(c).failOnError();
-  cmdWriteFlags = cmd.path.pathContainsWhitespace() ? CmdWriteFlags.QuotePath : CmdWriteFlags.None;
+  cmdWriteFlags = getEditCmdWriteFlags(cmd);
   rlSettings    = RlSettings(inStream, outStream, List{string}(), cmdWriter(cmdWriteFlags).run(cmd), "> ", !s.noColor);
   res           = ttyReadLine(rlSettings).failOnError();
   if res as RlResultSuccess success -> buildCmd(success.text)

--- a/utilities/cdb/cmd/edit.ns
+++ b/utilities/cdb/cmd/edit.ns
@@ -6,9 +6,16 @@ import "../writer.ns"
 
 struct EditSettings =
   bool                                noColor,
-  CliPositional{string}               key,
+  CliPositional{Option{string}}       key,
   CliPositional{Option{Path}}         path,
   CliPositional{Option{List{string}}} args
+
+act getEditKey(Console c, Database db, EditSettings s) -> Either{string, Error}
+  if s.key.val as string key -> key
+  else ->
+    inStream  = c.stdIn;
+    outStream = getInteractiveOutputStream(c).failOnError();
+    getKeyInteractive(db, EntryType.Any, inStream, outStream, !s.noColor)
 
 act editInteractive(Console c, Cmd cmd, EditSettings s) -> Either{Cmd, Error}
   inStream      = c.stdIn;
@@ -23,16 +30,21 @@ act updateDbEntry(Database db, Entry entry) -> Either{Database, Error}
   db.updateEntry(entry)
 
 act editCmd(EditSettings s) -> Option{Error}
-  c  = consoleOpen().failOnError();
-  db = loadDb().failOnError();
-  if db[s.key.val] as Entry entry ->
+  c        = consoleOpen().failOnError();
+  db       = loadDb().failOnError();
+  keyOrErr = getEditKey(c, db, s);
+  if keyOrErr as Error  keyErr  -> keyErr
+  if keyOrErr as string key     ->
+  if db[key]  as Entry  entry   ->
   ( newCmd = ( s.path.val as Path p ? buildCmd(p, s.args.val ?? List{string}())
                                     : editInteractive(c, entry.value, s) ).failOnError();
     newEntry = Entry(entry.key, newCmd, entry.creationTime, entry.accessTime);
-    transaction(updateDbEntry[newEntry], TransactionFlags.Backup).failOnError();
-    writer = litWriter("Updated '") & stringWriter() & litWriter("': ") & cmdWriter() & newlineWriter();
-    c.writeOut(writer, Tuple(entry.key, newCmd))
+    if transaction(updateDbEntry[newEntry], TransactionFlags.Backup) as Error transErr -> transErr
+    else ->
+      writer = litWriter("Updated '") & stringWriter() & litWriter("': ") & cmdWriter() & newlineWriter();
+      c.writeOut(writer, Tuple(entry.key, newCmd))
   )
-  else -> Error("No entry found with key: '" + s.key.val + '\'')
+  else -> Error("No entry found with key: '" + key + '\'')
+
 
 fun cliIsInteruptable(Type{EditSettings} s) false

--- a/utilities/cdb/cmd/edit.ns
+++ b/utilities/cdb/cmd/edit.ns
@@ -17,7 +17,7 @@ act editInteractive(Console c, Cmd cmd, EditSettings s) -> Either{Cmd, Error}
   rlSettings    = RlSettings(inStream, outStream, List{string}(), cmdWriter(cmdWriteFlags).run(cmd), "> ", !s.noColor);
   res           = ttyReadLine(rlSettings).failOnError();
   if res as RlResultSuccess success -> buildCmd(success.text)
-  if res is RlResultCancelled       -> Error("Cancelled")
+  if res is RlResultCancelled       -> cmd
 
 act updateDbEntry(Database db, Entry entry) -> Either{Database, Error}
   db.updateEntry(entry)

--- a/utilities/cdb/cmd/get.ns
+++ b/utilities/cdb/cmd/get.ns
@@ -8,6 +8,8 @@ struct GetSettings =
   EntryType                     type,
   bool                          quotePath,
   bool                          doubleQuotePath,
+  bool                          quoteArgs,
+  bool                          doubleQuoteArgs,
   bool                          noColor,
   CliPositional{Option{string}} key
 
@@ -26,9 +28,11 @@ act getFromDb(Database db, string key, EntryType t) -> Either{Tuple{Database, En
   else                  -> Error("No entry found with key: '" + key + '\'')
 
 fun getCmdWriteFlags(GetSettings s) -> CmdWriteFlags
-  if s.doubleQuotePath  -> CmdWriteFlags.DoubleQuotePath
-  if s.quotePath        -> CmdWriteFlags.QuotePath
-  else                  -> CmdWriteFlags.None
+  CmdWriteFlags.None
+  | (s.quotePath        ? CmdWriteFlags.QuotePath       : CmdWriteFlags.None)
+  | (s.doubleQuotePath  ? CmdWriteFlags.DoubleQuotePath : CmdWriteFlags.None)
+  | (s.quoteArgs        ? CmdWriteFlags.QuoteArgs       : CmdWriteFlags.None)
+  | (s.doubleQuoteArgs  ? CmdWriteFlags.DoubleQuoteArgs : CmdWriteFlags.None)
 
 act getCmdInteractive(GetSettings s) -> Option{Error}
   c           = consoleOpen().failOnError();

--- a/utilities/cdb/cmd/get.ns
+++ b/utilities/cdb/cmd/get.ns
@@ -30,19 +30,14 @@ fun getCmdWriteFlags(GetSettings s) -> CmdWriteFlags
   if s.quotePath        -> CmdWriteFlags.QuotePath
   else                  -> CmdWriteFlags.None
 
-fun getCmdEntryOrder(Entry e1, Entry e2)
-  e1.accessTime > e2.accessTime
-
-act getCmdInteractive(GetSettings s)
+act getCmdInteractive(GetSettings s) -> Option{Error}
   c           = consoleOpen().failOnError();
   inStream    = c.stdIn;
   outStream   = getInteractiveOutputStream(c).failOnError();
   db          = loadDb().failOnError();
-  keys        = db.entries.filterEntries(s.type).sort(getCmdEntryOrder).map(lambda (Entry e) e.key);
-  rlSettings  = RlSettings(inStream, outStream, keys, "", "> ", !s.noColor);
-  res         = ttyReadLine(rlSettings).failOnError();
-  if res as RlResultSuccess success -> getCmdWithKey(s, success.text)
-  if res is RlResultCancelled       -> fail("Cancelled")
+  keyOrErr    = getKeyInteractive(db, s.type, inStream, outStream, !s.noColor);
+  if keyOrErr as Error  err -> err
+  if keyOrErr as string key -> getCmdWithKey(s, key)
 
 act getCmdWithKey(GetSettings s, string key) -> Option{Error}
   c = consoleOpen().failOnError();

--- a/utilities/cdb/cmd/import.ns
+++ b/utilities/cdb/cmd/import.ns
@@ -12,9 +12,11 @@ act getImportStream(ImportSettings s) -> Either{sys_stream, Error}
 act importCmd(ImportSettings s) -> Option{Error}
   existingDb  = loadDb().failOnError();
   saveDbBack(existingDb).failOnError();
-  stream      = getImportStream(s).failOnError();
-  json        = stream.readToEnd().failOnError();
-  importedDb  = jsonParser{Database}().run(json).failOnError();
-  saveDb(mergeEntries(importedDb, existingDb))
+  stream          = getImportStream(s).failOnError();
+  json            = stream.readToEnd().failOnError();
+  importedDbOrErr = jsonParser{Database}().run(json);
+  if importedDbOrErr as Error     parseErr    -> parseErr
+  if importedDbOrErr as Database  importedDb  ->
+    saveDb(mergeEntries(importedDb, existingDb))
 
 fun cliIsInteruptable(Type{ImportSettings} s) true

--- a/utilities/cdb/cmd/install.ns
+++ b/utilities/cdb/cmd/install.ns
@@ -18,10 +18,10 @@ fun getJumpAlias(Shell s, Path programPath) -> string
   else                      -> ""
 
 fun getExecAlias(Shell s, Path programPath) -> string
-  if s == Shell.ZShell      -> "function e() { eval \"$(" + programPath.string() + " get $@ -t file --quote-path)\"; } # " + autoGenComment()
-  if s == Shell.Bash        -> "function e() { eval \"$(" + programPath.string() + " get $@ -t file --quote-path)\"; } # " + autoGenComment()
-  if s == Shell.PowerShell  -> "function e { $c = $(" + programPath.string() + " get $args -t file --quote-path); if ($c) { Invoke-Expression \"& $c\" } } # " + autoGenComment()
-  if s == Shell.CMD         -> "e=for /f \"usebackq delims=\" %A in (`" + programPath.string() + " get $* -t file --double-quote-path`) do call %A"
+  if s == Shell.ZShell      -> "function e() { eval \"$(" + programPath.string() + " get $@ -t file --quote-path --quote-args)\"; } # " + autoGenComment()
+  if s == Shell.Bash        -> "function e() { eval \"$(" + programPath.string() + " get $@ -t file --quote-path --quote-args)\"; } # " + autoGenComment()
+  if s == Shell.PowerShell  -> "function e { $c = $(" + programPath.string() + " get $args -t file --quote-path --quote-args); if ($c) { Invoke-Expression \"& $c\" } } # " + autoGenComment()
+  if s == Shell.CMD         -> "e=for /f \"usebackq delims=\" %A in (`" + programPath.string() + " get $* -t file --double-quote-path --double-quote-args`) do call %A"
   else                      -> ""
 
 act getShellConfigPossiblePaths(Shell s) -> List{PathAbsolute}

--- a/utilities/cdb/cmd/remove.ns
+++ b/utilities/cdb/cmd/remove.ns
@@ -27,7 +27,7 @@ act getKeysToRemove(RemoveSettings s, Console c) -> List{string}
 act removeCmd(RemoveSettings s) -> Option{Error}
   c     = consoleOpen().failOnError();
   keys  = getKeysToRemove(s, c);
-  if transaction(removeFromDb[keys], TransactionFlags.Backup) as Error err  -> fail(err)
+  if transaction(removeFromDb[keys], TransactionFlags.Backup) as Error err -> err
   else ->
     writer = listWriter(litWriter("Removed '") & stringWriter() & litWriter('\'') & newlineWriter());
     c.writeOut(writer, keys)

--- a/utilities/cdb/utils.ns
+++ b/utilities/cdb/utils.ns
@@ -31,6 +31,17 @@ act getInteractiveOutputStream(Console c) -> Either{sys_stream, Error}
   if c.stdErr.isTerm() -> c.stdErr
   else                 -> Error("An interactive terminal is required")
 
+act getKeyInteractive(Database db, EntryType t, sys_stream inStream, sys_stream outStream, bool color) -> Either{string, Error}
+  keys        = db.entries.filterEntries(t).sort(orderEntryAccessTime).map(lambda (Entry e) e.key);
+  rlSettings  = RlSettings(inStream, outStream, keys, "", "> ", color);
+  resOrError  = ttyReadLine(rlSettings);
+  if resOrError as Error    rlError -> rlError
+  if resOrError as RlResult res     ->
+  (
+    if res as RlResultSuccess success -> success.text
+    if res is RlResultCancelled       -> Error("Cancelled")
+  )
+
 act updateTimeToLocal(Entry e) -> Entry
   Entry(e.key, e.value, timeToLocal(e.creationTime), timeToLocal(e.accessTime))
 

--- a/utilities/cdb/writer.ns
+++ b/utilities/cdb/writer.ns
@@ -1,21 +1,28 @@
 import "database.ns"
 
 enum CmdWriteFlags =
-  None            : 0b00,
-  QuotePath       : 0b01,
-  DoubleQuotePath : 0b10
+  None            : 0b0000,
+  QuotePath       : 0b0001,
+  DoubleQuotePath : 0b0010,
+  QuoteArgs       : 0b0100,
+  DoubleQuoteArgs : 0b1000
 
-fun cmdQuoteWriter(CmdWriteFlags flags) -> Writer{None}
-  singleQuote = (flags & CmdWriteFlags.QuotePath) != 0;
-  doubleQuote = (flags & CmdWriteFlags.DoubleQuotePath) != 0;
+enum CmdQuoteFlags =
+  Quote       : 0b01,
+  DoubleQuote : 0b10
+
+fun cmdQuoteWriter(CmdQuoteFlags flags) -> Writer{None}
+  singleQuote = (flags & CmdQuoteFlags.Quote) != 0;
+  doubleQuote = (flags & CmdQuoteFlags.DoubleQuote) != 0;
   (singleQuote || doubleQuote) ? litWriter(doubleQuote ? '"' : '\'') : noneWriter()
 
-fun cmdQuotedWriter{T}(Writer{T} writer, CmdWriteFlags flags) -> Writer{T}
+fun cmdQuotedWriter{T}(Writer{T} writer, CmdQuoteFlags flags) -> Writer{T}
   cmdQuoteWriter(flags) & writer & cmdQuoteWriter(flags)
 
 fun cmdWriter(CmdWriteFlags flags = CmdWriteFlags.None) -> Writer{Cmd}
   (
-    cmdQuotedWriter(pathAbsWriter(), flags) & ?(litWriter(' ') & listWriter(stringWriter(), litWriter(' ')))
+    cmdQuotedWriter(pathAbsWriter(), CmdQuoteFlags(flags & 0b11)) &
+    ?(litWriter(' ') & listWriter(cmdQuotedWriter(stringWriter(), CmdQuoteFlags((flags >> 2) & 0b11)), litWriter(' ')))
   ).map(lambda (Cmd c) Tuple(c.path, !c.args.isEmpty() ? c.args : None()))
 
 fun entryDimWriter{T}(Writer{T} w, bool color)


### PR DESCRIPTION
Various fixes to the cdb utility:
* No longer treat cancelling a `edit` command as an error.
* Support reading the key to edit in the `edit` command interactively.
* Support command arguments with spaces (and pipes) by quoting them.
* Disable terminal word-wrap when editing interactively.