### PR TITLE
vm: Add support for detached processes

### DIFF
--- a/src/vm/internal/ref_process.hpp
+++ b/src/vm/internal/ref_process.hpp
@@ -32,6 +32,7 @@ enum ProcessFlags : uint8_t {
   ProcessPipeStdOut = 1u << 1, // Create a pipe for reading from std out.
   ProcessPipeStdErr = 1u << 2, // Create a pipe for reading from std err.
   ProcessNewGroup   = 1u << 3, // Create a new process group for the child proccess.
+  ProcessDetached   = 1u << 4, // Leave the process running when the reference gets destroyed
 };
 
 #if defined(_WIN32)
@@ -56,7 +57,7 @@ public:
   ProcessRef(ProcessRef&& rhs)      = delete;
   ~ProcessRef() noexcept {
     // Kill the process (if its still running).
-    if (isValid() && !isFinished()) {
+    if (!(m_flags & ProcessDetached) && isValid() && !isFinished()) {
       killImpl();
       // Wait for the process to stop, this prevents leaking zombie processes.
       block();

--- a/std/io/process.ns
+++ b/std/io/process.ns
@@ -9,13 +9,14 @@ struct ProcessId  = long id
 struct ExitCode   = int code
 
 enum ProcessFlags =
-  None        : 0b0000,
-  PipeStdIn   : 0b0001,
-  PipeStdOut  : 0b0010,
-  PipeStdErr  : 0b0100,
-  PipeOut     : 0b0110,
-  PipeInOut   : 0b0111,
-  NewGroup    : 0b1000
+  None        : 0b00000,
+  PipeStdIn   : 0b00001,
+  PipeStdOut  : 0b00010,
+  PipeStdErr  : 0b00100,
+  PipeOut     : 0b00110,
+  PipeInOut   : 0b00111,
+  NewGroup    : 0b01000,
+  Detached    : 0b11111
 
 enum Signal =
   Interupt  : 0,


### PR DESCRIPTION
Detached processes keep running after the handle to them gets cleaned up. Useful for starting gui-applications that should
keep running.