### PR TITLE
vm: Add OpenOrCreate file-mode

### DIFF
--- a/src/vm/internal/ref_stream_file.hpp
+++ b/src/vm/internal/ref_stream_file.hpp
@@ -26,7 +26,8 @@ enum class FileStreamMode : uint8_t {
   CreateNew    = 1,
   Open         = 2,
   OpenReadOnly = 3,
-  Append       = 4,
+  OpenOrCreate = 4,
+  Append       = 5,
 };
 
 enum FileStreamFlags : uint8_t {
@@ -213,9 +214,13 @@ inline auto openFileStream(
     desiredAccess |= GENERIC_READ;
     creationDisposition = OPEN_EXISTING;
     break;
+  case FileStreamMode::OpenOrCreate:
+    desiredAccess |= GENERIC_READ | GENERIC_WRITE;
+    creationDisposition = OPEN_ALWAYS;
+    break;
   case FileStreamMode::Append:
     desiredAccess |= FILE_APPEND_DATA;
-    creationDisposition = OPEN_EXISTING;
+    creationDisposition = OPEN_ALWAYS;
     break;
   }
 
@@ -243,8 +248,11 @@ inline auto openFileStream(
   case FileStreamMode::OpenReadOnly:
     flags |= O_RDONLY;
     break;
+  case FileStreamMode::OpenOrCreate:
+    flags |= O_RDWR | O_CREAT;
+    break;
   case FileStreamMode::Append:
-    flags |= O_RDWR | O_APPEND;
+    flags |= O_WRONLY | O_CREAT | O_APPEND;
     break;
   }
   const int newFilePerms = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH; // RW for owner, and R for others.

--- a/std/io/file.ns
+++ b/std/io/file.ns
@@ -13,6 +13,7 @@ enum FileMode =
   CreateNew,
   Open,
   OpenReadOnly,
+  OpenOrCreate,
   Append
 
 enum FileType =
@@ -251,22 +252,18 @@ assertIs(
   p = pathCurrent() / "file-test5.tmp";
   fileOpen(p, FileMode.Open), Type{Error}())
 
-assertIs(
-  p = pathCurrent() / "file-test6.tmp";
-  fileOpen(p, FileMode.Append, FileFlags.AutoRemove), Type{Error}())
-
 assertIs(fileRemove(pathCurrent() / "non-existing-file"), Type{Error}())
 
 assert(fileType(pathCurrent() / "non-existing-file") == FileType.None)
 
 assert(
-  p = pathCurrent() / "file-test7.tmp";
+  p = pathCurrent() / "file-test6.tmp";
   fileType(p) == FileType.None &&
   fileOpen(p, FileMode.Create, FileFlags.AutoRemove) is File &&
   fileType(p) == FileType.Regular)
 
 assert(
-  p = pathCurrent() / "file-test8";
+  p = pathCurrent() / "file-test7";
   fileType(p) == FileType.None &&
   fileCreateDir(p) is None &&
   fileType(p) == FileType.Directory &&
@@ -274,12 +271,12 @@ assert(
   fileType(p) == FileType.None)
 
 assert(
-  p = pathCurrent() / "file-test9.tmp";
+  p = pathCurrent() / "file-test8.tmp";
   s = "Hello World";
   f = fileOpen(p, FileMode.Create, FileFlags.AutoRemove).map( impure lambda (File f) f.write(s));
   fileSize(p) == ByteSize(s.length()))
 
 assert(
-  p = pathCurrent() / "file-test10.tmp";
+  p = pathCurrent() / "file-test9.tmp";
   fileOpen(p, FileMode.CreateNew, FileFlags.AutoRemove) is File &&
   fileOpen(p, FileMode.CreateNew) is Error)

--- a/utilities/cdb/cmd/install.ns
+++ b/utilities/cdb/cmd/install.ns
@@ -40,7 +40,6 @@ act getShellConfigPath(InstallSettings s) -> Option{PathAbsolute}
 
 act installCmd(InstallSettings s) -> Option{Error}
   configPath = getShellConfigPath(s).valueOrError(Error("No shell configuration file found for shell '" + s.shell.val + '\'')).failOnError();
-  fileCreate(configPath).failOnError();
   configFile = fileOpen(configPath, FileMode.Append).failOnError();
   configFile.write("\n" + getJumpAlias(s.shell.val, pathProgram()) + '\n' +
                           getExecAlias(s.shell.val, pathProgram()) + '\n');


### PR DESCRIPTION
`FileMode.OpenOrCreate` opens an existing file or creates a new file if there is no file at the given path.

One other (breaking) change: `FileMode.Append` now creates a new file if there is no file at the given path. Turns out that is almost always what you want. If we ever need the old behavior we should add a `FileMode.OpenAppend` mode.

