### PR TITLE
frontend: fix using mangled name in operator diags

### DIFF
--- a/src/frontend/internal/declare_user_funcs.cpp
+++ b/src/frontend/internal/declare_user_funcs.cpp
@@ -150,7 +150,7 @@ auto DeclareUserFuncs::visit(const parse::FuncDeclStmtNode& n) -> void {
   auto funcName     = isConv ? getName(*m_ctx, *retType) : name;
   const auto funcId = m_ctx->getProg()->declarePureFunc(
       std::move(funcName), input.value(), retType.value(), numOptInputs);
-  m_funcDecls->emplace_back(funcId, m_ctx, std::move(name), n);
+  m_funcDecls->emplace_back(funcId, m_ctx, std::move(displayName), n);
 }
 
 auto DeclareUserFuncs::validateFuncTemplateArgList(


### PR DESCRIPTION
Fix showing the mangled name for diagnostics related to overloaded operators:
```
error: Unable to infer return-type of function '__op_coloncolon', please specify return-type using the '-> [TYPE]' syntax
```
Instead show a user-friendly display name:
```
error: Unable to infer return-type of function 'operator::', please specify return-type using the '-> [TYPE]' syntax
````