### PR TITLE
vm: Fix a hanging child process (with piped streams) blocking the vm shutdown on win32

### DIFF
--- a/src/vm/internal/platform_utilities.hpp
+++ b/src/vm/internal/platform_utilities.hpp
@@ -24,6 +24,7 @@ enum class PlatformError : uint32_t {
   StreamNoDataAvailable     = 201,
   StreamReadNotSupported    = 202,
   StreamWriteNotSupported   = 203,
+  StreamInvalid             = 204,
 
   ProcessUnknownError        = 300,
   ProcessInvalid             = 301,

--- a/src/vm/internal/ref_process.hpp
+++ b/src/vm/internal/ref_process.hpp
@@ -313,6 +313,8 @@ inline auto processStart(
     // Failed to create all the pipes, close whichever child pipes where created.
     fileClose(pipeStdIn[0], pipeStdOut[1], pipeStdErr[1]);
 
+    ::free(localStr); // Free our local copy of the command-line string.
+
     *pErr = PlatformError::ProcessFailedToCreatePipes;
     return alloc->allocPlain<ProcessRef>(
         invalidProcess(), flags, pipeStdIn[1], pipeStdOut[0], pipeStdErr[0]);

--- a/src/vm/internal/stream_utilities.hpp
+++ b/src/vm/internal/stream_utilities.hpp
@@ -41,6 +41,7 @@ inline auto streamReadString(
 
   if (!streamCheckValid(stream)) {
     tgt->updateSize(0);
+    *pErr = PlatformError::StreamInvalid;
     return false;
   }
   STREAM_DISPATCH(stream, readString(execHandle, pErr, tgt))
@@ -51,6 +52,7 @@ inline auto streamWriteString(
     -> bool {
 
   if (!streamCheckValid(stream)) {
+    *pErr = PlatformError::StreamInvalid;
     return false;
   }
   STREAM_DISPATCH(stream, writeString(execHandle, pErr, str))
@@ -59,6 +61,7 @@ inline auto streamWriteString(
 inline auto streamSetOpts(PlatformError* pErr, const Value& stream, StreamOpts opts) noexcept
     -> bool {
   if (!streamCheckValid(stream)) {
+    *pErr = PlatformError::StreamInvalid;
     return false;
   }
   STREAM_DISPATCH(stream, setOpts(pErr, opts))
@@ -67,6 +70,7 @@ inline auto streamSetOpts(PlatformError* pErr, const Value& stream, StreamOpts o
 inline auto streamUnsetOpts(PlatformError* pErr, const Value& stream, StreamOpts opts) noexcept
     -> bool {
   if (!streamCheckValid(stream)) {
+    *pErr = PlatformError::StreamInvalid;
     return false;
   }
   STREAM_DISPATCH(stream, unsetOpts(pErr, opts))

--- a/std/sys/rt.ns
+++ b/std/sys/rt.ns
@@ -19,6 +19,7 @@ enum PlatformError =
   StreamNoDataAvailable         : 201,
   StreamReadNotSupported        : 202,
   StreamWriteNotSupported       : 203,
+  StreamInvalid                 : 204,
   ProcessUnknownError           : 300,
   ProcessInvalid                : 301,
   ProcessInvalidCmdLine         : 302,
@@ -81,6 +82,7 @@ fun noinline string(PlatformError err)
   if err == PlatformError.StreamNoDataAvailable         -> "No data available"
   if err == PlatformError.StreamReadNotSupported        -> "Stream does not support reading"
   if err == PlatformError.StreamWriteNotSupported       -> "Stream does not support writing"
+  if err == PlatformError.StreamInvalid                 -> "Stream is invalid"
   if err == PlatformError.ProcessUnknownError           -> "Unknown process error occured"
   if err == PlatformError.ProcessInvalid                -> "Invalid process"
   if err == PlatformError.ProcessInvalidCmdLine         -> "Invalid commandline string"


### PR DESCRIPTION
If there was still a process in flight on win32 then the vm shutdown would be blocked on it.

The problem was two fold:
* We where first calling `CloseHandle` on the piped streams before killing the child process, while on win32 `CloseHandle` blocks if there are still outstanding reads/writes.
* We where inheriting all inheritable handles to child processes, meaning if you start multiple child processes they all inherit each-others pipes. Which in turn causes `CloseHandle` to block when shutting down as other child processes still have the handle open.
