### PR TITLE
novc: Add 'deps' sub-command

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -22,6 +22,7 @@ FetchContent_MakeAvailable(rang)
 message(STATUS "Configuring novc executable")
 add_executable(novc
   novc/compiler.cpp
+  novc/deps.cpp
   novc/main.cpp
   novc/utilities.cpp)
 target_compile_features(novc PUBLIC cxx_std_17)

--- a/apps/novc/compiler.cpp
+++ b/apps/novc/compiler.cpp
@@ -23,7 +23,7 @@ static auto operator<<(std::ostream& out, const Duration& rhs) -> std::ostream&;
 static auto msgHeader(std::ostream& out) -> std::ostream&;
 static auto infHeader(std::ostream& out) -> std::ostream&;
 
-auto compile(Options options) -> bool {
+auto compile(const CompileOptions& options) -> bool {
 
   std::cout << rang::style::bold << "--- Novus compiler [" PROJECT_VER "] ---\n"
             << rang::style::reset;

--- a/apps/novc/deps.cpp
+++ b/apps/novc/deps.cpp
@@ -1,0 +1,39 @@
+// -- Include rang before any os headers.
+#include "../rang_include.hpp"
+// --
+
+#include "config.hpp"
+#include "deps.hpp"
+#include "frontend/analysis.hpp"
+#include "frontend/source.hpp"
+#include <fstream>
+
+namespace novc {
+
+auto deps(const DepsOptions& options) -> bool {
+
+  // Load the source file.
+  const auto absSrcPath = filesystem::canonical(filesystem::absolute(options.srcPath));
+  auto srcFilestream    = std::ifstream{absSrcPath.string()};
+  if (!srcFilestream.good()) {
+    std::cerr << rang::style::bold << rang::bg::red << "Failed to read source file\n"
+              << rang::style::reset;
+    return false;
+  }
+
+  // Parse the source.
+  const auto src = frontend::buildSource(
+      absSrcPath.filename().string(),
+      absSrcPath,
+      std::istreambuf_iterator<char>{srcFilestream},
+      std::istreambuf_iterator<char>{});
+
+  // Gather dependencies.
+  for (const auto& depSource : frontend::getDependencies(src, options.searchPaths)) {
+    std::cout << *depSource.getPath() << '\n';
+  }
+
+  return true;
+}
+
+} // namespace novc

--- a/apps/novc/deps.hpp
+++ b/apps/novc/deps.hpp
@@ -4,13 +4,11 @@
 
 namespace novc {
 
-struct CompileOptions {
+struct DepsOptions {
   filesystem::path srcPath;
-  filesystem::path destPath;
   const std::vector<filesystem::path>& searchPaths;
-  bool optimize;
 };
 
-auto compile(const CompileOptions& options) -> bool;
+auto deps(const DepsOptions& options) -> bool;
 
 } // namespace novc

--- a/apps/novc/main.cpp
+++ b/apps/novc/main.cpp
@@ -5,6 +5,7 @@
 #include "CLI/CLI.hpp"
 #include "compiler.hpp"
 #include "config.hpp"
+#include "deps.hpp"
 #include "filesystem.hpp"
 #include "input/search_paths.hpp"
 #include <algorithm>
@@ -15,7 +16,6 @@ auto main(int argc, const char** argv) noexcept -> int {
   auto additionalSearchPaths = std::vector<filesystem::path>{};
   auto colorMode             = rang::control::Auto;
   auto optimize              = true;
-  auto validateOnly          = false;
   filesystem::path srcPath;
   filesystem::path outPath;
 
@@ -28,11 +28,15 @@ auto main(int argc, const char** argv) noexcept -> int {
       ->required();
   app.add_option("-o,--out", outPath, "Path to output the program to");
   app.add_flag("--optimize,!--no-optimize", optimize, "Optimize the program");
-  app.add_flag("-v,--validate-only", validateOnly, "Only validate but do not output the program");
   app.add_option(
          "-s,--searchpaths", additionalSearchPaths, "Additional paths to search for imports")
       ->check(CLI::ExistingDirectory);
   app.validate_positionals();
+
+  // Sub-commands.
+  auto validateCmd =
+      app.add_subcommand("validate", "Validate the given sourcefile without compiling it");
+  auto depsCmd = app.add_subcommand("deps", "Output the dependencies of the given sourcefile");
 
   // Parse arguments.
   std::atexit([]() {
@@ -50,14 +54,14 @@ auto main(int argc, const char** argv) noexcept -> int {
 
   rang::setControlMode(colorMode);
 
-  // If no output path is given generate one based on the source file path.
-  if (outPath.empty()) {
-    outPath = srcPath;
-  }
-  outPath.replace_extension("nx");
-
-  // In validate-only mode don't specify an output path.
-  if (validateOnly) {
+  const bool outputProgram = !app.got_subcommand(validateCmd) && !app.got_subcommand(depsCmd);
+  if (outputProgram) {
+    // If no output path is given generate one based on the source file path.
+    if (outPath.empty()) {
+      outPath = srcPath;
+    }
+    outPath.replace_extension("nx");
+  } else {
     outPath = filesystem::path{};
   }
 
@@ -66,8 +70,9 @@ auto main(int argc, const char** argv) noexcept -> int {
   std::copy(
       additionalSearchPaths.begin(), additionalSearchPaths.end(), std::back_inserter(searchPaths));
 
-  auto options = novc::Options{srcPath, outPath, searchPaths, optimize};
-  auto success = novc::compile(options);
+  if (app.got_subcommand(depsCmd)) {
+    return novc::deps({srcPath, searchPaths}) ? 0 : 1;
+  }
 
-  return success ? 0 : 1;
+  return novc::compile({srcPath, outPath, searchPaths, optimize}) ? 0 : 1;
 }

--- a/include/frontend/analysis.hpp
+++ b/include/frontend/analysis.hpp
@@ -8,4 +8,8 @@ namespace frontend {
 auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchPaths = {})
     -> Output;
 
+// Gather the dependencies (all imports) of the given source file.
+auto getDependencies(const Source& mainSrc, const std::vector<filesystem::path>& searchPaths)
+    -> std::forward_list<Source>;
+
 } // namespace frontend

--- a/src/frontend/analysis.cpp
+++ b/src/frontend/analysis.cpp
@@ -68,7 +68,7 @@ auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchP
   // Resolve all imports.
   auto importedSources = std::forward_list<Source>{};
   auto import =
-      internal::ImportSources{mainSrc, sourceTableBuilder, searchPaths, &importedSources, &diags};
+      internal::ImportSources{mainSrc, searchPaths, &importedSources, &sourceTableBuilder, &diags};
   mainSrc.accept(&import);
   auto allContexts = std::vector<internal::Context>{makeCtx(mainSrc)};
   for (const auto& importSrc : importedSources) {
@@ -178,6 +178,14 @@ auto analyze(const Source& mainSrc, const std::vector<filesystem::path>& searchP
   }
 
   return buildOutput(std::move(prog), std::move(importedSources), std::move(sourceTable), {});
+}
+
+auto getDependencies(const Source& mainSrc, const std::vector<filesystem::path>& searchPaths)
+    -> std::forward_list<Source> {
+  auto dependencies = std::forward_list<Source>{};
+  auto import       = internal::ImportSources{mainSrc, searchPaths, &dependencies};
+  mainSrc.accept(&import);
+  return dependencies;
 }
 
 } // namespace frontend

--- a/src/frontend/internal/import_sources.hpp
+++ b/src/frontend/internal/import_sources.hpp
@@ -18,26 +18,26 @@ public:
   ImportSources() = delete;
   ImportSources(
       const Source& mainSource,
-      SourceTableBuilder& sourceTableBuilder,
       const std::vector<Path>& searchPaths,
       std::forward_list<Source>* importedSources,
-      std::vector<Diag>* diags);
+      SourceTableBuilder* sourceTableBuilder = nullptr,
+      std::vector<Diag>* diags               = nullptr);
   ImportSources(
       const Source& mainSource,
       const Source& currentSource,
-      SourceTableBuilder& sourceTableBuilder,
       const std::vector<Path>& searchPaths,
       std::forward_list<Source>* importedSources,
-      std::vector<Diag>* diags);
+      SourceTableBuilder* sourceTableBuilder = nullptr,
+      std::vector<Diag>* diags               = nullptr);
 
   auto visit(const parse::ImportStmtNode& n) -> void override;
 
 private:
   const Source& m_mainSource;
   const Source& m_currentSource;
-  SourceTableBuilder& m_sourceTableBuilder;
   const std::vector<Path>& m_searchPaths;
   std::forward_list<Source>* m_importedSources;
+  SourceTableBuilder* m_sourceTableBuilder;
   std::vector<Diag>* m_diags;
 
   [[nodiscard]] auto alreadyImportedAbsPath(const Path& file) const -> bool;

--- a/utilities/nov-watch.ns
+++ b/utilities/nov-watch.ns
@@ -21,7 +21,7 @@ fun getSearchPathArgs(ValidateSettings s)
 
 act validateAction(Context ctx, ValidateSettings s)
   ProcessAction(impure lambda (PathAbsolute file) -> Option{Error}
-    run = run("novc", file.string() :: "--validate-only" :: getSearchPathArgs(s));
+    run = run("novc", file.string() :: getSearchPathArgs(s) :: "validate");
     if run as Error   err     -> ctx.console.writeErr("Failed to invoke compiler: " + err + '\n'); err
     if run as Process process -> process.wait(); None()
   )


### PR DESCRIPTION
Adds a `deps` sub-command to the `novc` compiler that will output the paths of dependencies of the given source file.

Example usage:
`novc examples/fizzbuzz.ns deps`:
<details><summary>Output</summary><p>

```
"/home/bastian/dev/projects/novus/std/cli/parser.ns"
"/home/bastian/dev/projects/novus/std/cli/invoker.ns"
"/home/bastian/dev/projects/novus/std/core/text-pattern.ns"
"/home/bastian/dev/projects/novus/std/core/parallel.ns"
"/home/bastian/dev/projects/novus/std/core/math.ns"
"/home/bastian/dev/projects/novus/std/core/future.ns"
"/home/bastian/dev/projects/novus/std/core/byte-size.ns"
"/home/bastian/dev/projects/novus/std/core/text.ns"
"/home/bastian/dev/projects/novus/std/core/tuple.ns"
"/home/bastian/dev/projects/novus/std/core/list.ns"
"/home/bastian/dev/projects/novus/std/core/time.ns"
"/home/bastian/dev/projects/novus/std/core/lazy.ns"
"/home/bastian/dev/projects/novus/std/core/option.ns"
"/home/bastian/dev/projects/novus/std/diag/error.ns"
"/home/bastian/dev/projects/novus/std/diag/bench.ns"
"/home/bastian/dev/projects/novus/std/io/watcher.ns"
"/home/bastian/dev/projects/novus/std/io/tcp.ns"
"/home/bastian/dev/projects/novus/std/io/readline.ns"
"/home/bastian/dev/projects/novus/std/io/process.ns"
"/home/bastian/dev/projects/novus/std/io/ip.ns"
"/home/bastian/dev/projects/novus/std/io/path.ns"
"/home/bastian/dev/projects/novus/std/io/file.ns"
"/home/bastian/dev/projects/novus/std/io/tty.ns"
"/home/bastian/dev/projects/novus/std/sys/rt.ns"
"/home/bastian/dev/projects/novus/std/sys/gc.ns"
"/home/bastian/dev/projects/novus/std/sys/env.ns"
"/home/bastian/dev/projects/novus/std/sys.ns"
"/home/bastian/dev/projects/novus/std/io/stream.ns"
"/home/bastian/dev/projects/novus/std/io/console.ns"
"/home/bastian/dev/projects/novus/std/io.ns"
"/home/bastian/dev/projects/novus/std/format/version.ns"
"/home/bastian/dev/projects/novus/std/format/python.ns"
"/home/bastian/dev/projects/novus/std/format/python-orm.ns"
"/home/bastian/dev/projects/novus/std/format/unicode.ns"
"/home/bastian/dev/projects/novus/std/format/parser.ns"
"/home/bastian/dev/projects/novus/std/format/utf8.ns"
"/home/bastian/dev/projects/novus/std/format/json.ns"
"/home/bastian/dev/projects/novus/std/format/json-orm.ns"
"/home/bastian/dev/projects/novus/std/utilities/rng.ns"
"/home/bastian/dev/projects/novus/std/utilities/noise.ns"
"/home/bastian/dev/projects/novus/std/utilities/color.ns"
"/home/bastian/dev/projects/novus/std/utilities.ns"
"/home/bastian/dev/projects/novus/std/format/writer.ns"
"/home/bastian/dev/projects/novus/std/format/image.ns"
"/home/bastian/dev/projects/novus/std/format/base64.ns"
"/home/bastian/dev/projects/novus/std/prim/string.ns"
"/home/bastian/dev/projects/novus/std/prim/meta.ns"
"/home/bastian/dev/projects/novus/std/prim/long.ns"
"/home/bastian/dev/projects/novus/std/prim/int.ns"
"/home/bastian/dev/projects/novus/std/prim/float.ns"
"/home/bastian/dev/projects/novus/std/prim/char.ns"
"/home/bastian/dev/projects/novus/std/prim/type.ns"
"/home/bastian/dev/projects/novus/std/prim/bool.ns"
"/home/bastian/dev/projects/novus/std/prim.ns"
"/home/bastian/dev/projects/novus/std/format/ascii.ns"
"/home/bastian/dev/projects/novus/std/format.ns"
"/home/bastian/dev/projects/novus/std/diag/sourceloc.ns"
"/home/bastian/dev/projects/novus/std/diag/assert.ns"
"/home/bastian/dev/projects/novus/std/diag.ns"
"/home/bastian/dev/projects/novus/std/core/func.ns"
"/home/bastian/dev/projects/novus/std/core/either.ns"
"/home/bastian/dev/projects/novus/std/core/reflect.ns"
"/home/bastian/dev/projects/novus/std/core/bits.ns"
"/home/bastian/dev/projects/novus/std/core.ns"
"/home/bastian/dev/projects/novus/std/cli/options.ns"
"/home/bastian/dev/projects/novus/std/cli/help.ns"
"/home/bastian/dev/projects/novus/std/cli/runner.ns"
"/home/bastian/dev/projects/novus/std/cli/buildin.ns"
"/home/bastian/dev/projects/novus/std/cli/api.ns"
"/home/bastian/dev/projects/novus/bin/std/cli.ns"
"/home/bastian/dev/projects/novus/bin/std.ns"
```

</p></details>