### PR TITLE
vm: Add new 'CreateNew' file mode

### DIFF
--- a/std/io/file.ns
+++ b/std/io/file.ns
@@ -10,6 +10,7 @@ import "std/prim.ns"
 
 enum FileMode =
   Create : 0,
+  CreateNew,
   Open,
   OpenReadOnly,
   Append
@@ -273,7 +274,12 @@ assert(
   fileType(p) == FileType.None)
 
 assert(
-  p = pathCurrent() / "file-test11.tmp";
+  p = pathCurrent() / "file-test9.tmp";
   s = "Hello World";
   f = fileOpen(p, FileMode.Create, FileFlags.AutoRemove).map( impure lambda (File f) f.write(s));
   fileSize(p) == ByteSize(s.length()))
+
+assert(
+  p = pathCurrent() / "file-test10.tmp";
+  fileOpen(p, FileMode.CreateNew, FileFlags.AutoRemove) is File &&
+  fileOpen(p, FileMode.CreateNew) is Error)

--- a/tests/vm/io_test.cpp
+++ b/tests/vm/io_test.cpp
@@ -93,7 +93,7 @@ TEST_CASE("[vm] Execute input and output", "vm") {
 
           // Open the file again for reading.
           asmb->addLoadLitString(filePath); // Load stream.
-          asmb->addLoadLitInt(1U);          // Options, mode 1 (Open).
+          asmb->addLoadLitInt(2U);          // Options, mode 2 (Open).
           asmb->addPCall(novasm::PCallCode::FileOpenStream);
           asmb->addStackStore(0); // Store file-stream.
 
@@ -129,7 +129,7 @@ TEST_CASE("[vm] Execute input and output", "vm") {
 
           // Open steam to non existing file.
           asmb->addLoadLitString("does-not-exist.tmp"); // Path.
-          asmb->addLoadLitInt(1U);                      // Options, mode 1 (Open).
+          asmb->addLoadLitInt(2U);                      // Options, mode 2 (Open).
           asmb->addPCall(novasm::PCallCode::FileOpenStream);
 
           // Assert that file-stream is not valid.
@@ -150,7 +150,7 @@ TEST_CASE("[vm] Execute input and output", "vm") {
 
           // Open steam to non existing file.
           asmb->addLoadLitString("does-not-exist.tmp"); // Path.
-          asmb->addLoadLitInt(1U);                      // Options, mode 1 (Open).
+          asmb->addLoadLitInt(2U);                      // Options, mode 2 (Open).
           asmb->addPCall(novasm::PCallCode::FileOpenStream);
 
           // Read file content.
@@ -174,7 +174,7 @@ TEST_CASE("[vm] Execute input and output", "vm") {
 
           // Open steam to non existing file.
           asmb->addLoadLitString("test.tmp"); // Path.
-          asmb->addLoadLitInt(1U);            // Options, mode 1 (Open).
+          asmb->addLoadLitInt(2U);            // Options, mode 2 (Open).
           asmb->addPCall(novasm::PCallCode::FileOpenStream);
 
           // Write to file.


### PR DESCRIPTION
Similar to 'Create' but fails when a file already exists at the given path. Avoids the race-condition of checking for file-existence before creating a new file.