### PR TITLE
vm: Fix 'read on non-read stream' curruption

### DIFF
--- a/src/vm/internal/ref_stream_console.hpp
+++ b/src/vm/internal/ref_stream_console.hpp
@@ -52,6 +52,7 @@ public:
       -> bool {
     if (unlikely(m_kind != ConsoleStreamKind::StdIn)) {
       *pErr = PlatformError::StreamReadNotSupported;
+      str->updateSize(0);
       return false;
     }
 

--- a/src/vm/internal/ref_stream_file.hpp
+++ b/src/vm/internal/ref_stream_file.hpp
@@ -74,6 +74,7 @@ public:
 
     if (unlikely(m_mode == FileStreamMode::Append)) {
       *pErr = PlatformError::StreamReadNotSupported;
+      str->updateSize(0);
       return false;
     }
     if (unlikely(str->getSize() == 0)) {

--- a/src/vm/internal/ref_stream_process.hpp
+++ b/src/vm/internal/ref_stream_process.hpp
@@ -37,6 +37,7 @@ public:
       -> bool {
     if (unlikely(m_streamKind == ProcessStreamKind::StdIn)) {
       *pErr = PlatformError::StreamReadNotSupported;
+      str->updateSize(0);
       return false;
     }
 


### PR DESCRIPTION
Fix returning a string containing non-initialized memory when reading from a non-readable stream (like an 'append' file-stream)