### PR TITLE
std: Fix deadlock while waiting for piped process

### DIFF
--- a/std/io/process.ns
+++ b/std/io/process.ns
@@ -95,12 +95,12 @@ act wait(Either{Process, Error} pOrErr) -> Either{ProcessResult, Error}
   pOrErr.map(impure lambda (Process p) p.wait())
 
 act wait(Process p) -> Either{ProcessResult, Error}
-  exitCode = ExitCode(intrinsic{process_block}(p.handle));
-  stdOutRes = p.readProcessOutPipe();
-  stdErrRes = p.readProcessErrPipe();
-  if stdOutRes as Error outErr -> outErr
-  if stdErrRes as Error errErr -> errErr
-  else -> ProcessResult(stdOutRes ?? Option{string}(), stdErrRes ?? Option{string}(), exitCode)
+  stdOutRes = fork p.readProcessOutPipe();
+  stdErrRes = fork p.readProcessErrPipe();
+  exitCode  = ExitCode(intrinsic{process_block}(p.handle));
+  if stdOutRes.get() as Error outErr -> outErr
+  if stdErrRes.get() as Error errErr -> errErr
+  else -> ProcessResult(stdOutRes.get() ?? Option{string}(), stdErrRes.get() ?? Option{string}(), exitCode)
 
 act waitAsync(Process p) -> future{Either{ProcessResult, Error}}
   fork p.wait()


### PR DESCRIPTION
When waiting for a process with redirected streams a could deadlock occur when the target process writes more data then the buffer size of the OS. Reason is we where not reading from the stream while the target process is still running.

Fixed by reading from both stdOut and stdErr in parallel with waiting for the process to end.