### PR TITLE
frontend: Fix crash when importing empty path

### DIFF
--- a/src/frontend/internal/import_sources.cpp
+++ b/src/frontend/internal/import_sources.cpp
@@ -84,6 +84,11 @@ auto ImportSources::alreadyImportedRelPath(const Path& file) const -> bool {
 }
 
 auto ImportSources::import(const Path& file, input::Span span) const -> bool {
+  if (file.empty()) {
+    const auto srcId = m_sourceTableBuilder->add(&m_currentSource, span);
+    m_diags->push_back(errUnresolvedImport(srcId, file.string()));
+    return false;
+  }
 
   if (file.is_absolute() && importAbsPath(file)) {
     return true;

--- a/tests/frontend/import_test.cpp
+++ b/tests/frontend/import_test.cpp
@@ -8,6 +8,7 @@ TEST_CASE("[frontend] Analyzing import statements", "frontend") {
 
   SECTION("Diagnostics") {
     CHECK_DIAG("import \"nonexisting.ns\"", errUnresolvedImport(NO_SRC, "nonexisting.ns"));
+    CHECK_DIAG("import \"\"", errUnresolvedImport(NO_SRC, ""));
   }
 }
 


### PR DESCRIPTION
When importing an empty path:
```
import ""
```
The frontend crashed trying to resolve the path, now it produces an 'unresolved import' diagnostic.