### PR TITLE
build: Remove clang-tidy install step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,6 @@ jobs:
       if: matrix.config.os != 'windows'
       run: |
         echo "Installing llvm-10"; sudo apt install llvm-10
-        echo "Installing clang-tidy-10"; sudo apt install clang-tidy-10
-        sudo ln -s /usr/bin/clang-tidy-10 /usr/bin/clang-tidy
         sudo ln -s /usr/bin/llvm-cov-10 /usr/bin/llvm-cov
         sudo ln -s /usr/bin/llvm-profdata-10 /usr/bin/llvm-profdata
 


### PR DESCRIPTION
Its already installed by default on github actions now.