### PR TITLE
Opt: Add rudimentary heuristics 

### DIFF
--- a/src/opt/call_inline.cpp
+++ b/src/opt/call_inline.cpp
@@ -11,6 +11,10 @@
 
 namespace opt {
 
+// Calls to functions with more then 'g_maxInlineSrcFuncSize' expressions will not be inlined to
+// avoid bloating the executable.
+static unsigned int g_maxInlineSrcFuncSize = 50;
+
 class CallInlineRewriter final : public prog::expr::Rewriter {
 public:
   CallInlineRewriter(
@@ -73,6 +77,10 @@ auto CallInlineRewriter::isInlinable(const prog::expr::CallExprNode* callExpr) -
   }
 
   if (funcDef->hasFlags(prog::sym::FuncDef::Flags::NoInline)) {
+    return false;
+  }
+
+  if (internal::exprSize(funcDef->getBody()) > g_maxInlineSrcFuncSize) {
     return false;
   }
 

--- a/src/opt/internal/expr_matchers.cpp
+++ b/src/opt/internal/expr_matchers.cpp
@@ -83,4 +83,13 @@ auto isLiteral(const prog::expr::Node& expr) -> bool {
   }
 }
 
+auto exprSize(const prog::expr::Node& expr) -> unsigned int {
+  constexpr bool stopAtFirstHit = false;
+  auto predicate                = [](const prog::expr::Node&) { return true; };
+
+  auto matcher = ExprMatcher<decltype(predicate), stopAtFirstHit>{predicate};
+  expr.accept(&matcher);
+  return matcher.getCount();
+}
+
 } // namespace opt::internal

--- a/src/opt/internal/expr_matchers.hpp
+++ b/src/opt/internal/expr_matchers.hpp
@@ -4,31 +4,34 @@
 
 namespace opt::internal {
 
-template <typename UnaryPredicate>
+template <typename UnaryPredicate, bool StopAtFirstHit = true>
 class ExprMatcher final : public prog::expr::DeepNodeVisitor {
   static_assert(std::is_invocable_r<bool, UnaryPredicate, const prog::expr::Node&>::value);
 
 public:
-  explicit ExprMatcher(UnaryPredicate pred) : m_pred{pred}, m_found{false} {}
+  explicit ExprMatcher(UnaryPredicate pred) : m_pred{pred}, m_count{0} {}
 
-  [[nodiscard]] auto isFound() const { return m_found; }
+  [[nodiscard]] auto isFound() const { return m_count != 0; }
+  [[nodiscard]] auto getCount() const { return m_count; }
 
 protected:
   auto visitNode(const prog::expr::Node* n) -> void override {
     if (m_pred(*n)) {
-      m_found = true;
-    } else {
+      ++m_count;
+    }
+    if (m_count == 0 || !StopAtFirstHit) {
       prog::expr::DeepNodeVisitor::visitNode(n);
     }
   }
 
 private:
   UnaryPredicate m_pred;
-  bool m_found;
+  unsigned int m_count;
 };
 
-template <typename UnaryPredicate>
-auto matchesExpr(const prog::Program& prog, prog::sym::FuncId funcId, UnaryPredicate predicate) {
+template <typename UnaryPredicate, bool StopAtFirstHit = true>
+auto matchesExpr(const prog::Program& prog, prog::sym::FuncId funcId, UnaryPredicate predicate)
+    -> unsigned int {
   const auto& funcDecl = prog.getFuncDecl(funcId);
 
   // Non-user funcs have no expressions.
@@ -37,10 +40,10 @@ auto matchesExpr(const prog::Program& prog, prog::sym::FuncId funcId, UnaryPredi
   }
 
   const auto& funcDef = prog.getFuncDef(funcId);
-  auto matcher        = ExprMatcher{predicate};
+  auto matcher        = ExprMatcher<UnaryPredicate, StopAtFirstHit>{predicate};
   funcDef.getBody().accept(&matcher);
 
-  return matcher.isFound();
+  return matcher.getCount();
 }
 
 auto isRecursive(const prog::Program& prog, const prog::sym::FuncDef& funcDef) -> bool;
@@ -51,5 +54,7 @@ auto hasFuncDefFlags(
 auto hasSideEffect(const prog::Program& prog, const prog::expr::Node& expr) -> bool;
 
 auto isLiteral(const prog::expr::Node& expr) -> bool;
+
+auto exprSize(const prog::expr::Node& expr) -> unsigned int;
 
 } // namespace opt::internal

--- a/src/opt/optimize.cpp
+++ b/src/opt/optimize.cpp
@@ -2,6 +2,8 @@
 
 namespace opt {
 
+static unsigned int g_maxOptimizeItrs = 5;
+
 auto optimize(const prog::Program& prog) -> prog::Program {
 
   // We start with one pass of treeshaking to avoid optimizing unused functions.
@@ -9,6 +11,7 @@ auto optimize(const prog::Program& prog) -> prog::Program {
 
   // Keep optimizing until the program cannot be simplified anymore.
   bool modified;
+  unsigned int itrs = 0;
   do {
     modified = false;
 
@@ -21,7 +24,7 @@ auto optimize(const prog::Program& prog) -> prog::Program {
     // Inline possible functions.
     result = inlineCalls(result, modified);
 
-  } while (modified);
+  } while (modified && ++itrs < g_maxOptimizeItrs);
 
   // Remove any functions that have become unused due to inlining.
   result = treeshake(result);


### PR DESCRIPTION
Added two small heuristics to avoid spending too long optimizing (and producing a too big binary)
* Doesn't inline calls to functions bigger then 50 expressions.
* Stops optimizing after 5 iterations (further gains are usually negligible).