### PR TITLE
vm: Handle EPIPE error on console write

### DIFF
--- a/src/vm/internal/ref_stream_console.hpp
+++ b/src/vm/internal/ref_stream_console.hpp
@@ -408,6 +408,7 @@ inline auto getConsolePlatformError() noexcept -> PlatformError {
     return PlatformError::StreamNoDataAvailable;
   case ENOENT:
   case ETIMEDOUT:
+  case EPIPE:
     return PlatformError::ConsoleNoLongerAvailable;
   }
 


### PR DESCRIPTION
Instead of returning `ConsoleUnknownError` we now return `ConsoleNoLongerAvailable`.

Happens on linux when the program on the other end of a pipe crashes.